### PR TITLE
fix: enable logical operators (&&, ||, !) in if conditions

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1130,8 +1130,9 @@ func (p *Parser) parseExpression(precedence int) Expression {
 func (p *Parser) parseIdentifier() Expression {
 	ident := &Label{Token: p.currentToken, Value: p.currentToken.Literal}
 
-	// Check if this is a struct literal: Identifier{...}
-	if p.peekTokenMatches(LBRACE) {
+	// Check if this is a struct literal: TypeName{...}
+	// Only treat it as struct literal if identifier starts with uppercase (type naming convention)
+	if p.peekTokenMatches(LBRACE) && len(ident.Value) > 0 && ident.Value[0] >= 'A' && ident.Value[0] <= 'Z' {
 		p.nextToken() // move to {
 		return p.parseStructLiteralFromIdent(ident)
 	}


### PR DESCRIPTION
This fix resolves parser conflicts between struct literals and conditional blocks that prevented logical operators from working in if statements.

Root Cause:
The parser's parseIdentifier() function was treating any identifier followed by { as a struct literal. When parsing if conditions like 'if x > 5 && y {', the parser would see the variable 'y' followed by '{' and incorrectly attempt to parse 'y{...}' as a struct literal instead of recognizing '{' as the start of the if block.

Solution:
Modified parseIdentifier() to only treat Identifier{ as a struct literal when the identifier starts with an uppercase letter (following EZ's type naming convention). Lowercase identifiers followed by { are now correctly parsed as separate tokens.

Fixes:
- Issue #8: Logical operators (&&, ||) not working in if conditions
- Issue #17: Unary negation operator (!) not working in if conditions

Test cases verified:
- if x > 5 && y { }
- if x < 5 || y { }
- if !flag { }
- Complex expressions: if (a || b) && c { }
- Struct literals still work: Person{name: "Alice", age: 30}