### PR TITLE
fix: make arrays.push() and arrays.pop() modify arrays in-place (issu…

### DIFF
--- a/pkg/interpreter/lib_arrays.go
+++ b/pkg/interpreter/lib_arrays.go
@@ -45,10 +45,9 @@ var arraysBuiltins = map[string]*Builtin{
 			if !ok {
 				return newError("arrays.push() requires an array as first argument")
 			}
-			newElements := make([]Object, len(arr.Elements), len(arr.Elements)+len(args)-1)
-			copy(newElements, arr.Elements)
-			newElements = append(newElements, args[1:]...)
-			return &Array{Elements: newElements}
+			// Modify the array in-place by appending to its Elements slice
+			arr.Elements = append(arr.Elements, args[1:]...)
+			return NIL
 		},
 	},
 	"arrays.unshift": {
@@ -104,7 +103,11 @@ var arraysBuiltins = map[string]*Builtin{
 			if len(arr.Elements) == 0 {
 				return newError("arrays.pop() cannot pop from empty array")
 			}
-			return arr.Elements[len(arr.Elements)-1]
+			// Get the last element
+			lastElement := arr.Elements[len(arr.Elements)-1]
+			// Remove it from the array in-place
+			arr.Elements = arr.Elements[:len(arr.Elements)-1]
+			return lastElement
 		},
 	},
 	"arrays.shift": {


### PR DESCRIPTION
 ## Summary
  Fixes `arrays.push()` and `arrays.pop()` to properly modify arrays in-place instead of leaving the original arrays unchanged.

  ## Problem
  Both array modification functions were broken:
  - `arrays.push(arr, element)` would return a new array with the element added, but the original array remained unchanged
  - `arrays.pop(arr)` would return the last element but NOT remove it from the array

  ## Root Cause
  - `arrays.push()` created a new array, copied elements, and returned the new array
  - `arrays.pop()` only returned `arr.Elements[len-1]` without modifying the slice

  ## Solution
  Modified both functions to work in-place:
  - `arrays.push()`: Directly appends to `arr.Elements` using Go's `append()`, returns `NIL`
  - `arrays.pop()`: Stores last element, slices it off from `arr.Elements`, returns the stored element

  Since `Array` objects are pointers in the interpreter, modifying `arr.Elements` directly updates the original array.

  ## Changes
  - Modified `pkg/interpreter/lib_arrays.go`:
    - `arrays.push()`: Changed to append in-place
    - `arrays.pop()`: Changed to remove element before returning

  ## Testing
  ```ez
  temp arr [int] = {1, 2, 3}
  arrays.push(arr, 4)
  println(arr)  // Now prints: {1, 2, 3, 4} ✅

  temp arr2 [int] = {10, 20, 30}
  temp val = arrays.pop(arr2)
  println(val)   // 30
  println(arr2)  // Now prints: {10, 20} ✅
```
  Fixes

  - Closes #1
  - Closes #18