### PR TITLE
fix: initialize dynamic arrays to empty array instead of NIL

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2,6 +2,7 @@ package interpreter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/marshallburns/ez/pkg/ast"
 	"github.com/marshallburns/ez/pkg/errors"
@@ -277,6 +278,18 @@ func evalVariableDeclaration(node *ast.VariableDeclaration, env *Environment) Ob
 		if isError(val) {
 			return val
 		}
+	} else if node.TypeName != "" {
+		// Variable declared with type but no value - provide appropriate default
+		// Check if it's a dynamic array type (starts with '[' but doesn't contain ',')
+		// Dynamic arrays: [int], [string], etc. - can be declared without values
+		// Fixed-size arrays: [int,3], [string,5], etc. - MUST be initialized with values
+		if len(node.TypeName) > 0 && node.TypeName[0] == '[' && !strings.Contains(node.TypeName, ",") {
+			// Initialize dynamic array to empty array instead of NIL
+			val = &Array{Elements: []Object{}}
+		}
+		// For other types (int, float, string, bool, etc.) and fixed-size arrays,
+		// they remain NIL for now. This matches the current behavior, but could be
+		// extended to provide defaults like 0 for int, 0.0 for float, "" for string, false for bool, etc.
 	}
 
 	// Handle multiple assignment: temp result, err = function()


### PR DESCRIPTION
## Summary
Fixed dynamic array declarations without values to initialize to empty arrays instead of NIL.

## Problem
When declaring a dynamic array without a value:
```ez
temp arr [int]
```

The variable was being set to `nil` with type `NIL` instead of an empty array `{}` with type `ARRAY`.

## Solution
Modified `evalVariableDeclaration` in the interpreter to check if a variable has an array type annotation and no value. For dynamic arrays (type like `[int]` without a size), it now initializes to an empty array.

The fix correctly distinguishes between:
- **Dynamic arrays** `[type]` → initialize to empty array `{}`
- **Fixed-size arrays** `[type, size]` → remain `nil` (must be explicitly initialized)

## Changes
- Added `strings` import to `pkg/interpreter/evaluator.go`
- Modified `evalVariableDeclaration()` to initialize dynamic arrays to empty arrays
- Check uses `strings.Contains(node.TypeName, ",")` to distinguish dynamic from fixed-size arrays

## Testing
✅ Dynamic arrays without values now work correctly:
```ez
temp arr1 [int]
println(arr1)        // Output: {}
println(typeof(arr1)) // Output: ARRAY
arrays.push(arr1, 10) // Works!
```

✅ Fixed-size arrays still require initialization:
```ez
temp arr2 [int, 3]
println(arr2)        // Output: nil
println(typeof(arr2)) // Output: NIL
```

✅ Initialized arrays still work as before:
```ez
temp arr3 [int] = {1, 2, 3}  // Works
const arr4 [int, 3] = {1, 2, 3}  // Works
```

- closes #3