### PR TITLE
fix: provide default values for uninitialized primitive types

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -286,10 +286,24 @@ func evalVariableDeclaration(node *ast.VariableDeclaration, env *Environment) Ob
 		if len(node.TypeName) > 0 && node.TypeName[0] == '[' && !strings.Contains(node.TypeName, ",") {
 			// Initialize dynamic array to empty array instead of NIL
 			val = &Array{Elements: []Object{}}
+		} else {
+			// Provide default values for primitive types
+			switch node.TypeName {
+			case "int":
+				val = &Integer{Value: 0}
+			case "float":
+				val = &Float{Value: 0.0}
+			case "string":
+				val = &String{Value: ""}
+			case "bool":
+				val = FALSE // Use existing FALSE constant
+			case "char":
+				val = &Char{Value: '\x00'} // null character as default
+			// For fixed-size arrays and other types, remain NIL
+			default:
+				val = NIL
+			}
 		}
-		// For other types (int, float, string, bool, etc.) and fixed-size arrays,
-		// they remain NIL for now. This matches the current behavior, but could be
-		// extended to provide defaults like 0 for int, 0.0 for float, "" for string, false for bool, etc.
 	}
 
 	// Handle multiple assignment: temp result, err = function()


### PR DESCRIPTION
## Summary
Fixed uninitialized primitive types to use appropriate default values instead of NIL.

## Problem
When declaring primitive types without initialization:
```ez
temp uninit int
println(uninit)  // Output: nil
```

Variables were showing `nil` instead of their expected default values.

## Expected Behavior (from README)
- Numbers (int, float): `0`
- Strings: `""` (empty string)
- Booleans: `false`

## Solution
Extended the `evalVariableDeclaration` function (which already handled arrays from issue #3) to provide default values for all primitive types when no value is specified.

Default values now provided:
- `int` → `0`
- `float` → `0.0`
- `string` → `""`
- `bool` → `false`
- `char` → `'\x00'` (null character)

## Changes
- Added switch statement in `evalVariableDeclaration()` to handle primitive types
- Maintained existing behavior for arrays (issue #3)
- Fixed-size arrays and custom types still default to NIL

## Testing
✅ All primitive types now have correct defaults:
```ez
temp x int       // 0
temp y float     // 0.0
temp s string    // ""
temp b bool      // false
temp c char      // '\x00'
```

✅ Initialized values still work:
```ez
temp x int = 42  // 42 (not affected)
```

✅ Arrays still work from issue #3:
```ez
temp arr [int]   // {} (empty array)
```

- closes #11