### PR TITLE
fix: implement char comparison operators

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -716,6 +716,8 @@ func evalInfixExpression(operator string, left, right Object, line, col int) Obj
 		return evalFloatInfixExpression(operator, left, right, line, col)
 	case left.Type() == STRING_OBJ && right.Type() == STRING_OBJ:
 		return evalStringInfixExpression(operator, left, right)
+	case left.Type() == CHAR_OBJ && right.Type() == CHAR_OBJ:
+		return evalCharInfixExpression(operator, left, right, line, col)
 	case operator == "==":
 		return nativeBoolToBooleanObject(left == right)
 	case operator == "!=":
@@ -834,6 +836,28 @@ func evalStringInfixExpression(operator string, left, right Object) Object {
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
 		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+	}
+}
+
+func evalCharInfixExpression(operator string, left, right Object, line, col int) Object {
+	leftVal := left.(*Char).Value
+	rightVal := right.(*Char).Value
+
+	switch operator {
+	case "==":
+		return nativeBoolToBooleanObject(leftVal == rightVal)
+	case "!=":
+		return nativeBoolToBooleanObject(leftVal != rightVal)
+	case "<":
+		return nativeBoolToBooleanObject(leftVal < rightVal)
+	case ">":
+		return nativeBoolToBooleanObject(leftVal > rightVal)
+	case "<=":
+		return nativeBoolToBooleanObject(leftVal <= rightVal)
+	case ">=":
+		return nativeBoolToBooleanObject(leftVal >= rightVal)
+	default:
+		return newErrorWithLocation("E2002", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixed char comparison operators to work correctly by comparing values instead of pointers.

## Problem
Comparing char values with `==` or other operators always failed:
```ez
temp ch char = 'A'
if ch == 'A' {
    println("Match")  // Never executed
}
```

The comparison always evaluated to false, even when comparing identical values.

## Root Cause
The `evalInfixExpression` function had no specific handling for `CHAR_OBJ` types. It fell through to the generic `==` case (line 719-720) which uses Go's `left == right` pointer comparison.

Since each `Char` object is a separate struct instance with its own memory address, pointer comparison always returned false, even when the underlying `Value` fields (rune values) were identical.

## Solution
Added `evalCharInfixExpression` function to handle char-specific comparison operators, similar to how `evalIntegerInfixExpression` handles integers.

The function extracts and compares the underlying `rune` values from both `Char` objects.

Implemented operators:
- `==` (equality)
- `!=` (inequality)
- `<` (less than)
- `>` (greater than)
- `<=` (less than or equal)
- `>=` (greater than or equal)

## Changes
- Added `CHAR_OBJ` case in `evalInfixExpression` switch statement
- Implemented `evalCharInfixExpression()` function in evaluator.go
- Function compares `char.Value` (rune) fields directly

## Testing
✅ All char comparison operators now work:
```ez
temp ch char = 'A'
if ch == 'A' { println("Match!") }  // ✓ Works!
if ch != 'B' { println("Different!") }  // ✓ Works!
if 'A' < 'B' { println("Ordered!") }  // ✓ Works!
```

✅ Variable-to-variable and variable-to-literal comparisons both work
✅ All comparison operators (==, !=, <, >, <=, >=) tested and working

- closes #16