### PR TITLE
fix: allow variable shadowing in nested blocks (parser)

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -776,6 +776,9 @@ func (p *Parser) parseBlockStatementWithSuppress(suppressions []*Attribute) *Blo
 	openBrace := p.currentToken // save the { token for error reporting
 	block.Statements = []Statement{}
 
+	// Push a new scope for this block
+	p.pushScope()
+
 	p.nextToken() // move past {
 
 	unreachable := false // track if we've hit a terminating statement
@@ -819,6 +822,9 @@ func (p *Parser) parseBlockStatementWithSuppress(suppressions []*Attribute) *Blo
 		p.errors = append(p.errors, msg)
 		p.addEZError(errors.E1004, msg, openBrace)
 	}
+
+	// Pop the scope when exiting the block
+	p.popScope()
 
 	return block
 }


### PR DESCRIPTION
## Summary
Partial fix for variable shadowing - parser now allows it, interpreter needs additional work.

## Problem
Variables could not be redeclared in nested scopes:
```ez
temp x int = 10
if true {
    temp x int = 20  // ERROR: 'x' is already declared in this scope
}
```

## Solution - Parser
Added scope management to `parseBlockStatementWithSuppress`:
- Calls `pushScope()` when entering a block
- Calls `popScope()` when exiting a block

This creates separate parser scopes for nested blocks, allowing variables to be shadowed without parse errors.

## What Works Now ✅
- No parse error when redeclaring variables in nested blocks
- Inner variables get their own initial values
- Multiple levels of nesting work

## Known Limitation ❌
The interpreter's Environment doesn't yet properly isolate scoped variables. Inner scope assignments currently affect outer scope variables with the same name:

```ez
temp x int = 10
if true {
    temp x int = 20
    println(x)      // 20 ✅ correct
}
println(x)          // 20 ❌ (should be 10)
```

## Next Steps
The interpreter's Environment needs modification to:
1. Create new environment frames for each scope
2. Look up variables in the correct scope chain
3. Prevent inner scope assignments from affecting outer scopes

This PR fixes the parser side. The interpreter work should be done separately.

## Changes
- Modified `parseBlockStatementWithSuppress()` in parser.go
- Added pushScope/popScope calls around block parsing

Partial fix for #15