### PR TITLE
Fix parser panic on early return statements (Issue #50)

### DIFF
--- a/pkg/errors/format.go
+++ b/pkg/errors/format.go
@@ -53,8 +53,13 @@ func FormatError(err *EZError) string {
 			BoldBlue, lineNumStr, Reset, err.SourceLine))
 
 		// Line 5: pointer/underline
-		pointerPadding := strings.Repeat(" ", err.Column-1)
-		pointerLen := err.EndColumn - err.Column
+		// Guard against negative or zero column values to prevent panic
+		column := err.Column
+		if column < 1 {
+			column = 1
+		}
+		pointerPadding := strings.Repeat(" ", column-1)
+		pointerLen := err.EndColumn - column
 		if pointerLen < 1 {
 			pointerLen = 1
 		}


### PR DESCRIPTION
This commit fixes a critical bug where the parser would panic with "strings: negative Repeat count" when encountering unreachable code immediately after an early return statement.

**Root Cause:**
When a return statement appeared before the first substantive statement in a function, p.currentToken.Column could be 0. The error formatter would then call strings.Repeat(" ", -1), causing a panic.

**Solution:**
Added validation in pkg/errors/format.go to ensure column values are always >= 1 before calculating pointer padding. This prevents the panic while maintaining correct error display.

**Changes:**
- pkg/errors/format.go:56-60: Added column value guard to prevent negative values in strings.Repeat()

**Testing:**
- Tested with early return before first statement - no panic, proper warning
- Tested with examples/tests.ez - all tests pass with expected warnings
- No regression in existing error formatting

Fixes #50