### PR TITLE
Fix variable shadowing bug 

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -469,9 +469,13 @@ func evalIfStatement(node *ast.IfStatement, env *Environment) Object {
 	}
 
 	if isTruthy(condition) {
-		return Eval(node.Consequence, env)
+		// Create a new enclosed environment for the if block to support proper variable shadowing
+		ifEnv := NewEnclosedEnvironment(env)
+		return Eval(node.Consequence, ifEnv)
 	} else if node.Alternative != nil {
-		return Eval(node.Alternative, env)
+		// Create a new enclosed environment for the else block to support proper variable shadowing
+		elseEnv := NewEnclosedEnvironment(env)
+		return Eval(node.Alternative, elseEnv)
 	}
 
 	return NIL
@@ -491,7 +495,9 @@ func evalWhileStatement(node *ast.WhileStatement, env *Environment) Object {
 			break
 		}
 
-		result := Eval(node.Body, env)
+		// Create a new enclosed environment for each iteration to support proper variable shadowing
+		whileEnv := NewEnclosedEnvironment(env)
+		result := Eval(node.Body, whileEnv)
 		if result != nil {
 			if result.Type() == RETURN_VALUE_OBJ || result.Type() == ERROR_OBJ {
 				return result
@@ -511,7 +517,9 @@ func evalLoopStatement(node *ast.LoopStatement, env *Environment) Object {
 	defer env.ExitLoop()
 
 	for {
-		result := Eval(node.Body, env)
+		// Create a new enclosed environment for each iteration to support proper variable shadowing
+		loopEnv := NewEnclosedEnvironment(env)
+		result := Eval(node.Body, loopEnv)
 		if result != nil {
 			if result.Type() == RETURN_VALUE_OBJ || result.Type() == ERROR_OBJ {
 				return result


### PR DESCRIPTION
This commit fixes a critical bug where variable shadowing incorrectly overwrote outer variables instead of creating separate scoped bindings.

**Root Cause:**
Control flow blocks (if/else, while, loop) were evaluating their bodies using the same environment as the outer scope. When an inner variable was declared with the same name as an outer variable, the Set() method would overwrite the outer variable instead of creating a new binding in a separate scope.

**Solution:**
Modified all control flow evaluation functions to create new enclosed environments for their blocks, similar to how for loops already worked:
- evalIfStatement: Creates new environments for consequence and alternative blocks
- evalWhileStatement: Creates new environment for each iteration
- evalLoopStatement: Creates new environment for each iteration

This ensures proper scope isolation - inner variables shadow outer ones without modifying them, and outer variables retain their values after the block exits.

**Changes:**
- pkg/interpreter/evaluator.go:465-482: Added enclosed env for if/else blocks
- pkg/interpreter/evaluator.go:484-513: Added enclosed env for while loops
- pkg/interpreter/evaluator.go:515-534: Added enclosed env for loop statements

**Testing:**
- Verified if statement shadowing works correctly
- Verified else block shadowing works correctly
- Verified nested if statement scoping maintains separate scopes
- Verified for loop shadowing still works (already had enclosed env)
- All examples/tests.ez tests pass with no regressions

Fixes #34