### PR TITLE
Add comprehensive tests and examples for `as_long_as loop`

### DIFF
--- a/examples/as_long_as_loop.ez
+++ b/examples/as_long_as_loop.ez
@@ -1,0 +1,106 @@
+import @std
+
+/*
+ * EZ Language - as_long_as Loop Examples
+ *
+ * The as_long_as keyword provides a clear syntax for while-style loops.
+ * The loop continues as long as the condition evaluates to true.
+ */
+
+do main() {
+    using std
+
+    println("=== as_long_as Loop Examples ===")
+    println("")
+
+    example_basic()
+    example_with_break()
+    example_with_continue()
+    example_nested()
+    example_countdown()
+}
+
+// Basic as_long_as loop
+do example_basic() {
+    using std
+
+    println("1. Basic as_long_as loop:")
+    temp x int = 0
+    as_long_as x < 5 {
+        print("  ")
+        println(x)
+        x = x + 1
+    }
+    println("")
+}
+
+// as_long_as with break
+do example_with_break() {
+    using std
+
+    println("2. as_long_as with break:")
+    temp i int = 0
+    as_long_as i < 100 {
+        i = i + 1
+        if i > 5 {
+            println("  Breaking at:", i)
+            break
+        }
+        print("  ")
+        println(i)
+    }
+    println("")
+}
+
+// as_long_as with continue
+do example_with_continue() {
+    using std
+
+    println("3. as_long_as with continue (skip even numbers):")
+    temp num int = 0
+    as_long_as num < 10 {
+        num = num + 1
+        if num % 2 == 0 {
+            continue
+        }
+        print("  ")
+        println(num)
+    }
+    println("")
+}
+
+// Nested as_long_as loops
+do example_nested() {
+    using std
+
+    println("4. Nested as_long_as loops:")
+    temp outer int = 0
+    as_long_as outer < 3 {
+        temp inner int = 0
+        as_long_as inner < 3 {
+            print("  (")
+            print(outer)
+            print(", ")
+            print(inner)
+            println(")")
+            inner = inner + 1
+        }
+        outer = outer + 1
+    }
+    println("")
+}
+
+// Countdown example
+do example_countdown() {
+    using std
+
+    println("5. Countdown:")
+    temp count int = 5
+    as_long_as count > 0 {
+        print("  ")
+        println(count)
+        count = count - 1
+    }
+    println("  Liftoff!")
+    println("")
+}

--- a/examples/tests.ez
+++ b/examples/tests.ez
@@ -221,6 +221,32 @@ do test_control_flow() {
         }
     }
 
+    // While loop (as_long_as)
+    temp count int = 0
+    as_long_as count < 5 {
+        count += 1
+    }
+
+    // While loop with break
+    temp breakTest int = 0
+    as_long_as breakTest < 100 {
+        breakTest += 1
+        if breakTest == 10 {
+            break
+        }
+    }
+
+    // While loop with continue
+    temp continueTest int = 0
+    temp oddSum int = 0
+    as_long_as continueTest < 10 {
+        continueTest += 1
+        if continueTest % 2 == 0 {
+            continue
+        }
+        oddSum += continueTest
+    }
+
     println("  ✓ Control flow working")
 }
 


### PR DESCRIPTION
- Add as_long_as tests to examples/tests.ez in test_control_flow()
- Test basic loop functionality
- Test break statement in as_long_as loops
- Test continue statement in as_long_as loops
- Create examples/as_long_as_loop.ez with comprehensive examples:
  - Basic usage
  - Using break to exit early
  - Using continue to skip iterations
  - Nested as_long_as loops
  - Countdown example
- Verify all examples run correctly
- Feature was already implemented but not tested or documented

- closes #38 