### PR TITLE
Fix std.read_int to return (int, Error)

### DIFF
--- a/examples/user_input.ez
+++ b/examples/user_input.ez
@@ -1,0 +1,84 @@
+import @std
+
+/*
+ * EZ Language - User Input Examples
+ *
+ * Demonstrates reading user input using:
+ * - input() for reading strings
+ * - std.read_int() for reading integers with error handling
+ */
+
+do main() {
+    using std
+
+    println("=== User Input Examples ===")
+    println("")
+
+    example_string_input()
+    example_integer_input()
+    example_integer_validation()
+}
+
+// Example 1: Reading string input
+do example_string_input() {
+    using std
+
+    println("1. String input with input():")
+    println("   Enter your name:")
+    temp name string = input()
+    println("   Hello,", name)
+    println("")
+}
+
+// Example 2: Reading integer input with error handling
+do example_integer_input() {
+    using std
+
+    println("2. Integer input with std.read_int():")
+    println("   Enter your age:")
+    temp age, err = read_int()
+
+    if err == nil {
+        println("   You are", age, "years old")
+    } otherwise {
+        println("   Error:", err.message)
+    }
+    println("")
+}
+
+// Example 3: Integer input with validation loop
+do example_integer_validation() {
+    using std
+
+    println("3. Integer input with validation:")
+    println("   Enter a number between 1 and 100:")
+
+    temp valid bool = false
+    temp num int = 0
+
+    as_long_as !valid {
+        temp input, err = read_int()
+
+        if err != nil {
+            println("   Invalid input:", err.message)
+            println("   Please try again:")
+            continue
+        }
+
+        if input < 1 {
+            println("   Too small! Try again:")
+            continue
+        }
+
+        if input > 100 {
+            println("   Too large! Try again:")
+            continue
+        }
+
+        num = input
+        valid = true
+    }
+
+    println("   You entered:", num)
+    println("")
+}


### PR DESCRIPTION
- Modify std.read_int() to return (int, Error) for proper error handling
- On success: return (value, nil)
- On parse error: return (0, Error{message: "invalid integer input", code: 2})
- On read error: return (0, Error{message: "failed to read input", code: 1})
- Create examples/user_input.ez with comprehensive input examples
- Prevents crashes on invalid input, follows EZ error handling pattern

- closes #43 