### PR TITLE
Implement file-scoped using declarations 

### DIFF
--- a/examples/file_scoped_using.ez
+++ b/examples/file_scoped_using.ez
@@ -1,0 +1,59 @@
+import @std
+import @arrays
+
+/*
+ * EZ Language - File-Scoped Using Declarations
+ *
+ * File-scoped 'using' declarations make imported modules available
+ * throughout the entire file, eliminating the need to repeat 'using'
+ * statements in every function.
+ *
+ * Key features:
+ * - Must come after imports, before other declarations
+ * - Available in all functions in the file
+ * - Supports comma-separated syntax: using std, arrays
+ * - Function-scoped 'using' adds to (not replaces) file-scoped modules
+ */
+
+// File-scoped using - available in all functions
+using std, arrays
+
+do main() {
+    println("=== File-Scoped Using Examples ===")
+    println("")
+
+    example_basic()
+    example_function_scoped()
+}
+
+// Example 1: File-scoped using
+do example_basic() {
+    // std and arrays are already available via file-scoped using
+    println("1. File-scoped using:")
+
+    temp numbers [int] = {1, 2, 3}
+    println("  Original array:", numbers)
+
+    push(numbers, 4)
+    push(numbers, 5)
+    println("  After pushes:", numbers)
+
+    temp last int = pop(numbers)
+    println("  Popped:", last)
+    println("  Final array:", numbers)
+    println("")
+}
+
+// Example 2: Function-scoped using ADDS to file-scoped
+do example_function_scoped() {
+    // Already have std and arrays from file-scoped using
+    println("2. Function-scoped using adds to file-scoped:")
+
+    temp data [string] = {"hello", "world"}
+    println("  Data:", data)
+    println("  Length:", len(data))
+
+    // If we added 'using strings' here, we'd have std + arrays + strings
+    // But for this example, we just demonstrate that file-scoped is available
+    println("")
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -23,6 +23,7 @@ type Expression interface {
 
 // Program is the root node of every AST
 type Program struct {
+	FileUsing  []*UsingStatement // File-scoped using declarations
 	Statements []Statement
 }
 
@@ -386,10 +387,11 @@ type ImportStatement struct {
 func (i *ImportStatement) statementNode(){}
 func (i *ImportStatement) TokenLiteral() string { return i.Token.Literal }
 
-// UsingStatement represents using module
+// UsingStatement represents using module(s)
+// Supports both single (using std) and comma-separated (using std, arrays)
 type UsingStatement struct {
-	Token  Token
-	Module *Label
+	Token   Token
+	Modules []*Label // List of modules to bring into scope
 }
 
 func (u *UsingStatement) statementNode(){}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -40,6 +40,7 @@ var (
 	E3003 = ErrorCode{"E3003", "undefined-field", "field does not exist"}
 	E3004 = ErrorCode{"E3004", "undefined-module", "module not found"}
 	E3005 = ErrorCode{"E3005", "not-imported", "module not imported"}
+	E3006 = ErrorCode{"E3006", "ambiguous-function", "function found in multiple modules"}
 
 	// Runtime Errors (E4xxx)
 	E4001 = ErrorCode{"E4001", "division-by-zero", "cannot divide by zero"}
@@ -54,6 +55,7 @@ var (
 	E5001 = ErrorCode{"E5001", "circular-import", "circular import detected"}
 	E5002 = ErrorCode{"E5002", "file-not-found", "file not found"}
 	E5003 = ErrorCode{"E5003", "invalid-module", "invalid module"}
+	E5004 = ErrorCode{"E5004", "module-not-imported-yet", "module not imported yet"}
 )
 
 // Warning code definitions


### PR DESCRIPTION
- Add error codes E3006 (ambiguous function) and E5004 (module not imported yet)
- Modify AST: Program now has FileUsing field for file-scoped using declarations
- Modify UsingStatement to support multiple modules via Modules field (comma-separated)
- Update parser to parse file-scoped using after imports, before other declarations
- Validate placement: using must come before structs/functions/etc
- Update evaluator to process imports first, then file-scoped using, then statements
- Implement ambiguity detection: error E3006 when multiple modules have same function
- Support both single and comma-separated syntax: using std OR using std, arrays
- Create examples/file_scoped_using.ez demonstrating file-scoped using

- closes #54 