### PR TITLE
Fix struct field compound assignment operators broken

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -461,6 +461,19 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 		if !ok {
 			return newError("member access not supported: %s", obj.Type())
 		}
+
+		// Handle compound assignment
+		if node.Operator != "=" {
+			oldVal, exists := structObj.Fields[target.Member.Value]
+			if !exists {
+				return newError("field '%s' not found", target.Member.Value)
+			}
+			val = evalCompoundAssignment(node.Operator, oldVal, val, node.Token.Line, node.Token.Column)
+			if isError(val) {
+				return val
+			}
+		}
+
 		structObj.Fields[target.Member.Value] = val
 	}
 


### PR DESCRIPTION
- Add compound assignment handling for MemberExpression (struct fields)
- Retrieve old field value before calling evalCompoundAssignment
- Now person.age += 1 correctly adds to existing value (30 + 1 = 31)
- Previously was just assigning right operand (age = 1 instead of 31)
- Matches array index compound assignment behavior
- All compound operators now work: +=, -=, *=, /=, %=

- closes #59