### PR TITLE
Add string interpolation with dollar-brace syntax (Issue #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ do add(x, y int) -> int {
 
 - **Strings & Characters**
   - String concatenation with `+`
+  - String interpolation with dollar-brace syntax
   - String indexing and character access
   - String mutation for `temp` variables
   - Character type with single quotes: `'A'`

--- a/examples/string_interpolation.ez
+++ b/examples/string_interpolation.ez
@@ -1,0 +1,59 @@
+import @std
+
+do main() {
+    using std
+
+    // Test 1: Simple variable interpolation
+    temp name string = "Alice"
+    temp age int = 25
+    println("Test 1: Hello, ${name}! You are ${age} years old.")
+
+    // Test 2: Multiple interpolations in one string
+    temp x int = 10
+    temp y int = 20
+    println("Test 2: x = ${x}, y = ${y}, sum = ${x + y}")
+
+    // Test 3: Expressions in interpolation
+    temp score int = 85
+    println("Test 3: Score: ${score}, Passing: ${score >= 60}")
+
+    // Test 4: Float values
+    temp pi float = 3.14159
+    println("Test 4: Pi is approximately ${pi}")
+
+    // Test 5: Character interpolation
+    temp letter char = 'A'
+    println("Test 5: The letter is ${letter}")
+
+    // Test 6: Boolean interpolation
+    temp isValid bool = true
+    println("Test 6: Valid: ${isValid}")
+
+    // Test 7: Arithmetic expressions
+    temp a int = 5
+    temp b int = 3
+    println("Test 7: ${a} + ${b} = ${a + b}, ${a} * ${b} = ${a * b}")
+
+    // Test 8: Comparison expressions
+    temp num1 int = 10
+    temp num2 int = 20
+    println("Test 8: Is ${num1} less than ${num2}? ${num1 < num2}")
+
+    // Test 9: String concatenation in interpolation
+    temp first string = "Hello"
+    temp second string = "World"
+    println("Test 9: ${first} ${second}!")
+
+    // Test 10: Nested expressions
+    temp value int = 42
+    println("Test 10: The answer is ${value}, doubled is ${value * 2}")
+
+    // Test 11: No interpolation (plain string)
+    println("Test 11: This is a plain string with no interpolation")
+
+    // Test 12: Multiple variables
+    temp city string = "Austin"
+    temp state string = "Texas"
+    temp population int = 961855
+    println("Test 12: ${city}, ${state} has a population of ${population}")
+}

--- a/examples/string_interpolation_advanced.ez
+++ b/examples/string_interpolation_advanced.ez
@@ -1,0 +1,49 @@
+import @std
+
+const Person struct {
+    name string
+    age int
+}
+
+do main() {
+    using std
+
+    // Test with struct fields
+    temp person Person = Person{name: "Bob", age: 30}
+    println("Person: ${person.name}, Age: ${person.age}")
+
+    // Test with array elements
+    temp nums [int] = {10, 20, 30, 40, 50}
+    println("First: ${nums[0]}, Last: ${nums[4]}")
+
+    // Test with function calls
+    temp text string = "hello"
+    println("Length of '${text}' is ${len(text)}")
+
+    // Test with nested expressions
+    temp score int = 85
+    println("Grade: ${score >= 90}, Above 80: ${score > 80}")
+
+    // Test with logical operators
+    temp x int = 5
+    temp y int = 10
+    println("x < y && y > 0: ${x < y && y > 0}")
+
+    // Test with modulo
+    temp num int = 17
+    println("${num} % 5 = ${num % 5}")
+
+    // Test interpolation at start and end of string
+    temp value int = 42
+    println("${value} is the answer")
+    println("The answer is ${value}")
+
+    // Test multiple same variable
+    temp name string = "Alice"
+    println("${name}, ${name}, ${name}!")
+
+    // Test empty parts between interpolations
+    temp a int = 1
+    temp b int = 2
+    println("${a}${b}")
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -80,6 +80,15 @@ type StringValue struct {
 func (v *StringValue) expressionNode(){}
 func (v *StringValue) TokenLiteral() string { return v.Token.Literal }
 
+// InterpolatedString represents a string with embedded expressions like "Hello, ${name}!"
+type InterpolatedString struct {
+	Token Token
+	Parts []Expression // alternating StringValue and Expression nodes
+}
+
+func (i *InterpolatedString) expressionNode(){}
+func (i *InterpolatedString) TokenLiteral() string { return i.Token.Literal }
+
 // CharValue represents a character value
 type CharValue struct {
 	Token Token

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -168,6 +168,9 @@ func Eval(node ast.Node, env *Environment) Object {
 	case *ast.StringValue:
 		return &String{Value: node.Value}
 
+	case *ast.InterpolatedString:
+		return evalInterpolatedString(node, env)
+
 	case *ast.CharValue:
 		return &Char{Value: node.Value}
 
@@ -1300,6 +1303,23 @@ func evalStringIndexExpression(str, index Object) Object {
 	}
 
 	return &Char{Value: rune(stringObject.Value[idx])}
+}
+
+func evalInterpolatedString(node *ast.InterpolatedString, env *Environment) Object {
+	var result strings.Builder
+
+	for _, part := range node.Parts {
+		// Evaluate the part
+		val := Eval(part, env)
+		if isError(val) {
+			return val
+		}
+
+		// Convert to string using Inspect()
+		result.WriteString(val.Inspect())
+	}
+
+	return &String{Value: result.String()}
 }
 
 func evalStructValue(node *ast.StructValue, env *Environment) Object {


### PR DESCRIPTION
## Summary
Implements string interpolation allowing expressions to be embedded within string literals using dollar-brace syntax. This addresses issue #61 and provides a more ergonomic way to construct strings with embedded values.

## Changes
- **AST**: Added InterpolatedString node type to represent strings with embedded expressions
- **Parser**: Added logic to detect and parse interpolation patterns, creating mini-parsers for embedded expressions
- **Evaluator**: Added evalInterpolatedString() function to evaluate and concatenate string parts
- **Examples**: Added comprehensive test files demonstrating all use cases

## Features
- Simple variable interpolation
- Arithmetic and comparison expressions
- Struct field access and array indexing
- Function calls within interpolations
- Multiple interpolations per string
- Proper error handling for unclosed/empty interpolations

## Test Coverage
All test cases pass successfully:
- Basic variable interpolation with multiple data types
- Complex expressions with operators
- Struct field access and array element access
- Function calls and edge cases

## Files Changed
- pkg/ast/ast.go (+9 lines)
- pkg/parser/parser.go (+166 lines)
- pkg/interpreter/evaluator.go (+20 lines)
- examples/string_interpolation.ez (new)
- examples/string_interpolation_advanced.ez (new)
- README.md (updated)

Closes #61
