### PR TITLE
Add numeric separators with underscores for readability (Issue #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ do add(x, y int) -> int {
 
 - **Data Types**
   - Primitives: `int`, `float`, `string`, `char`, `bool`
+  - Numeric separators: underscores for readability (`1_000_000`)
   - Arrays: dynamic `[type]` and fixed-size `[type, size]`
   - Structs: user-defined types with fields
   - Enums: integer, float, and string enums with attributes
@@ -219,6 +220,12 @@ temp price float = 19.99
 temp text string = "hello"
 temp letter char = 'A'
 temp isActive bool = true
+
+// Numeric separators for readability
+temp million int = 1_000_000
+temp billion int = 7_800_000_000
+temp pi float = 3.141_592_653
+temp money float = 1_234.56
 
 // Arrays
 temp numbers [int] = {1, 2, 3, 4, 5}

--- a/examples/numeric_separators.ez
+++ b/examples/numeric_separators.ez
@@ -1,0 +1,80 @@
+import @std
+
+do main() {
+    using std
+
+    println("=== Valid Integer Separators ===")
+
+    // Thousands separators
+    temp thousand int = 1_000
+    temp million int = 1_000_000
+    temp billion int = 7_800_000_000
+
+    println("Thousand:", thousand)
+    println("Million:", million)
+    println("Billion:", billion)
+
+    // Arbitrary grouping (all valid)
+    temp group1 int = 12_34_56
+    temp group2 int = 1_2_3_4_5
+    temp group3 int = 5_000
+
+    println("Arbitrary grouping 1:", group1)
+    println("Arbitrary grouping 2:", group2)
+    println("Arbitrary grouping 3:", group3)
+
+    println("")
+    println("=== Valid Float Separators ===")
+
+    // Float with separators
+    temp pi float = 3.141_592_653
+    temp money float = 1_000.50
+    temp both_sides float = 1_234.567_890
+    temp precise float = 3.141_592_653_59
+
+    println("Pi:", pi)
+    println("Money:", money)
+    println("Both sides:", both_sides)
+    println("Precise:", precise)
+
+    println("")
+    println("=== Arithmetic with Separators ===")
+
+    temp x int = 1_000
+    temp y int = 2_000
+    temp sum int = x + y
+    temp product int = x * y
+
+    println("1_000 + 2_000 =", sum)
+    println("1_000 * 2_000 =", product)
+
+    temp a float = 10_000.5
+    temp b float = 2_000.25
+    temp diff float = a - b
+
+    println("10_000.5 - 2_000.25 =", diff)
+
+    println("")
+    println("=== Comparisons ===")
+
+    temp population int = 7_800_000_000
+    if population > 7_000_000_000 {
+        println("Population is over 7 billion")
+    }
+
+    temp price float = 1_234.56
+    if price >= 1_000.00 {
+        println("Price is over $1000")
+    }
+
+    println("")
+    println("=== Mixed Usage ===")
+
+    temp array_size int = 10_000
+    temp bytes int = 16_777_216
+    temp percentage float = 99.999_999
+
+    println("Array size:", array_size)
+    println("Bytes:", bytes)
+    println("Percentage:", percentage)
+}

--- a/examples/numeric_separators_invalid.ez
+++ b/examples/numeric_separators_invalid.ez
@@ -1,0 +1,30 @@
+import @std
+
+do main() {
+    using std
+
+    // These should all produce errors:
+
+    // Leading underscore
+    // temp bad1 int = _123
+
+    // Trailing underscore
+    // temp bad2 int = 123_
+
+    // Consecutive underscores
+    // temp bad3 int = 1__000
+
+    // Underscore before decimal point
+    // temp bad4 float = 3_.14
+
+    // Underscore after decimal point
+    // temp bad5 float = 3._14
+
+    // Trailing underscore in float
+    // temp bad6 float = 3.14_
+
+    // Multiple violations
+    // temp bad7 float = _3._14_
+
+    println("If you see this, the error checking might not be working correctly!")
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -5,6 +5,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	. "github.com/marshallburns/ez/pkg/ast"
 	"github.com/marshallburns/ez/pkg/errors"
@@ -1553,7 +1554,10 @@ func (p *Parser) parseStructValue(name *Label) Expression {
 func (p *Parser) parseIntegerValue() Expression {
 	lit := &IntegerValue{Token: p.currentToken}
 
-	value, err := strconv.ParseInt(p.currentToken.Literal, 0, 64)
+	// Strip underscores for numeric conversion (they're only for readability)
+	cleanedLiteral := stripUnderscores(p.currentToken.Literal)
+
+	value, err := strconv.ParseInt(cleanedLiteral, 0, 64)
 	if err != nil {
 		msg := fmt.Sprintf("could not parse %q as integer", p.currentToken.Literal)
 		p.errors = append(p.errors, msg)
@@ -1565,10 +1569,27 @@ func (p *Parser) parseIntegerValue() Expression {
 	return lit
 }
 
+// stripUnderscores removes all underscores from a numeric literal
+func stripUnderscores(s string) string {
+	if !strings.Contains(s, "_") {
+		return s
+	}
+	var result strings.Builder
+	for _, ch := range s {
+		if ch != '_' {
+			result.WriteRune(ch)
+		}
+	}
+	return result.String()
+}
+
 func (p *Parser) parseFloatValue() Expression {
 	lit := &FloatValue{Token: p.currentToken}
 
-	value, err := strconv.ParseFloat(p.currentToken.Literal, 64)
+	// Strip underscores for numeric conversion (they're only for readability)
+	cleanedLiteral := stripUnderscores(p.currentToken.Literal)
+
+	value, err := strconv.ParseFloat(cleanedLiteral, 64)
 	if err != nil {
 		msg := fmt.Sprintf("could not parse %q as float", p.currentToken.Literal)
 		p.errors = append(p.errors, msg)


### PR DESCRIPTION
## Summary
Implements numeric separators with underscores to improve readability of large numbers, following conventions from Rust, Python, and Java. This addresses issue #53.

## Changes
- **Lexer**: Modified readNumber() to accept underscores between digits with full validation
- **Parser**: Added stripUnderscores() function to remove underscores before numeric conversion
- **Validation**: Comprehensive error checking for all invalid underscore placements
- **Examples**: Added test files demonstrating valid and invalid usage

## Features
- Underscores in integers: 1_000_000, 7_800_000_000
- Underscores in floats: 3.141_592_653, 1_234.56
- Arbitrary grouping allowed: 12_34_56
- Underscores stripped during parsing (purely cosmetic)

## Validation Rules
All invalid placements produce clear error messages:
- Cannot start or end with underscore
- Cannot have consecutive underscores
- Cannot be adjacent to decimal points

## Test Coverage
All test cases pass:
- Valid integer separators (thousands, millions, arbitrary grouping)
- Valid float separators (before/after decimal, both sides)
- Arithmetic operations with separators
- All error cases properly detected and reported

## Files Changed
- pkg/lexer/lexer.go (+72 lines)
- pkg/parser/parser.go (+18 lines)
- README.md (updated with examples)
- examples/numeric_separators.ez (new)
- examples/numeric_separators_invalid.ez (new)

Closes #53
