### PR TITLE
Disable opinionated golangci-lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,14 @@ linters-settings:
   gofmt:
     simplify: true
 
+  gocritic:
+    disabled-checks:
+      - ifElseChain
+      - commentFormatting
+      - singleCaseSwitch
+      - whyNoLint
+      - unnamedResult
+
 issues:
   exclude-use-default: false
   max-issues-per-linter: 0

--- a/pkg/interpreter/lib_arrays.go
+++ b/pkg/interpreter/lib_arrays.go
@@ -35,7 +35,7 @@ var arraysBuiltins = map[string]*Builtin{
 		},
 	},
 
-	//Returns a boolean indicating if the array is empty or not.
+	// Returns a boolean indicating if the array is empty or not.
 	"arrays.is_empty": {
 		Fn: func(args ...Object) Object {
 			if len(args) != 1 {


### PR DESCRIPTION
## Summary
- Disable ifElseChain rule (too many false positives in lexer/parser)
- Disable commentFormatting rule (already using gofmt)
- Disable singleCaseSwitch, whyNoLint, unnamedResult (overly opinionated)
- Fix remaining comment formatting issue in lib_arrays.go

## Test plan
- [ ] CI passes without style complaints