### PR TITLE
Remove linting and formatting checks from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,24 +24,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Check Go formatting
-        if: runner.os != 'Windows'
-        run: |
-          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-            echo "The following files are not formatted:"
-            gofmt -s -l .
-            exit 1
-          fi
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: latest
-          args: --timeout=5m
-
       - name: Build interpreter
         run: go build -o ez.bin ./cmd/ez
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
Remove gofmt, go vet, and golangci-lint steps from CI workflow.

CI will now only build and test the code.

## Test plan
- [ ] CI builds successfully
- [ ] CI runs tests successfully