### PR TITLE
fix: add error E3007 for missing main() function

### DIFF
--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -200,6 +200,8 @@ func printRuntimeError(errObj *interpreter.Error, source, filename string) {
 			code = errors.E3004
 		case "E3005":
 			code = errors.E3005
+		case "E3007":
+			code = errors.E3007
 		case "E4001":
 			code = errors.E4001
 		case "E4002":

--- a/examples/tests.ez
+++ b/examples/tests.ez
@@ -532,6 +532,10 @@ do test_reference_errors() {
     // E3002: Module function not found
     // std.nonExistentFunction()
 
+    // E3007: No entry point (missing main function)
+    // NOTE: To test this, create a file without main() function
+    // The program should fail with "Program must define a main() function"
+
     println("  Reference error tests complete")
 }
 

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -42,6 +42,7 @@ var (
 	E3004 = ErrorCode{"E3004", "undefined-module", "module not found"}
 	E3005 = ErrorCode{"E3005", "not-imported", "module not imported"}
 	E3006 = ErrorCode{"E3006", "ambiguous-function", "function found in multiple modules"}
+	E3007 = ErrorCode{"E3007", "no-entry-point", "no entry point found"}
 
 	// Runtime Errors (E4xxx)
 	E4001 = ErrorCode{"E4001", "division-by-zero", "cannot divide by zero"}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -189,6 +189,9 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) bool {
 		}
 	}
 
+	// Phase 4: Validate that a main() function exists
+	tc.checkMainFunction()
+
 	errCount, _ := tc.errors.Count()
 	return errCount == 0
 }
@@ -326,4 +329,16 @@ func (tc *TypeChecker) checkFunctionBody(node *ast.FunctionDeclaration) {
 	// - Expressions
 	// - Function calls
 	// - Return statements
+}
+
+// checkMainFunction validates that a main() function exists as the program entry point
+func (tc *TypeChecker) checkMainFunction() {
+	if _, exists := tc.functions["main"]; !exists {
+		tc.addError(
+			errors.E3007,
+			"Program must define a main() function",
+			1,
+			1,
+		)
+	}
 }


### PR DESCRIPTION
- Added E3007 error code "no-entry-point" to pkg/errors/codes.go
- Implemented checkMainFunction() in typechecker to validate main() exists
- Added Phase 4 validation in CheckProgram() to check for entry point
- Updated error handling in cmd/ez/main.go to include E3007
- Added E3007 test documentation to examples/tests.ez

- fixes #73