### PR TITLE
fix: add warning W2003 for missing return statement

### DIFF
--- a/examples/tests.ez
+++ b/examples/tests.ez
@@ -662,6 +662,12 @@ do test_warnings() {
         temp shadow int = 20  // shadows outer variable
     }
 
+    // W2003: Function missing return statement
+    // NOTE: To test this, uncomment the function below
+    // do missing_return() -> int {
+    //     println("No return statement")
+    // }
+
     println("  Warning tests complete")
 }
 

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -70,4 +70,5 @@ var (
 	// Potential Bug Warnings (W2xxx)
 	W2001 = ErrorCode{"W2001", "unreachable-code", "Unreachable code"}
 	W2002 = ErrorCode{"W2002", "shadowed-variable", "Variable shadows outer scope"}
+	W2003 = ErrorCode{"W2003", "missing-return", "Function missing return statement"}
 )


### PR DESCRIPTION
- Added W2003 warning code to pkg/errors/codes.go
- Implemented addWarning() helper in typechecker
- Implemented checkFunctionBody() to detect missing return statements
- Added helper methods isSuppressed() and hasReturnStatement()
- Recursively checks for return statements in function bodies
- Respects @suppress(W2003) attribute
- Updated examples/tests.ez with W2003 documentation

The type checker now warns when functions declare return types but lack return statements.

- fixes #74