### PR TITLE
fix: deduplicate modules in using scope to prevent ambiguity

### DIFF
--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -278,13 +278,25 @@ func (e *Environment) Use(alias string) {
 }
 
 // GetUsing returns all modules in scope (checks parent scopes too)
+// Deduplicates modules to avoid ambiguity when same module is used in multiple scopes
 func (e *Environment) GetUsing() []string {
 	result := make([]string, len(e.using))
 	copy(result, e.using)
 	if e.outer != nil {
 		result = append(result, e.outer.GetUsing()...)
 	}
-	return result
+
+	// Deduplicate the modules
+	seen := make(map[string]bool)
+	deduped := make([]string, 0, len(result))
+	for _, module := range result {
+		if !seen[module] {
+			seen[module] = true
+			deduped = append(deduped, module)
+		}
+	}
+
+	return deduped
 }
 
 func (e *Environment) Get(name string) (Object, bool) {


### PR DESCRIPTION
Fixes #71

- Modified GetUsing() in pkg/interpreter/object.go to deduplicate modules before returning
- When same module is used in both global and local scope, it now only appears once in the result
- Prevents false E3006 ambiguity error when functions are called

Previously, declaring "using std" both globally and in a function would cause GetUsing() to return ["std", "std"], making the interpreter think the function was available in two different modules.

Now properly deduplicates to return ["std"] only once.