### PR TITLE
fix: track imports by alias to support aliased using statements

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -391,14 +391,12 @@ func (p *Parser) ParseProgram() *Program {
 		if stmt != nil {
 			program.Statements = append(program.Statements, stmt)
 
-			// Track imported modules
+			// Track imported modules by both alias and module name
 			if importStmt, ok := stmt.(*ImportStatement); ok {
-				// Extract module name (handle both @std and alias@std)
-				moduleName := importStmt.Module
-				if strings.HasPrefix(moduleName, "@") {
-					moduleName = moduleName[1:] // Remove @ prefix
-				}
-				importedModules[moduleName] = true
+				// Track the alias so "using arr" works with "import arr@arrays"
+				importedModules[importStmt.Alias] = true
+				// Also track the module name so "using arrays" still works
+				importedModules[importStmt.Module] = true
 			}
 		}
 		p.nextToken()


### PR DESCRIPTION
- Modified ParseProgram() in pkg/parser/parser.go to track imports by both alias and module name
- Changed validation to accept importedModules[Alias] for "using"
- Allows "using arr" to work with "import arr@arrays"

Previously, when tracking imported modules for validation, the parser stored only the module name (e.g., "arrays") but the using statement was validated against the alias (e.g., "arr"), causing a mismatch.

Now correctly validates against both alias and module name, enabling:
- File-scoped: "import arr@arrays" + "using arr"
- Function-scoped: "using arr" inside function bodies
- Explicit prefix: "arr.push()" continues to work

- fixes #79