### PR TITLE
fix: use global stdin reader to fix input() buffering issues

### DIFF
--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -8,7 +8,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
+
+// Global stdin reader to maintain buffering across multiple input() calls
+var stdinReader = bufio.NewReader(os.Stdin)
 
 var builtins = map[string]*Builtin{
 	// BASIC STANDARD LIBRARY BUILTINS
@@ -169,12 +173,10 @@ var builtins = map[string]*Builtin{
 	// Reads a line of input from standard input and returns it as a string.
 	"input": {
 		Fn: func(args ...Object) Object {
-			reader := bufio.NewReader(os.Stdin)
-			text, _ := reader.ReadString('\n')
-			// Trim newline
-			if len(text) > 0 && text[len(text)-1] == '\n' {
-				text = text[:len(text)-1]
-			}
+			// Use global reader to avoid buffering issues with multiple input() calls
+			text, _ := stdinReader.ReadString('\n')
+			// Trim newline characters (both \n and \r\n for cross-platform support)
+			text = strings.TrimRight(text, "\r\n")
 			return &String{Value: text}
 		},
 	},


### PR DESCRIPTION
- Created global stdinReader in pkg/interpreter/builtins.go
- Modified input() function to use global reader instead of creating new bufio.Reader on each call
- Improved newline trimming with strings.TrimRight for cross-platform support (handles both \n and \r\n)

Root Cause:
Each input() call was creating a new bufio.Reader(os.Stdin). When the first reader was created, it would buffer multiple lines from stdin. Subsequent input() calls would create new readers that couldn't access the buffered data, causing them to return empty strings.

Solution:
Use a single global bufio.Reader that persists across all input() calls. This ensures the buffer is shared and all input lines are read correctly.

- fixes #80

This fixes string interpolation with input() values, which was the reported symptom, but the actual issue was multiple input() calls.