### PR TITLE
fix: preserve enum type information with EnumValue wrapper

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1240,6 +1240,9 @@ func objectTypeToEZ(obj Object) string {
 			return v.TypeName
 		}
 		return "struct"
+	case *EnumValue:
+		// Return the enum type name (e.g., "COLOR")
+		return v.EnumType
 	case *Nil:
 		return "nil"
 	case *Function:
@@ -1423,7 +1426,12 @@ func evalMemberExpression(node *ast.MemberExpression, env *Environment) Object {
 	// Check for enum value access (e.g., STATUS.ACTIVE)
 	if enumObj, ok := obj.(*Enum); ok {
 		if val, ok := enumObj.Values[node.Member.Value]; ok {
-			return val
+			// Wrap the value in an EnumValue to preserve type information
+			return &EnumValue{
+				EnumType: enumObj.Name,
+				Name:     node.Member.Value,
+				Value:    val,
+			}
 		}
 		return newErrorWithLocation("E3003", node.Token.Line, node.Token.Column,
 			"enum value '%s' not found in enum '%s'", node.Member.Value, enumObj.Name)

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -28,6 +28,7 @@ const (
 	BREAK_OBJ        ObjectType = "BREAK"
 	CONTINUE_OBJ     ObjectType = "CONTINUE"
 	ENUM_OBJ         ObjectType = "ENUM"
+	ENUM_VALUE_OBJ   ObjectType = "ENUM_VALUE"
 )
 
 type Object interface {
@@ -210,6 +211,18 @@ func (e *Enum) Inspect() string {
 	}
 	out.WriteString(" }")
 	return out.String()
+}
+
+// EnumValue wraps an enum member value with its type information
+type EnumValue struct {
+	EnumType string // The enum type name (e.g., "COLOR")
+	Name     string // The value name (e.g., "RED")
+	Value    Object // The underlying value (Integer, Float, or String)
+}
+
+func (ev *EnumValue) Type() ObjectType { return ENUM_VALUE_OBJ }
+func (ev *EnumValue) Inspect() string {
+	return ev.Value.Inspect()
 }
 
 // Environment holds variable bindings


### PR DESCRIPTION
- Added ENUM_VALUE_OBJ constant to ObjectType
- Created EnumValue struct to wrap enum member values with type info
- Modified member access evaluation to return EnumValue instead of raw primitive when accessing enum members
- Updated objectTypeToEZ() to recognize EnumValue and return enum type

Root Cause:
When accessing enum members (e.g., COLOR.RED), the evaluator returned only the underlying primitive value (Integer/String/Float), discarding the enum type context. This caused type checking to fail for:
- Function returns: "expected COLOR, got int"
- Variable assignments
- Function parameters

Solution:
Introduced EnumValue wrapper that preserves:
- EnumType: The enum type name (e.g., "COLOR")
- Name: The member name (e.g., "RED")
- Value: The underlying primitive value

- fixes #77

Now enum values maintain their type identity throughout execution while still providing access to the underlying value when needed.

Changes:
- pkg/interpreter/object.go:
  * Added ENUM_VALUE_OBJ constant
  * Added EnumValue struct with Type() and Inspect() methods

- pkg/interpreter/evaluator.go:
  * Wrapped enum member access return values in EnumValue
  * Added EnumValue case to objectTypeToEZ()