### PR TITLE
feat: add installation and distribution system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *bin
 !*examples/
 main.ez
+ez
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# EZ Language Build System
+.PHONY: build install uninstall clean test help
+
+BINARY_NAME=ez
+INSTALL_PATH=/usr/local/bin
+GO=go
+
+# Version info
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
+LDFLAGS=-ldflags "-X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)"
+
+help:
+	@echo "EZ Language Build System"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  make build      - Build the ez binary"
+	@echo "  make install    - Install ez to $(INSTALL_PATH)"
+	@echo "  make uninstall  - Remove ez from $(INSTALL_PATH)"
+	@echo "  make clean      - Remove built binaries"
+	@echo "  make test       - Run tests"
+	@echo "  make release    - Build for multiple platforms"
+
+build:
+	@echo "Building EZ..."
+	$(GO) build $(LDFLAGS) -o $(BINARY_NAME) ./cmd/ez
+	@echo "Build complete! Binary: ./$(BINARY_NAME)"
+
+install: build
+	@echo "Installing EZ to $(INSTALL_PATH)..."
+	@if [ -w $(INSTALL_PATH) ]; then \
+		mkdir -p $(INSTALL_PATH); \
+		cp $(BINARY_NAME) $(INSTALL_PATH)/$(BINARY_NAME); \
+		chmod +x $(INSTALL_PATH)/$(BINARY_NAME); \
+	else \
+		echo "Need sudo permissions to install to $(INSTALL_PATH)"; \
+		sudo mkdir -p $(INSTALL_PATH); \
+		sudo cp $(BINARY_NAME) $(INSTALL_PATH)/$(BINARY_NAME); \
+		sudo chmod +x $(INSTALL_PATH)/$(BINARY_NAME); \
+	fi
+	@echo "EZ installed successfully!"
+	@echo "Try: ez help"
+
+uninstall:
+	@echo "Uninstalling EZ..."
+	@rm -f $(INSTALL_PATH)/$(BINARY_NAME)
+	@echo "EZ uninstalled"
+
+clean:
+	@echo "Cleaning build artifacts..."
+	@rm -f $(BINARY_NAME)
+	@rm -f ez.bin
+	@rm -rf dist/
+	@echo "Clean complete"
+
+test:
+	$(GO) test ./... -v
+
+# Build for multiple platforms
+release:
+	@echo "Building releases..."
+	@mkdir -p dist
+	GOOS=darwin GOARCH=amd64 $(GO) build $(LDFLAGS) -o dist/$(BINARY_NAME)-darwin-amd64 ./cmd/ez
+	GOOS=darwin GOARCH=arm64 $(GO) build $(LDFLAGS) -o dist/$(BINARY_NAME)-darwin-arm64 ./cmd/ez
+	GOOS=linux GOARCH=amd64 $(GO) build $(LDFLAGS) -o dist/$(BINARY_NAME)-linux-amd64 ./cmd/ez
+	GOOS=linux GOARCH=arm64 $(GO) build $(LDFLAGS) -o dist/$(BINARY_NAME)-linux-arm64 ./cmd/ez
+	GOOS=windows GOARCH=amd64 $(GO) build $(LDFLAGS) -o dist/$(BINARY_NAME)-windows-amd64.exe ./cmd/ez
+	@echo "Release builds complete in dist/"

--- a/README.md
+++ b/README.md
@@ -45,17 +45,40 @@ A simple interpreted programming language written in Go. The core philosophy is 
 
 ### Installation
 
-  ```bash
-  # Clone the repository
-  git clone https://github.com/SchoolyB/EZ.git
-  cd EZ
+**Option 1: Install Globally (Recommended)**
+```bash
+# Clone the repository
+git clone https://github.com/SchoolyB/EZ.git
+cd EZ
 
-  # Build the interpreter
-  go build -o ez.bin ./cmd/ez
+# Install EZ to your system (requires sudo password)
+make install
 
-  # Run the hello world example
-  ./ez.bin run examples/hello.ez
-  ```
+# Run from anywhere
+ez examples/hello.ez
+ez help
+```
+
+**Option 2: Build Locally**
+```bash
+# Clone the repository
+git clone https://github.com/SchoolyB/EZ.git
+cd EZ
+
+# Build the binary
+make build
+
+# Run with local binary
+./ez run examples/hello.ez
+```
+
+**Uninstall**
+```bash
+sudo make uninstall
+```
+
+**Requirements**
+- Go 1.23.1 or higher
 
   # Hello World
   ## Here's what's in examples/hello.ez:
@@ -67,8 +90,17 @@ A simple interpreted programming language written in Go. The core philosophy is 
   }
   ```
 
-To create your own programs, just create a `.ez` file in root of the project and run it:
-`./ez.bin run your_program.ez`
+### Usage
+
+Once installed, you can use EZ from anywhere:
+
+```bash
+ez your_program.ez       # Direct execution
+ez run your_program.ez   # Explicit run command
+ez build your_program.ez # Check syntax without running
+ez help                  # Show help
+ez version               # Show version
+```
 
 ### Basic Example
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# EZ Language Installer
+set -e
+
+INSTALL_DIR="/usr/local/bin"
+BINARY_NAME="ez"
+
+echo "EZ Language Installer"
+echo "===================="
+
+# Check if Go is installed
+if ! command -v go &> /dev/null; then
+    echo "Error: Go is not installed"
+    echo "Please install Go from https://golang.org/dl/"
+    exit 1
+fi
+
+# Build the binary
+echo "Building EZ..."
+go build -o "$BINARY_NAME" ./cmd/ez
+
+# Install to system
+echo "Installing to $INSTALL_DIR..."
+if [ -w "$INSTALL_DIR" ]; then
+    cp "$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+else
+    echo "Need sudo permissions to install to $INSTALL_DIR"
+    sudo cp "$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+    sudo chmod +x "$INSTALL_DIR/$BINARY_NAME"
+fi
+
+# Cleanup local binary
+rm -f "$BINARY_NAME"
+
+echo ""
+echo "EZ installed successfully!"
+echo "Run 'ez run <file>' to execute EZ programs"
+echo ""
+echo "To uninstall, run: sudo rm $INSTALL_DIR/$BINARY_NAME"


### PR DESCRIPTION
- Add Makefile with build, install, uninstall, clean, and release targets
- Create install.sh script for easy cross-platform setup
- Update README with installation instructions and usage examples
- Add help, version, and build commands to CLI
- Support direct file execution (ez file.ez) like Go and Odin
- Update .gitignore to exclude build artifacts

Users can now:
- Install globally: `make install`
- Run directly: `ez myProgram.ez`
- Build without running: `ez build myProgram.ez`
- Get help: `ez help`
- Check version: `ez version`