### PR TITLE
feat: add support for multiple inline imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ do get_user_name() -> string{
 
 - **Modules & Imports**
   - `import @module` syntax
+  - Multiple inline imports: `import @std, @arrays`
   - Module aliasing: `import alias@module`
+  - Mixed syntax support: `import @std, arr@arrays`
   - `using` keyword for namespace convenience
   - Standard library: `@std`, `@arrays`
 
@@ -427,8 +429,17 @@ temp result int = add(5, 10)
 // Import standard library
 import @std
 
+// Import multiple modules on one line
+import @std, @arrays, @math
+
 // Import with alias
 import arr@arrays
+
+// Import multiple modules with aliases
+import s@std, arr@arrays
+
+// Mix both syntaxes
+import @std, arr@arrays
 
 do main() {
     // Use with prefix

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -380,9 +380,18 @@ type Parameter struct {
 	TypeName string
 }
 
+// ImportItem represents a single module import with optional alias
+type ImportItem struct {
+	Alias  string
+	Module string
+}
+
 // ImportStatement represents import "module" or import alias "module"
+// Supports both single (import @std) and comma-separated (import @std, @arrays)
 type ImportStatement struct {
-	Token  Token
+	Token   Token
+	Imports []ImportItem // For multiple imports
+	// Deprecated: For backward compatibility with single imports
 	Alias  string
 	Module string
 }


### PR DESCRIPTION
## Summary
Implements comma-separated import syntax to allow importing multiple modules on a single line.

## Changes
- Added `ImportItem` struct to AST for representing individual imports
- Extended `ImportStatement` to support multiple imports via `Imports` array
- Updated parser to handle comma-separated import syntax with new `parseSingleImport()` helper
- Modified evaluator to process multiple imports
- Updated README with comprehensive examples
- Maintained full backward compatibility with existing single import syntax

## Syntax Support
The feature now supports three syntax variations:

**Multiple imports without aliases:**
```ez
import @std, @arrays, @math
```

**Multiple imports with aliases:**
```ez
import s@std, arr@arrays, m@math
```

**Mixed syntax:**
```ez
import @std, arr@arrays
```

## Testing
- ✅ Tested all three syntax variations
- ✅ Existing test suite passes (test/interpreter_tests.ez)
- ✅ Existing examples still work
- ✅ No regressions detected

Closes #72