### PR TITLE
Fix: Make range() end value exclusive (issue #112)

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -631,7 +631,7 @@ func evalForStatement(node *ast.ForStatement, env *Environment) Object {
 
 	loopEnv := NewEnclosedEnvironment(env)
 
-	for i := start.Value; i <= end.Value; i++ { // Inclusive range
+	for i := start.Value; i < end.Value; i++ { // Exclusive end
 		loopEnv.Set(node.Variable.Value, &Integer{Value: i}, true) // loop vars are mutable
 
 		result := Eval(node.Body, loopEnv)

--- a/test/range_exclusive_test.ez
+++ b/test/range_exclusive_test.ez
@@ -1,0 +1,230 @@
+import @std
+
+/*
+ * EZ Language - range() Exclusive End Test
+ *
+ * This test file verifies that range() uses an exclusive end value,
+ * matching the behavior of Python, Go, JavaScript, and other modern languages.
+ *
+ * Test Coverage:
+ * - Basic exclusive end behavior
+ * - Array iteration alignment
+ * - Edge cases (zero length, same start/end)
+ * - Mathematical correctness
+ */
+
+do main() {
+    using std
+
+    println("╔════════════════════════════════════════╗")
+    println("║   range() Exclusive End Value Test    ║")
+    println("╚════════════════════════════════════════╝")
+    println("")
+
+    test_basic_exclusive()
+    test_array_iteration()
+    test_mathematical_sums()
+    test_edge_cases()
+    test_iteration_counts()
+
+    println("")
+    println("╔════════════════════════════════════════╗")
+    println("║     All range() Tests Passed ✓         ║")
+    println("╚════════════════════════════════════════╝")
+}
+
+// Test that range(0, 2) iterates exactly 2 times (0, 1) not 3 times (0, 1, 2)
+do test_basic_exclusive() {
+    using std
+    println("→ Testing basic exclusive end behavior...")
+
+    // range(0, 2) should iterate: 0, 1 (2 times total)
+    temp count int = 0
+    for i in range(0, 2) {
+        count += 1
+    }
+
+    if count != 2 {
+        println("  ✗ FAILED: range(0, 2) iterated", count, "times, expected 2")
+        return
+    }
+
+    // range(0, 5) should iterate: 0, 1, 2, 3, 4 (5 times total)
+    count = 0
+    for i in range(0, 5) {
+        count += 1
+    }
+
+    if count != 5 {
+        println("  ✗ FAILED: range(0, 5) iterated", count, "times, expected 5")
+        return
+    }
+
+    // range(1, 4) should iterate: 1, 2, 3 (3 times total)
+    count = 0
+    for i in range(1, 4) {
+        count += 1
+    }
+
+    if count != 3 {
+        println("  ✗ FAILED: range(1, 4) iterated", count, "times, expected 3")
+        return
+    }
+
+    println("  ✓ Basic exclusive end behavior correct")
+}
+
+// Test that range aligns perfectly with array iteration
+do test_array_iteration() {
+    using std
+    println("→ Testing array iteration alignment...")
+
+    temp arr [int] = {10, 20, 30}
+    temp arrLen int = len(arr)
+
+    // range(0, len(arr)) should iterate exactly len(arr) times
+    temp count int = 0
+    for i in range(0, arrLen) {
+        count += 1
+    }
+
+    if count != arrLen {
+        println("  ✗ FAILED: range(0,", arrLen, ") iterated", count, "times, expected", arrLen)
+        return
+    }
+
+    // Verify we can safely access all array elements
+    temp sum int = 0
+    for i in range(0, len(arr)) {
+        sum += arr[i]
+    }
+
+    if sum != 60 {
+        println("  ✗ FAILED: Array sum =", sum, ", expected 60")
+        return
+    }
+
+    println("  ✓ Array iteration alignment correct")
+}
+
+// Test mathematical correctness of range sums
+do test_mathematical_sums() {
+    using std
+    println("→ Testing mathematical correctness...")
+
+    // range(0, 10) should sum to 0+1+2+3+4+5+6+7+8+9 = 45
+    temp sum int = 0
+    for i in range(0, 10) {
+        sum += i
+    }
+
+    if sum != 45 {
+        println("  ✗ FAILED: range(0, 10) sum =", sum, ", expected 45")
+        return
+    }
+
+    // range(5, 10) should sum to 5+6+7+8+9 = 35
+    sum = 0
+    for i in range(5, 10) {
+        sum += i
+    }
+
+    if sum != 35 {
+        println("  ✗ FAILED: range(5, 10) sum =", sum, ", expected 35")
+        return
+    }
+
+    // range(1, 6) should sum to 1+2+3+4+5 = 15
+    sum = 0
+    for i in range(1, 6) {
+        sum += i
+    }
+
+    if sum != 15 {
+        println("  ✗ FAILED: range(1, 6) sum =", sum, ", expected 15")
+        return
+    }
+
+    println("  ✓ Mathematical correctness verified")
+}
+
+// Test edge cases
+do test_edge_cases() {
+    using std
+    println("→ Testing edge cases...")
+
+    // range(0, 0) should not iterate at all
+    temp count int = 0
+    for i in range(0, 0) {
+        count += 1
+    }
+
+    if count != 0 {
+        println("  ✗ FAILED: range(0, 0) iterated", count, "times, expected 0")
+        return
+    }
+
+    // range(5, 5) should not iterate at all
+    count = 0
+    for i in range(5, 5) {
+        count += 1
+    }
+
+    if count != 0 {
+        println("  ✗ FAILED: range(5, 5) iterated", count, "times, expected 0")
+        return
+    }
+
+    // range(0, 1) should iterate exactly once
+    count = 0
+    for i in range(0, 1) {
+        count += 1
+    }
+
+    if count != 1 {
+        println("  ✗ FAILED: range(0, 1) iterated", count, "times, expected 1")
+        return
+    }
+
+    println("  ✓ Edge cases handled correctly")
+}
+
+// Test that iteration counts match the mathematical difference
+do test_iteration_counts() {
+    using std
+    println("→ Testing iteration count formulas...")
+
+    // For range(start, end), iteration count should be: end - start
+
+    // range(0, 10): 10 - 0 = 10 iterations
+    temp count int = 0
+    for i in range(0, 10) {
+        count += 1
+    }
+    if count != 10 {
+        println("  ✗ FAILED: range(0, 10) count =", count, ", expected 10")
+        return
+    }
+
+    // range(5, 15): 15 - 5 = 10 iterations
+    count = 0
+    for i in range(5, 15) {
+        count += 1
+    }
+    if count != 10 {
+        println("  ✗ FAILED: range(5, 15) count =", count, ", expected 10")
+        return
+    }
+
+    // range(100, 200): 200 - 100 = 100 iterations
+    count = 0
+    for i in range(100, 200) {
+        count += 1
+    }
+    if count != 100 {
+        println("  ✗ FAILED: range(100, 200) count =", count, ", expected 100")
+        return
+    }
+
+    println("  ✓ Iteration count formulas correct")
+}


### PR DESCRIPTION
Changed range() to use exclusive end value instead of inclusive. This aligns with Python, Go, JavaScript and makes array iteration natural.

- Modified evaluator.go line 634: changed <= to <
- Added comprehensive test suite for range() exclusive behavior
- Verified all existing tests still pass

Fixes #112