### PR TITLE
Fix: Validate enum type attributes to only allow primitives (issue #119)

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2127,6 +2127,12 @@ func (p *Parser) parseEnumAttributes(attrs []*Attribute) *EnumAttributes {
 			// First arg is the type
 			enumAttrs.TypeName = attr.Args[0]
 
+			// Validate that type is a primitive (int, float, or string)
+			if enumAttrs.TypeName != "int" && enumAttrs.TypeName != "float" && enumAttrs.TypeName != "string" {
+				msg := fmt.Sprintf("enum type attributes must be primitive types (int, float, or string), got '%s'", enumAttrs.TypeName)
+				p.addEZError(errors.E2006, msg, attr.Token)
+			}
+
 			// Check for "skip" keyword
 			for i, arg := range attr.Args {
 				if arg == "skip" {

--- a/test/enum_invalid_type_bool.ez
+++ b/test/enum_invalid_type_bool.ez
@@ -1,0 +1,17 @@
+import @std
+
+/*
+ * This file should FAIL to parse with an error message:
+ * "enum type attributes must be primitive types (int, float, or string), got 'bool'"
+ */
+
+// This should be REJECTED - bool is not allowed as enum type attribute
+@(bool)
+const INVALID enum {
+    VALUE
+}
+
+do main() {
+    using std
+    println("This should never execute")
+}

--- a/test/enum_invalid_type_struct.ez
+++ b/test/enum_invalid_type_struct.ez
@@ -1,0 +1,25 @@
+import @std
+
+/*
+ * EZ Language - Invalid Enum Type Attribute Test (Struct)
+ *
+ * This file should FAIL to parse with an error message:
+ * "enum type attributes must be primitive types (int, float, or string), got 'Person'"
+ *
+ * This test validates that non-primitive types are properly rejected.
+ */
+
+const Person struct {
+    name string
+}
+
+// This should be REJECTED - Person is a struct, not a primitive type
+@(Person)
+const SOMETHING enum {
+    SOMETHING_VALUE
+}
+
+do main() {
+    using std
+    println("This should never execute - parser should reject this file")
+}

--- a/test/enum_type_attribute_validation_test.ez
+++ b/test/enum_type_attribute_validation_test.ez
@@ -1,0 +1,80 @@
+import @std
+
+/*
+ * EZ Language - Enum Type Attribute Validation Test
+ *
+ * This test file verifies that enum type attributes (@()) only accept
+ * primitive types: int, float, string.
+ *
+ * Non-primitive types (like structs, arrays, etc.) should be rejected
+ * with a clear error message during parsing.
+ */
+
+// Valid primitive types for enum attributes
+
+@(int)
+const IntEnum enum {
+    FIRST
+    SECOND
+    THIRD
+}
+
+@(float)
+const FloatEnum enum {
+    PI = 3.14
+    E = 2.71
+}
+
+@(string)
+const StringEnum enum {
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+}
+
+// Valid with skip and increment
+@(int, skip, 10)
+const SkipEnum enum {
+    START = 0
+    MIDDLE
+    END
+}
+
+do main() {
+    using std
+
+    println("╔════════════════════════════════════════╗")
+    println("║  Enum Type Attribute Validation Test  ║")
+    println("╚════════════════════════════════════════╝")
+    println("")
+
+    test_valid_primitives()
+
+    println("")
+    println("╔════════════════════════════════════════╗")
+    println("║    Valid Enum Types Test Passed ✓     ║")
+    println("╚════════════════════════════════════════╝")
+}
+
+do test_valid_primitives() {
+    using std
+    println("→ Testing valid primitive type attributes...")
+
+    // Test int enum
+    temp intVal int = IntEnum.FIRST
+    println("  IntEnum.FIRST =", intVal)
+
+    // Test float enum
+    temp floatVal float = FloatEnum.PI
+    println("  FloatEnum.PI =", floatVal)
+
+    // Test string enum
+    temp strVal string = StringEnum.RED
+    println("  StringEnum.RED =", strVal)
+
+    // Test skip enum
+    temp skipVal int = SkipEnum.START
+    println("  SkipEnum.START =", skipVal)
+
+    println("  ✓ All valid primitive type attributes work correctly")
+}


### PR DESCRIPTION
Added validation in parser to ensure enum type attributes only accept primitive types: int, float, string. Non-primitive types (structs, bool, arrays, etc.) are now properly rejected with clear error messages.

Changes:
- Added type validation in parseEnumAttributes() (parser.go:2130-2134)
- Uses EZ error code E2006 with formatted error output
- Created comprehensive test suite for valid primitive types
- Created test cases demonstrating rejection of invalid types

Tests:
- enum_type_attribute_validation_test.ez: validates int, float, string work
- enum_invalid_type_struct.ez: verifies struct types are rejected
- enum_invalid_type_bool.ez: verifies bool types are rejected
- All existing interpreter tests pass

Fixes #119