### PR TITLE
Fix: Support underscore syntax in int() and float() conversions (issu…

### DIFF
--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -125,7 +125,9 @@ var builtins = map[string]*Builtin{
 			case *Float:
 				return &Integer{Value: int64(arg.Value)}
 			case *String:
-				val, err := strconv.ParseInt(arg.Value, 10, 64)
+				// Strip underscores to support underscore integer syntax (e.g., "100_000")
+				cleanedValue := strings.ReplaceAll(arg.Value, "_", "")
+				val, err := strconv.ParseInt(cleanedValue, 10, 64)
 				if err != nil {
 					return newError("cannot convert %q to int", arg.Value)
 				}
@@ -149,7 +151,9 @@ var builtins = map[string]*Builtin{
 			case *Integer:
 				return &Float{Value: float64(arg.Value)}
 			case *String:
-				val, err := strconv.ParseFloat(arg.Value, 64)
+				// Strip underscores to support underscore number syntax (e.g., "3.14_159")
+				cleanedValue := strings.ReplaceAll(arg.Value, "_", "")
+				val, err := strconv.ParseFloat(cleanedValue, 64)
 				if err != nil {
 					return newError("cannot convert %q to float", arg.Value)
 				}

--- a/test/underscore_conversion_test.ez
+++ b/test/underscore_conversion_test.ez
@@ -1,0 +1,155 @@
+import @std
+
+/*
+ * EZ Language - Underscore Number Conversion Test
+ *
+ * This test file verifies that int() and float() conversion functions
+ * properly recognize and parse underscore-separated numbers in strings.
+ *
+ * EZ supports underscore integer syntax for numeric literals (e.g., 100_000),
+ * so the conversion functions should also support this format.
+ *
+ * Test Coverage:
+ * - int() conversion with underscores
+ * - float() conversion with underscores
+ * - Edge cases (multiple underscores, different positions)
+ * - Negative numbers with underscores
+ */
+
+do main() {
+    using std
+
+    println("╔════════════════════════════════════════╗")
+    println("║  Underscore Number Conversion Test    ║")
+    println("╚════════════════════════════════════════╝")
+    println("")
+
+    test_int_conversion()
+    test_float_conversion()
+    test_edge_cases()
+    test_negative_numbers()
+
+    println("")
+    println("╔════════════════════════════════════════╗")
+    println("║  All Conversion Tests Passed ✓        ║")
+    println("╚════════════════════════════════════════╝")
+}
+
+do test_int_conversion() {
+    using std
+    println("→ Testing int() conversion with underscores...")
+
+    // Basic underscore integer conversion
+    temp x1 int = int("100_000")
+    if x1 != 100000 {
+        println("  ✗ FAILED: int(\"100_000\") =", x1, ", expected 100000")
+        return
+    }
+
+    // Multiple underscores
+    temp x2 int = int("1_000_000")
+    if x2 != 1000000 {
+        println("  ✗ FAILED: int(\"1_000_000\") =", x2, ", expected 1000000")
+        return
+    }
+
+    // Different positions
+    temp x3 int = int("1234_5678")
+    if x3 != 12345678 {
+        println("  ✗ FAILED: int(\"1234_5678\") =", x3, ", expected 12345678")
+        return
+    }
+
+    // Single digit groups
+    temp x4 int = int("1_2_3_4")
+    if x4 != 1234 {
+        println("  ✗ FAILED: int(\"1_2_3_4\") =", x4, ", expected 1234")
+        return
+    }
+
+    // Large number
+    temp x5 int = int("999_999_999")
+    if x5 != 999999999 {
+        println("  ✗ FAILED: int(\"999_999_999\") =", x5, ", expected 999999999")
+        return
+    }
+
+    println("  ✓ int() conversion with underscores works correctly")
+}
+
+do test_float_conversion() {
+    using std
+    println("→ Testing float() conversion with underscores...")
+
+    // Float with underscores in integer part
+    temp f1 float = float("100_000.5")
+    if f1 != 100000.5 {
+        println("  ✗ FAILED: float(\"100_000.5\") =", f1, ", expected 100000.5")
+        return
+    }
+
+    // Float with underscores in decimal part
+    temp f2 float = float("3.14_159")
+    if f2 != 3.14159 {
+        println("  ✗ FAILED: float(\"3.14_159\") =", f2, ", expected 3.14159")
+        return
+    }
+
+    // Float with underscores in both parts
+    temp f3 float = float("1_234.567_89")
+    if f3 != 1234.56789 {
+        println("  ✗ FAILED: float(\"1_234.567_89\") =", f3, ", expected 1234.56789")
+        return
+    }
+
+    println("  ✓ float() conversion with underscores works correctly")
+}
+
+do test_edge_cases() {
+    using std
+    println("→ Testing edge cases...")
+
+    // No underscores (should still work)
+    temp x1 int = int("12345")
+    if x1 != 12345 {
+        println("  ✗ FAILED: int(\"12345\") =", x1, ", expected 12345")
+        return
+    }
+
+    // Zero with underscores
+    temp x2 int = int("0_0_0")
+    if x2 != 0 {
+        println("  ✗ FAILED: int(\"0_0_0\") =", x2, ", expected 0")
+        return
+    }
+
+    // Small number with underscore
+    temp x3 int = int("1_0")
+    if x3 != 10 {
+        println("  ✗ FAILED: int(\"1_0\") =", x3, ", expected 10")
+        return
+    }
+
+    println("  ✓ Edge cases handled correctly")
+}
+
+do test_negative_numbers() {
+    using std
+    println("→ Testing negative numbers with underscores...")
+
+    // Negative integer with underscores
+    temp x1 int = int("-100_000")
+    if x1 != -100000 {
+        println("  ✗ FAILED: int(\"-100_000\") =", x1, ", expected -100000")
+        return
+    }
+
+    // Negative float with underscores
+    temp f1 float = float("-3.14_159")
+    if f1 != -3.14159 {
+        println("  ✗ FAILED: float(\"-3.14_159\") =", f1, ", expected -3.14159")
+        return
+    }
+
+    println("  ✓ Negative numbers with underscores work correctly")
+}


### PR DESCRIPTION
…e #103)

Added underscore stripping in string-to-number conversion functions to support underscore number syntax (e.g., "100_000", "3.14_159").

This maintains consistency with EZ's support for underscore numeric literals. The conversion functions now strip all underscores before parsing, allowing users to convert underscore-formatted strings.

Changes:
- Modified int() builtin to strip underscores before ParseInt (builtins.go:128-129)
- Modified float() builtin to strip underscores before ParseFloat (builtins.go:154-155)
- Uses strings.ReplaceAll to remove all underscore characters

Tests:
- Created comprehensive test suite (underscore_conversion_test.ez)
- Tests int() with various underscore patterns
- Tests float() with underscores in integer and decimal parts
- Tests edge cases (no underscores, zeros, small numbers)
- Tests negative numbers with underscores
- All existing interpreter tests pass

Examples now supported:
- int("100_000") → 100000
- int("1_000_000") → 1000000
- float("3.14_159") → 3.14159
- float("-100_000.5") → -100000.5

Fixes #103