### PR TITLE
Require fixed size for const arrays

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -67,6 +67,7 @@ var (
 	E2029 = ErrorCode{"E2029", "expected-identifier", "expected identifier"}
 	E2030 = ErrorCode{"E2030", "expected-block", "expected block statement"}
 	E2031 = ErrorCode{"E2031", "string-enum-requires-values", "string enum needs explicit values"}
+	E2032 = ErrorCode{"E2032", "const-array-requires-size", "const array must have fixed size"}
 )
 
 // =============================================================================

--- a/test/test_const_array_requires_size.ez
+++ b/test/test_const_array_requires_size.ez
@@ -1,0 +1,12 @@
+/*
+ * TEST: const array with dynamic size should ERROR
+ * Expected: E2032 - const array must have fixed size
+ */
+
+import @std
+
+do main() {
+    // This should produce error E2032
+    const arr [string] = {"Hello"}
+    std.println(arr)
+}


### PR DESCRIPTION
- Add validation in evalVariableDeclaration to ensure const arrays specify a fixed size (e.g., [int, 3] instead of [int])
- Dynamic arrays [type] without size can only be used with temp
- Add error code E2032 (const-array-requires-size)
- Error message includes helpful example with correct syntax