### PR TITLE
Implement build-time type checking

### DIFF
--- a/test/array_type_validation_test.ez
+++ b/test/array_type_validation_test.ez
@@ -39,11 +39,11 @@ do test_valid_array_declarations() {
 
     // Integer arrays
     temp int_arr [int] = {1, 2, 3, 4, 5}
-    const const_int_arr [int] = {10, 20, 30}
+    const const_int_arr [int, 3] = {10, 20, 30}
 
     // String arrays
     temp str_arr [string] = {"hello", "world"}
-    const const_str_arr [string] = {"a", "b", "c"}
+    const const_str_arr [string, 3] = {"a", "b", "c"}
 
     // Boolean arrays
     temp bool_arr [bool] = {true, false, true}

--- a/test/buildtime_type_checking_test.ez
+++ b/test/buildtime_type_checking_test.ez
@@ -1,0 +1,243 @@
+/*
+ * EZ Language - Build-time Type Checking Tests
+ *
+ * This file tests that type checking happens at build-time (before execution).
+ * These tests verify that:
+ * - Variable declarations check types
+ * - Return statements check types
+ * - Function arguments check types
+ * - Operators check types
+ * - Loop conditions check types
+ */
+
+import @std
+import @arrays
+
+do main() {
+    using std
+
+    println("========================================")
+    println("  Build-time Type Checking Tests       ")
+    println("========================================")
+    println("")
+
+    test_valid_assignments()
+    test_valid_returns()
+    test_valid_function_calls()
+    test_valid_operators()
+    test_valid_control_flow()
+    test_scoping()
+
+    println("")
+    println("========================================")
+    println("  All Type Checking Tests Passed!      ")
+    println("========================================")
+}
+
+// ============================================================================
+// TEST: Valid Assignments
+// ============================================================================
+
+do test_valid_assignments() {
+    using std
+    println("-> Testing valid assignments...")
+
+    // Primitive type assignments
+    temp x int = 42
+    temp y float = 3.14
+    temp z string = "hello"
+    temp w bool = true
+    temp c char = 'a'
+
+    // Array assignments
+    temp arr [int] = {1, 2, 3}
+    temp empty_arr [string] = {}
+
+    // Nil assignment
+    temp maybe_nil int = nil
+
+    // Same-family integer assignments
+    temp a i32 = 100
+    temp b i64 = a // i32 -> i64 is fine
+
+    temp c2 u16 = 500
+    temp d u32 = c2 // u16 -> u32 is fine
+
+    // Unsigned to signed (safe direction)
+    temp u u32 = 1000
+    temp s i64 = u // u32 -> i64 is safe
+
+    println("  [OK] Valid assignments work")
+}
+
+// ============================================================================
+// TEST: Valid Returns
+// ============================================================================
+
+do test_valid_returns() {
+    using std
+    println("-> Testing valid returns...")
+
+    temp a int = get_int()
+    temp b string = get_string()
+    temp d i64 = get_from_unsigned()
+
+    println("  int return: ${a}")
+    println("  string return: ${b}")
+    println("  unsigned to signed: ${d}")
+
+    println("  [OK] Valid returns work")
+}
+
+do get_int() -> int {
+    return 42
+}
+
+do get_string() -> string {
+    return "hello"
+}
+
+do get_from_unsigned() -> i64 {
+    temp x u32 = 5000
+    return x // u32 -> i64 is safe
+}
+
+// ============================================================================
+// TEST: Valid Function Calls
+// ============================================================================
+
+do test_valid_function_calls() {
+    using std
+    println("-> Testing valid function calls...")
+
+    temp result int = add(10, 20)
+    println("  add(10, 20) = ${result}")
+
+    greet("World")
+
+    process_array({1, 2, 3})
+
+    println("  [OK] Valid function calls work")
+}
+
+do add(a, b int) -> int {
+    return a + b
+}
+
+do greet(name string) {
+    std.println("  Hello, ${name}!")
+}
+
+do process_array(arr [int]) {
+    std.println("  Array has ${len(arr)} elements")
+}
+
+// ============================================================================
+// TEST: Valid Operators
+// ============================================================================
+
+do test_valid_operators() {
+    using std
+    println("-> Testing valid operators...")
+
+    // Arithmetic
+    temp a int = 10 + 5
+    temp b float = 3.14 * 2.0
+    temp c int = 20 - 8
+    temp d float = 10.0 / 4.0
+
+    // Comparison
+    temp eq bool = (10 == 10)
+    temp lt bool = (5 < 10)
+    temp gt bool = (10 > 5)
+
+    // Logical
+    temp and_result bool = true && false
+    temp or_result bool = true || false
+    temp not_result bool = !false
+
+    // String concatenation
+    temp greeting string = "Hello" + " " + "World"
+
+    println("  Arithmetic: a=${a}, b=${b}, c=${c}")
+    println("  Comparison: eq=${eq}, lt=${lt}")
+    println("  Logical: and=${and_result}, or=${or_result}, not=${not_result}")
+    println("  String concat: ${greeting}")
+
+    println("  [OK] Valid operators work")
+}
+
+// ============================================================================
+// TEST: Valid Control Flow
+// ============================================================================
+
+do test_valid_control_flow() {
+    using std
+    println("-> Testing valid control flow...")
+
+    // If with boolean condition
+    if true {
+        println("  if statement works")
+    }
+
+    // If with comparison
+    if 10 > 5 {
+        println("  comparison in if works")
+    }
+
+    // While with boolean
+    temp counter int = 0
+    as_long_as counter < 3 {
+        counter++
+    }
+    println("  while loop works: counter=${counter}")
+
+    // For loop
+    temp sum int = 0
+    for i in range(0, 3) {
+        sum = sum + i
+    }
+    println("  for loop works: sum=${sum}")
+
+    // For each
+    temp arr [int] = {10, 20, 30}
+    temp total int = 0
+    for_each item in arr {
+        total = total + item
+    }
+    println("  for_each works: total=${total}")
+
+    println("  [OK] Valid control flow works")
+}
+
+// ============================================================================
+// TEST: Scoping
+// ============================================================================
+
+do test_scoping() {
+    using std
+    println("-> Testing scoping...")
+
+    temp outer int = 10
+
+    if true {
+        temp inner int = 20
+        // Both outer and inner are accessible here
+        temp sum int = outer + inner
+        println("  inner scope: outer=${outer}, inner=${inner}, sum=${sum}")
+    }
+
+    // Only outer is accessible here
+    println("  outer scope: outer=${outer}")
+
+    // Parameters are in scope
+    test_param_scope(42)
+
+    println("  [OK] Scoping works")
+}
+
+do test_param_scope(x int) {
+    // x should be accessible and have type int
+    temp doubled int = x * 2
+    std.println("  param scope: x=${x}, doubled=${doubled}")
+}

--- a/test/test_argument_type_mismatch.ez
+++ b/test/test_argument_type_mismatch.ez
@@ -1,0 +1,15 @@
+/*
+ * TEST: Argument type mismatch should ERROR at build-time
+ * Expected: E3001 - type mismatch (argument type)
+ */
+
+import @std
+
+do add(x, y int) -> int {
+    return x + y
+}
+
+do main() {
+    // This should produce error E3001 for both arguments
+    add("a", "b")
+}

--- a/test/test_invalid_index_type.ez
+++ b/test/test_invalid_index_type.ez
@@ -1,0 +1,13 @@
+/*
+ * TEST: Non-integer array index should ERROR at build-time
+ * Expected: E3003 - index must be integer
+ */
+
+import @std
+
+do main() {
+    temp arr [int] = {1, 2, 3}
+    // This should produce error E3003
+    temp x int = arr["key"]
+    std.println(x)
+}

--- a/test/test_invalid_operator.ez
+++ b/test/test_invalid_operator.ez
@@ -1,0 +1,12 @@
+/*
+ * TEST: Invalid operator usage should ERROR at build-time
+ * Expected: E3002 - operator not valid for type
+ */
+
+import @std
+
+do main() {
+    // This should produce error E3002
+    temp x string = "hello" - "world"
+    std.println(x)
+}

--- a/test/test_return_type_mismatch.ez
+++ b/test/test_return_type_mismatch.ez
@@ -1,0 +1,15 @@
+/*
+ * TEST: Return type mismatch should ERROR at build-time
+ * Expected: E3012 - return type mismatch
+ */
+
+import @std
+
+do get_number() -> int {
+    // This should produce error E3012
+    return "not a number"
+}
+
+do main() {
+    std.println(get_number())
+}

--- a/test/test_string_to_number_conversion.ez
+++ b/test/test_string_to_number_conversion.ez
@@ -1,0 +1,18 @@
+/*
+ * TEST: String variable to int/float conversion should ERROR at build-time
+ * Expected: E3005 (int) or E3006 (float) - cannot convert string at build-time
+ *
+ * Reason: We can't guarantee a string variable contains a valid number,
+ * so int(string_var) and float(string_var) are rejected at build-time.
+ *
+ * Valid: int("123"), float("3.14") - numeric string literals are OK
+ */
+
+import @std
+
+do main() {
+    temp name string = "Hello"
+    // This should produce error E3005
+    temp x int = int(name)
+    std.println(x)
+}

--- a/test/test_struct_field_mismatch.ez
+++ b/test/test_struct_field_mismatch.ez
@@ -1,0 +1,18 @@
+/*
+ * TEST: Struct field type mismatch should ERROR at build-time
+ * Expected: E3001 - type mismatch on field assignment
+ */
+
+import @std
+
+const Person struct {
+    name string
+    age int
+}
+
+do main() {
+    temp p Person = Person{name: "Bob", age: 25}
+    // This should produce error E3001
+    p.age = "old"
+    std.println(p.age)
+}

--- a/test/test_type_mismatch_variable.ez
+++ b/test/test_type_mismatch_variable.ez
@@ -1,0 +1,12 @@
+/*
+ * TEST: Variable type mismatch should ERROR at build-time
+ * Expected: E3001 - type mismatch
+ */
+
+import @std
+
+do main() {
+    // This should produce error E3001
+    temp x int = "hello"
+    std.println(x)
+}


### PR DESCRIPTION
This major feature moves type checking from runtime to build-time:

- Add expression type inference for all expression types (literals, variables, operators, function calls, etc.)
- Add local scope tracking with nested scopes for blocks
- Add type validation for variable declarations
- Add type validation for return statements
- Add type validation for function call arguments
- Add helper functions for type compatibility checking

Type errors are now caught BEFORE the program runs:
- temp x int = "hello"  -> E3001: type mismatch
- return "foo" in -> int function  -> E3012: return type mismatch
- add("a", "b") for add(x, y int)  -> E3001: argument type mismatch

- fixes #131 
Includes comprehensive tests for valid type usage and error cases.