### PR TITLE
Complete `@maps` stdlib with remaining functions

### DIFF
--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -4,6 +4,8 @@ package stdlib
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
+	"fmt"
+
 	"github.com/marshallburns/ez/pkg/object"
 )
 
@@ -213,10 +215,154 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if len(args) < 2 {
 				return newError("maps.merge() takes at least 2 arguments")
 			}
-			// First argument is the target map
+			// Create a new map with all entries from all input maps (non-destructive)
+			result := object.NewMap()
+			for _, arg := range args {
+				m, ok := arg.(*object.Map)
+				if !ok {
+					return &object.Error{Code: "E9025", Message: "maps.merge() requires maps as arguments"}
+				}
+				for _, pair := range m.Pairs {
+					result.Set(pair.Key, pair.Value)
+				}
+			}
+			return result
+		},
+	},
+
+	// has_key is an alias for has
+	"maps.has_key": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return newError("maps.has_key() takes exactly 2 arguments (map, key)")
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.has_key() requires a map as first argument"}
+			}
+			key := args[1]
+			if _, hashOk := object.HashKey(key); !hashOk {
+				return &object.Error{Code: "E9020", Message: "maps.has_key() key must be a hashable type (string, int, bool, char)"}
+			}
+			_, exists := m.Get(key)
+			if exists {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	"maps.has_value": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return newError("maps.has_value() takes exactly 2 arguments (map, value)")
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.has_value() requires a map as first argument"}
+			}
+			searchValue := args[1]
+			for _, pair := range m.Pairs {
+				if objectsEqual(pair.Value, searchValue) {
+					return object.TRUE
+				}
+			}
+			return object.FALSE
+		},
+	},
+
+	"maps.equals": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return newError("maps.equals() takes exactly 2 arguments")
+			}
+			m1, ok1 := args[0].(*object.Map)
+			m2, ok2 := args[1].(*object.Map)
+			if !ok1 || !ok2 {
+				return &object.Error{Code: "E9025", Message: "maps.equals() requires two maps"}
+			}
+			// Check same length
+			if len(m1.Pairs) != len(m2.Pairs) {
+				return object.FALSE
+			}
+			// Check all key-value pairs match
+			for _, pair := range m1.Pairs {
+				val2, exists := m2.Get(pair.Key)
+				if !exists || !objectsEqual(pair.Value, val2) {
+					return object.FALSE
+				}
+			}
+			return object.TRUE
+		},
+	},
+
+	"maps.get_or_set": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return newError("maps.get_or_set() takes exactly 3 arguments (map, key, default)")
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.get_or_set() requires a map as first argument"}
+			}
+			key := args[1]
+			if _, hashOk := object.HashKey(key); !hashOk {
+				return &object.Error{Code: "E9020", Message: "maps.get_or_set() key must be a hashable type (string, int, bool, char)"}
+			}
+			// If key exists, return the value
+			value, exists := m.Get(key)
+			if exists {
+				return value
+			}
+			// Key doesn't exist - set the default and return it
+			if !m.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable map (declared as const)",
+					Code:    "E4005",
+				}
+			}
+			m.Set(key, args[2])
+			return args[2]
+		},
+	},
+
+	// remove is an alias for delete
+	"maps.remove": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return newError("maps.remove() takes exactly 2 arguments (map, key)")
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.remove() requires a map as first argument"}
+			}
+			if !m.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable map (declared as const)",
+					Code:    "E4005",
+				}
+			}
+			key := args[1]
+			if _, hashOk := object.HashKey(key); !hashOk {
+				return &object.Error{Code: "E9020", Message: "maps.remove() key must be a hashable type (string, int, bool, char)"}
+			}
+			deleted := m.Delete(key)
+			if deleted {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	"maps.update": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) < 2 {
+				return newError("maps.update() takes at least 2 arguments")
+			}
+			// First argument is the target map (destructive update)
 			target, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.merge() requires maps as arguments"}
+				return &object.Error{Code: "E9025", Message: "maps.update() requires maps as arguments"}
 			}
 			if !target.Mutable {
 				return &object.Error{
@@ -228,13 +374,91 @@ var MapsBuiltins = map[string]*object.Builtin{
 			for i := 1; i < len(args); i++ {
 				source, ok := args[i].(*object.Map)
 				if !ok {
-					return &object.Error{Code: "E9025", Message: "maps.merge() requires maps as arguments"}
+					return &object.Error{Code: "E9025", Message: "maps.update() requires maps as arguments"}
 				}
 				for _, pair := range source.Pairs {
 					target.Set(pair.Key, pair.Value)
 				}
 			}
 			return object.NIL
+		},
+	},
+
+	"maps.to_array": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("maps.to_array() takes exactly 1 argument")
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.to_array() requires a map"}
+			}
+			// Create array of [key, value] pairs
+			pairs := make([]object.Object, len(m.Pairs))
+			for i, pair := range m.Pairs {
+				pairs[i] = &object.Array{
+					Elements: []object.Object{pair.Key, pair.Value},
+					Mutable:  true,
+				}
+			}
+			return &object.Array{Elements: pairs, Mutable: true}
+		},
+	},
+
+	"maps.from_array": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("maps.from_array() takes exactly 1 argument")
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.from_array() requires an array"}
+			}
+			// Each element should be an array of [key, value]
+			result := object.NewMap()
+			for i, elem := range arr.Elements {
+				pair, ok := elem.(*object.Array)
+				if !ok || len(pair.Elements) != 2 {
+					return &object.Error{
+						Code:    "E9025",
+						Message: fmt.Sprintf("maps.from_array() element %d must be a [key, value] pair", i),
+					}
+				}
+				key := pair.Elements[0]
+				if _, hashOk := object.HashKey(key); !hashOk {
+					return &object.Error{
+						Code:    "E9020",
+						Message: fmt.Sprintf("maps.from_array() key at index %d must be a hashable type (string, int, bool, char)", i),
+					}
+				}
+				result.Set(key, pair.Elements[1])
+			}
+			return result
+		},
+	},
+
+	"maps.invert": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("maps.invert() takes exactly 1 argument")
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E9025", Message: "maps.invert() requires a map"}
+			}
+			// Create new map with values as keys and keys as values
+			result := object.NewMap()
+			for _, pair := range m.Pairs {
+				// Value must be hashable to become a key
+				if _, hashOk := object.HashKey(pair.Value); !hashOk {
+					return &object.Error{
+						Code:    "E9020",
+						Message: fmt.Sprintf("maps.invert() value %s is not hashable and cannot become a key", pair.Value.Inspect()),
+					}
+				}
+				result.Set(pair.Value, pair.Key)
+			}
+			return result
 		},
 	},
 }

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2342,19 +2342,34 @@ func (tc *TypeChecker) checkMapsModuleCall(funcName string, call *ast.CallExpres
 		"values":   {1, 1, []string{"map"}, "array"},
 		"clear":    {1, 1, []string{"map"}, "void"},
 		"copy":     {1, 1, []string{"map"}, "map"},
+		"to_array": {1, 1, []string{"map"}, "array"},
+		"invert":   {1, 1, []string{"map"}, "map"},
 
 		// Map + key
-		"has":    {2, 2, []string{"map", "any"}, "bool"},
-		"delete": {2, 2, []string{"map", "any"}, "bool"},
+		"has":     {2, 2, []string{"map", "any"}, "bool"},
+		"has_key": {2, 2, []string{"map", "any"}, "bool"},
+		"delete":  {2, 2, []string{"map", "any"}, "bool"},
+		"remove":  {2, 2, []string{"map", "any"}, "bool"},
+
+		// Map + value
+		"has_value": {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + key + optional default
 		"get": {2, 3, []string{"map", "any", "any"}, "any"},
 
 		// Map + key + value
-		"set": {3, 3, []string{"map", "any", "any"}, "void"},
+		"set":        {3, 3, []string{"map", "any", "any"}, "void"},
+		"get_or_set": {3, 3, []string{"map", "any", "any"}, "any"},
 
-		// Variadic map merge (map, map, ...)
-		"merge": {2, -1, []string{"map"}, "void"},
+		// Two maps
+		"equals": {2, 2, []string{"map", "map"}, "bool"},
+
+		// Variadic map operations (map, map, ...)
+		"merge":  {2, -1, []string{"map"}, "map"},
+		"update": {2, -1, []string{"map"}, "void"},
+
+		// Array to map
+		"from_array": {1, 1, []string{"array"}, "map"},
 	}
 
 	sig, exists := signatures[funcName]

--- a/test/maps_stdlib_test.ez
+++ b/test/maps_stdlib_test.ez
@@ -1,0 +1,89 @@
+import @std
+import @maps
+using std
+
+do main() {
+    println("=== Maps Stdlib Tests ===")
+    println("")
+
+    // Setup test maps
+    temp users map[string:int] = {"alice": 25, "bob": 30, "charlie": 35}
+    temp scores map[int:string] = {1: "first", 2: "second", 3: "third"}
+
+    // Test has_key (alias for has)
+    println("Test: maps.has_key()")
+    temp hasAlice bool = maps.has_key(users, "alice")
+    temp hasUnknown bool = maps.has_key(users, "unknown")
+    println("  has_key 'alice':", hasAlice)
+    println("  has_key 'unknown':", hasUnknown)
+
+    // Test has_value
+    println("Test: maps.has_value()")
+    temp hasAge25 bool = maps.has_value(users, 25)
+    temp hasAge100 bool = maps.has_value(users, 100)
+    println("  has_value 25:", hasAge25)
+    println("  has_value 100:", hasAge100)
+
+    // Test equals
+    println("Test: maps.equals()")
+    temp copy1 = maps.copy(users)
+    temp copy2 = maps.copy(users)
+    temp different map[string:int] = {"alice": 25}
+    temp areEqual bool = maps.equals(copy1, copy2)
+    temp areDiff bool = maps.equals(copy1, different)
+    println("  equals (same):", areEqual)
+    println("  equals (different):", areDiff)
+
+    // Test get_or_set
+    println("Test: maps.get_or_set()")
+    temp testMap map[string:int] = {"a": 1}
+    temp existingVal int = maps.get_or_set(testMap, "a", 999)
+    temp newVal int = maps.get_or_set(testMap, "b", 2)
+    println("  get_or_set existing key:", existingVal)
+    println("  get_or_set new key:", newVal)
+    println("  map after get_or_set:", testMap)
+
+    // Test remove (alias for delete)
+    println("Test: maps.remove()")
+    temp removeMap map[string:int] = {"x": 1, "y": 2}
+    temp removed bool = maps.remove(removeMap, "x")
+    println("  removed 'x':", removed)
+    println("  map after remove:", removeMap)
+
+    // Test update (destructive merge)
+    println("Test: maps.update()")
+    temp base map[string:int] = {"a": 1, "b": 2}
+    temp extra map[string:int] = {"b": 20, "c": 3}
+    maps.update(base, extra)
+    println("  after update:", base)
+
+    // Test merge (non-destructive)
+    println("Test: maps.merge()")
+    temp m1 map[string:int] = {"a": 1}
+    temp m2 map[string:int] = {"b": 2}
+    temp m3 map[string:int] = {"c": 3}
+    temp merged = maps.merge(m1, m2, m3)
+    println("  merged result:", merged)
+    println("  original m1 unchanged:", m1)
+
+    // Test to_array
+    println("Test: maps.to_array()")
+    temp small map[string:int] = {"x": 10, "y": 20}
+    temp arr = maps.to_array(small)
+    println("  to_array:", arr)
+
+    // Test from_array - use to_array output as input
+    println("Test: maps.from_array()")
+    temp arrFromMap = maps.to_array(small)
+    temp recreated = maps.from_array(arrFromMap)
+    println("  from_array (roundtrip):", recreated)
+
+    // Test invert
+    println("Test: maps.invert()")
+    temp inverted = maps.invert(scores)
+    println("  original:", scores)
+    println("  inverted:", inverted)
+
+    println("")
+    println("=== All Maps Stdlib Tests Passed! ===")
+}


### PR DESCRIPTION
Added new functions:
- has_key() - alias for has()
- has_value() - check if value exists in map
- equals() - compare two maps for equality
- get_or_set() - get value or set default
- remove() - alias for delete()
- update() - destructive merge into existing map
- to_array() - convert map to array of [key, value] pairs
- from_array() - create map from array of pairs
- invert() - swap keys and values

Also fixed merge() to be non-destructive (returns new map). Updated typechecker and documentation.

Closes #107