### PR TITLE
Support comma-separated struct field declarations

### DIFF
--- a/test/multi_member_struct_test.ez
+++ b/test/multi_member_struct_test.ez
@@ -1,0 +1,48 @@
+import @std
+using std
+
+// Test struct with multi-member declarations
+const User struct {
+    name, email string
+    age int
+    active, verified bool
+}
+
+// Test struct with mixed single and multi-member declarations
+const Point3D struct {
+    x, y, z float
+}
+
+do main() {
+    println("=== Multi-Member Struct Declaration Tests ===")
+    println("")
+
+    // Test User struct
+    println("Test 1: User struct with multi-member string fields")
+    temp user User = User{
+        name: "Alice",
+        email: "alice@example.com",
+        age: 25,
+        active: true,
+        verified: false
+    }
+    println("  name:", user.name)
+    println("  email:", user.email)
+    println("  age:", user.age)
+    println("  active:", user.active)
+    println("  verified:", user.verified)
+
+    // Test Point3D struct
+    println("Test 2: Point3D struct with multi-member float fields")
+    temp point Point3D = Point3D{
+        x: 1.5,
+        y: 2.5,
+        z: 3.5
+    }
+    println("  x:", point.x)
+    println("  y:", point.y)
+    println("  z:", point.z)
+
+    println("")
+    println("=== All Multi-Member Struct Tests Passed! ===")
+}


### PR DESCRIPTION
Enable declaring multiple struct members with the same type on a single line:

```ez
const User struct {
    name, email string  // Both fields are strings
    age int
}
```

Maintains duplicate field detection and works with all types including arrays.

Closes #110