### PR TITLE
Add Map Errors (E12xxx) category for @maps stdlib

### DIFF
--- a/context/EZ Errors.md
+++ b/context/EZ Errors.md
@@ -19,6 +19,7 @@ This document is the **authoritative source** for all error codes, types, and me
 | Array Errors | E9xxx | Array-specific operation errors |
 | String Errors | E10xxx | String-specific operation errors |
 | Time Errors | E11xxx | Time-specific operation errors |
+| Map Errors | E12xxx | Map-specific operation errors |
 | Warnings | W1xxx-W3xxx | Warnings (non-fatal) |
 
 ---
@@ -1277,6 +1278,64 @@ This document is the **authoritative source** for all error codes, types, and me
 
 ---
 
+## Map Errors (E12xxx)
+
+### E12001 - map-requires-map
+**Type:** `map-requires-map`
+**Message:** `function requires a map argument`
+**Used for:** Passing non-map to map function
+**Example:** `"maps.len() requires a map"`
+
+---
+
+### E12002 - map-key-not-hashable
+**Type:** `map-key-not-hashable`
+**Message:** `map key must be a hashable type`
+**Used for:** Using non-hashable type as map key
+**Example:** `"maps.get() key must be a hashable type (string, int, bool, char)"`
+
+---
+
+### E12003 - map-immutable
+**Type:** `map-immutable`
+**Message:** `cannot modify immutable map`
+**Used for:** Attempting to modify a const map
+**Example:** `"cannot modify immutable map (declared as const)"`
+
+---
+
+### E12004 - map-invalid-pair
+**Type:** `map-invalid-pair`
+**Message:** `map element must be a [key, value] pair`
+**Used for:** `maps.from_array()` with invalid element format
+**Example:** `"maps.from_array() element 0 must be a [key, value] pair"`
+
+---
+
+### E12005 - map-value-not-hashable
+**Type:** `map-value-not-hashable`
+**Message:** `map value is not hashable and cannot become a key`
+**Used for:** `maps.invert()` when value cannot be used as key
+**Example:** `"maps.invert() value {1, 2, 3} is not hashable and cannot become a key"`
+
+---
+
+### E12006 - map-key-not-found
+**Type:** `map-key-not-found`
+**Message:** `key not found in map`
+**Used for:** Accessing a key that doesn't exist in a map
+**Example:** `"key \"foo\" not found in map"`
+
+---
+
+### E12007 - map-key-not-found-compound
+**Type:** `map-key-not-found-compound`
+**Message:** `key not found in map for compound assignment`
+**Used for:** Using compound assignment (`+=`, etc.) on non-existent key
+**Example:** `"key not found in map for compound assignment"`
+
+---
+
 ## Warnings (W1xxx - W3xxx)
 
 ### W1001 - unused-variable
@@ -1377,8 +1436,9 @@ This document is the **authoritative source** for all error codes, types, and me
 | Array Errors | 18 | E9001-E9018 |
 | String Errors | 7 | E10001-E10007 |
 | Time Errors | 13 | E11001-E11013 |
+| Map Errors | 7 | E12001-E12007 |
 | Warnings | 12 | W1001-W3002 |
-| **Total** | **166** | |
+| **Total** | **173** | |
 
 ---
 
@@ -1397,3 +1457,4 @@ When implementing these errors in code:
 9. [ ] Update `pkg/interpreter/lib_arrays.go` to use array error codes (E9xxx)
 10. [ ] Update `pkg/interpreter/lib_strings.go` to use string error codes (E10xxx)
 11. [ ] Update `pkg/interpreter/lib_time.go` to use time error codes (E11xxx)
+12. [x] Update `pkg/stdlib/maps.go` to use map error codes (E12xxx)

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -234,6 +234,19 @@ var (
 )
 
 // =============================================================================
+// MAP ERRORS (E12xxx) - Map-specific operation errors
+// =============================================================================
+var (
+	E12001 = ErrorCode{"E12001", "map-requires-map", "function requires a map argument"}
+	E12002 = ErrorCode{"E12002", "map-key-not-hashable", "map key must be a hashable type"}
+	E12003 = ErrorCode{"E12003", "map-immutable", "cannot modify immutable map"}
+	E12004 = ErrorCode{"E12004", "map-invalid-pair", "map element must be a [key, value] pair"}
+	E12005 = ErrorCode{"E12005", "map-value-not-hashable", "map value is not hashable and cannot become a key"}
+	E12006 = ErrorCode{"E12006", "map-key-not-found", "key not found in map"}
+	E12007 = ErrorCode{"E12007", "map-key-not-found-compound", "key not found in map for compound assignment"}
+)
+
+// =============================================================================
 // WARNINGS (W1xxx - W3xxx)
 // =============================================================================
 var (

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -270,7 +270,7 @@ func Eval(node ast.Node, env *Environment) Object {
 				if len(availableKeys) > 0 {
 					keyList = fmt.Sprintf("\n\nAvailable keys: %v", availableKeys)
 				}
-				return newErrorWithLocation("E9021", node.Token.Line, node.Token.Column,
+				return newErrorWithLocation("E12006", node.Token.Line, node.Token.Column,
 					"key %s not found in map%s", index.Inspect(), keyList)
 			}
 			return value
@@ -651,7 +651,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			if node.Operator != "=" {
 				oldVal, exists := obj.Get(idx)
 				if !exists {
-					return newErrorWithLocation("E9022", node.Token.Line, node.Token.Column,
+					return newErrorWithLocation("E12007", node.Token.Line, node.Token.Column,
 						"key not found in map for compound assignment")
 				}
 				val = evalCompoundAssignment(node.Operator, oldVal, val, node.Token.Line, node.Token.Column)

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -18,7 +18,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.len() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.len() requires a map"}
 			}
 			return &object.Integer{Value: int64(len(m.Pairs))}
 		},
@@ -31,7 +31,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.is_empty() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.is_empty() requires a map"}
 			}
 			if len(m.Pairs) == 0 {
 				return object.TRUE
@@ -47,11 +47,11 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.has() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.has() requires a map as first argument"}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.has() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.has() key must be a hashable type (string, int, bool, char)"}
 			}
 			_, exists := m.Get(key)
 			if exists {
@@ -68,11 +68,11 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.get() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.get() requires a map as first argument"}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.get() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.get() key must be a hashable type (string, int, bool, char)"}
 			}
 			value, exists := m.Get(key)
 			if exists {
@@ -93,17 +93,17 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.set() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.set() requires a map as first argument"}
 			}
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E4005",
+					Code:    "E12003",
 				}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.set() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.set() key must be a hashable type (string, int, bool, char)"}
 			}
 			m.Set(key, args[2])
 			return object.NIL
@@ -117,17 +117,17 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.delete() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.delete() requires a map as first argument"}
 			}
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E4005",
+					Code:    "E12003",
 				}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.delete() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.delete() key must be a hashable type (string, int, bool, char)"}
 			}
 			deleted := m.Delete(key)
 			if deleted {
@@ -144,12 +144,12 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.clear() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.clear() requires a map"}
 			}
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E4005",
+					Code:    "E12003",
 				}
 			}
 			m.Pairs = []*object.MapPair{}
@@ -165,7 +165,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.keys() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.keys() requires a map"}
 			}
 			keys := make([]object.Object, len(m.Pairs))
 			for i, pair := range m.Pairs {
@@ -182,7 +182,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.values() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.values() requires a map"}
 			}
 			values := make([]object.Object, len(m.Pairs))
 			for i, pair := range m.Pairs {
@@ -199,7 +199,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.copy() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.copy() requires a map"}
 			}
 			// Create a shallow copy of the map
 			newMap := object.NewMap()
@@ -220,7 +220,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			for _, arg := range args {
 				m, ok := arg.(*object.Map)
 				if !ok {
-					return &object.Error{Code: "E9025", Message: "maps.merge() requires maps as arguments"}
+					return &object.Error{Code: "E12001", Message: "maps.merge() requires maps as arguments"}
 				}
 				for _, pair := range m.Pairs {
 					result.Set(pair.Key, pair.Value)
@@ -238,11 +238,11 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.has_key() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.has_key() requires a map as first argument"}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.has_key() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.has_key() key must be a hashable type (string, int, bool, char)"}
 			}
 			_, exists := m.Get(key)
 			if exists {
@@ -259,7 +259,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.has_value() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.has_value() requires a map as first argument"}
 			}
 			searchValue := args[1]
 			for _, pair := range m.Pairs {
@@ -279,7 +279,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			m1, ok1 := args[0].(*object.Map)
 			m2, ok2 := args[1].(*object.Map)
 			if !ok1 || !ok2 {
-				return &object.Error{Code: "E9025", Message: "maps.equals() requires two maps"}
+				return &object.Error{Code: "E12001", Message: "maps.equals() requires two maps"}
 			}
 			// Check same length
 			if len(m1.Pairs) != len(m2.Pairs) {
@@ -303,11 +303,11 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.get_or_set() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.get_or_set() requires a map as first argument"}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.get_or_set() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.get_or_set() key must be a hashable type (string, int, bool, char)"}
 			}
 			// If key exists, return the value
 			value, exists := m.Get(key)
@@ -318,7 +318,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E4005",
+					Code:    "E12003",
 				}
 			}
 			m.Set(key, args[2])
@@ -334,17 +334,17 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.remove() requires a map as first argument"}
+				return &object.Error{Code: "E12001", Message: "maps.remove() requires a map as first argument"}
 			}
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E4005",
+					Code:    "E12003",
 				}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E9020", Message: "maps.remove() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12002", Message: "maps.remove() key must be a hashable type (string, int, bool, char)"}
 			}
 			deleted := m.Delete(key)
 			if deleted {
@@ -362,19 +362,19 @@ var MapsBuiltins = map[string]*object.Builtin{
 			// First argument is the target map (destructive update)
 			target, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.update() requires maps as arguments"}
+				return &object.Error{Code: "E12001", Message: "maps.update() requires maps as arguments"}
 			}
 			if !target.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E4005",
+					Code:    "E12003",
 				}
 			}
 			// Merge all source maps into target
 			for i := 1; i < len(args); i++ {
 				source, ok := args[i].(*object.Map)
 				if !ok {
-					return &object.Error{Code: "E9025", Message: "maps.update() requires maps as arguments"}
+					return &object.Error{Code: "E12001", Message: "maps.update() requires maps as arguments"}
 				}
 				for _, pair := range source.Pairs {
 					target.Set(pair.Key, pair.Value)
@@ -391,7 +391,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.to_array() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.to_array() requires a map"}
 			}
 			// Create array of [key, value] pairs
 			pairs := make([]object.Object, len(m.Pairs))
@@ -412,7 +412,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			arr, ok := args[0].(*object.Array)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.from_array() requires an array"}
+				return &object.Error{Code: "E12001", Message: "maps.from_array() requires an array"}
 			}
 			// Each element should be an array of [key, value]
 			result := object.NewMap()
@@ -420,14 +420,14 @@ var MapsBuiltins = map[string]*object.Builtin{
 				pair, ok := elem.(*object.Array)
 				if !ok || len(pair.Elements) != 2 {
 					return &object.Error{
-						Code:    "E9025",
+						Code:    "E12004",
 						Message: fmt.Sprintf("maps.from_array() element %d must be a [key, value] pair", i),
 					}
 				}
 				key := pair.Elements[0]
 				if _, hashOk := object.HashKey(key); !hashOk {
 					return &object.Error{
-						Code:    "E9020",
+						Code:    "E12002",
 						Message: fmt.Sprintf("maps.from_array() key at index %d must be a hashable type (string, int, bool, char)", i),
 					}
 				}
@@ -444,7 +444,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E9025", Message: "maps.invert() requires a map"}
+				return &object.Error{Code: "E12001", Message: "maps.invert() requires a map"}
 			}
 			// Create new map with values as keys and keys as values
 			result := object.NewMap()
@@ -452,7 +452,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 				// Value must be hashable to become a key
 				if _, hashOk := object.HashKey(pair.Value); !hashOk {
 					return &object.Error{
-						Code:    "E9020",
+						Code:    "E12005",
 						Message: fmt.Sprintf("maps.invert() value %s is not hashable and cannot become a key", pair.Value.Inspect()),
 					}
 				}


### PR DESCRIPTION
- Add 7 new map-specific error codes (E12001-E12007)
- Update maps.go to use proper E12xxx codes instead of E9xxx
- Update evaluator.go map key errors to use E12006/E12007
- Document all map errors in EZ Errors.md