### PR TITLE
fix: unwrap enum values before comparison operations

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1328,6 +1328,14 @@ func evalInfixExpression(operator string, left, right Object, line, col int) Obj
 		}
 	}
 
+	// Unwrap EnumValue to get the underlying value for comparisons
+	if ev, ok := left.(*EnumValue); ok {
+		left = ev.Value
+	}
+	if ev, ok := right.(*EnumValue); ok {
+		right = ev.Value
+	}
+
 	switch {
 	case left.Type() == INTEGER_OBJ && right.Type() == INTEGER_OBJ:
 		return evalIntegerInfixExpression(operator, left, right, line, col)


### PR DESCRIPTION
## Summary

Unwrap enum values to their underlying primitive value before performing comparison operations.

## Root Cause

When comparing an enum value with another value, the fallback `==` case in `evalInfixExpression` was doing Go pointer comparison (`left == right`) instead of comparing the actual values. Since `*EnumValue` and `*Integer` are different object types, the comparison always returned `false`.

## Fix

Extract `EnumValue.Value` at the start of `evalInfixExpression` so all operators work correctly with enums:

```go
if ev, ok := left.(*EnumValue); ok {
    left = ev.Value
}
if ev, ok := right.(*EnumValue); ok {
    right = ev.Value
}
```

## Test plan

- [x] `Status.ACTIVE == Status.ACTIVE` returns `true`
- [x] `Status.ACTIVE != Status.PENDING` returns `true`
- [x] `intVar == Status.ACTIVE` returns `true` when values match
- [x] `Status.DONE > 0` returns `true`
- [x] `Status.DONE >= Status.ACTIVE` returns `true`
- [x] String enum comparisons work
- [x] All existing tests pass

Fixes #163