### PR TITLE
Fix: Validate unknown attributes and prevent parser hang

### DIFF
--- a/test/attribute_validation_test.ez
+++ b/test/attribute_validation_test.ez
@@ -1,0 +1,60 @@
+// Test file for attribute validation (issue #165)
+// This file tests that the parser properly handles:
+// 1. Valid @suppress(...) attributes
+// 2. Valid @(...) enum configuration attributes
+//
+// Note: Invalid/misspelled attributes like @supress or @foobar should
+// produce a clear error message and NOT cause the program to hang.
+// Those tests must be run separately since they produce parse errors.
+
+import @std
+
+// Test 1: Valid @suppress attribute
+@suppress(W2003)
+do function_without_return() -> string {
+    temp x int = 1
+    // Missing return - would normally warn but suppressed
+}
+
+// Test 2: Valid @(type, skip, value) enum configuration
+@(int, skip, 100)
+const HttpStatus enum {
+    OK          // 0
+    REDIRECT    // 100
+    NOT_FOUND   // 200
+    ERROR       // 300
+}
+
+// Test 3: Valid string enum
+@(string)
+const Color enum {
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+}
+
+do main() {
+    using std
+
+    println("=== Attribute Validation Tests ===")
+    println("")
+
+    // Test @suppress worked (no warnings from function_without_return)
+    println("Test 1: @suppress(W2003) - function defined without error")
+
+    // Test enum with @(int, skip, 100)
+    println("Test 2: @(int, skip, 100) enum:")
+    println("  HttpStatus.OK = ${HttpStatus.OK}")
+    println("  HttpStatus.REDIRECT = ${HttpStatus.REDIRECT}")
+    println("  HttpStatus.NOT_FOUND = ${HttpStatus.NOT_FOUND}")
+    println("  HttpStatus.ERROR = ${HttpStatus.ERROR}")
+
+    // Test string enum with @(string)
+    println("Test 3: @(string) enum:")
+    println("  Color.RED = ${Color.RED}")
+    println("  Color.GREEN = ${Color.GREEN}")
+    println("  Color.BLUE = ${Color.BLUE}")
+
+    println("")
+    println("=== All Attribute Tests Passed! ===")
+}


### PR DESCRIPTION
- Add validation for unknown/misspelled attribute names like @supress
- Emit clear error message: 'unknown attribute @supress, did you mean @suppress?'
- Use Levenshtein distance to suggest closest known attribute
- Properly skip malformed attributes to prevent infinite loop
- Add test file for valid attribute parsing

Fixes #165