### PR TITLE
Fix: Return statements now correctly parse struct/array/map literals

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -861,13 +861,10 @@ func (p *Parser) parseBlockStatementWithSuppress(suppressions []*Attribute) *Blo
 			switch stmt.(type) {
 			case *ReturnStatement, *BreakStatement, *ContinueStatement:
 				unreachable = true
-				// If we're at the closing brace after a terminating statement,
-				// don't advance - let the loop exit naturally
-				if p.currentTokenMatches(RBRACE) {
-					continue // Skip p.nextToken() and re-check loop condition
-				}
 			}
 		}
+		// Always advance to the next token after parsing a statement.
+		// The loop condition will exit when we reach the block's closing brace.
 		p.nextToken()
 	}
 

--- a/test/return_struct_literal_test.ez
+++ b/test/return_struct_literal_test.ez
@@ -1,0 +1,48 @@
+import @std
+
+const Point struct {
+    x int
+    y int
+}
+
+const User struct {
+    id int
+    name string
+    active bool
+}
+
+do createPoint() -> Point {
+    return Point{x: 10, y: 20}
+}
+
+do createUser() -> User {
+    return User{id: 1, name: "Alice", active: true}
+}
+
+do createPointInline() -> Point {
+    return Point{x: 5, y: 15}
+}
+
+do main() {
+    using std
+
+    println("=== Return Struct Literal Tests ===")
+    println("")
+
+    println("Test 1: Return struct literal with named fields")
+    temp p Point = createPoint()
+    println("  Point: (${p.x}, ${p.y})")
+
+    println("Test 2: Return struct with multiple field types")
+    temp u User = createUser()
+    println("  User id: ${u.id}")
+    println("  User name: ${u.name}")
+    println("  User active: ${u.active}")
+
+    println("Test 3: Return struct literal inline")
+    temp p2 Point = createPointInline()
+    println("  Point2: (${p2.x}, ${p2.y})")
+
+    println("")
+    println("=== All Return Struct Literal Tests Passed! ===")
+}


### PR DESCRIPTION
## Summary
- Fixed parser incorrectly handling closing brace after return statements containing literals
- `return User{id: 1}` and `return {1, 2, 3}` now parse correctly
- Removed special case in `parseBlockStatement` that skipped `nextToken()` at RBRACE

## Test plan
- [x] Added `test/return_struct_literal_test.ez` with struct literal return tests
- [x] All existing interpreter tests pass
- [x] Map, struct, and const tests pass

Closes #142