### PR TITLE
Fix: len() builtin now supports maps

### DIFF
--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -132,6 +132,8 @@ var StdBuiltins = map[string]*object.Builtin{
 				return &object.Integer{Value: int64(len(arg.Value))}
 			case *object.Array:
 				return &object.Integer{Value: int64(len(arg.Elements))}
+			case *object.Map:
+				return &object.Integer{Value: int64(len(arg.Pairs))}
 			default:
 				return &object.Error{Code: "E7003", Message: fmt.Sprintf("len() not supported for %s", args[0].Type())}
 			}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1256,10 +1256,10 @@ func (tc *TypeChecker) checkBuiltinTypeConversion(funcName string, call *ast.Cal
 			return true
 		}
 		argType, ok := tc.inferExpressionType(call.Arguments[0])
-		if ok && argType != "string" && !tc.isArrayType(argType) {
+		if ok && argType != "string" && !tc.isArrayType(argType) && !tc.isMapType(argType) {
 			line, column := tc.getExpressionPosition(call.Arguments[0])
 			tc.addError(errors.E3001,
-				fmt.Sprintf("len() argument must be string or array, got %s", argType),
+				fmt.Sprintf("len() argument must be string, array, or map, got %s", argType),
 				line, column)
 		}
 		return true

--- a/test/len_map_test.ez
+++ b/test/len_map_test.ez
@@ -1,0 +1,33 @@
+import @std
+
+do main() {
+    using std
+
+    println("=== len() Map Support Tests ===")
+    println("")
+
+    println("Test 1: len() on string-keyed map")
+    temp users map[string:int] = {"alice": 25, "bob": 30, "charlie": 35}
+    println("  Map: ${users}")
+    println("  len(users): ${len(users)}")
+
+    println("Test 2: len() on int-keyed map")
+    temp scores map[int:string] = {1: "first", 2: "second", 3: "third"}
+    println("  Map: ${scores}")
+    println("  len(scores): ${len(scores)}")
+
+    println("Test 3: len() on single-element map")
+    temp single map[string:bool] = {"active": true}
+    println("  len(single): ${len(single)}")
+
+    println("Test 4: len() still works on arrays")
+    temp arr [int] = {1, 2, 3, 4, 5}
+    println("  len(arr): ${len(arr)}")
+
+    println("Test 5: len() still works on strings")
+    temp s string = "hello"
+    println("  len(s): ${len(s)}")
+
+    println("")
+    println("=== All len() Map Tests Passed! ===")
+}


### PR DESCRIPTION
## Summary
- Added `*object.Map` case to `len()` builtin in `pkg/stdlib/builtins.go`
- Updated typechecker to accept map types as valid arguments to `len()`

## Test plan
- [x] Added `test/len_map_test.ez` with map length tests
- [x] All interpreter tests pass
- [x] All map tests pass

Closes #147