### PR TITLE
Cleanup: Remove redundant maps.len() and arrays.len() from stdlib

### DIFF
--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -13,19 +13,6 @@ import (
 
 // ArraysBuiltins contains the arrays module functions
 var ArraysBuiltins = map[string]*object.Builtin{
-	"arrays.len": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("arrays.len() takes exactly 1 argument")
-			}
-			arr, ok := args[0].(*object.Array)
-			if !ok {
-				return &object.Error{Code: "E9005", Message: "arrays.len() requires an array"}
-			}
-			return &object.Integer{Value: int64(len(arr.Elements))}
-		},
-	},
-
 	"arrays.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -11,19 +11,6 @@ import (
 
 // MapsBuiltins contains the maps module functions
 var MapsBuiltins = map[string]*object.Builtin{
-	"maps.len": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("maps.len() takes exactly 1 argument")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E12001", Message: "maps.len() requires a map"}
-			}
-			return &object.Integer{Value: int64(len(m.Pairs))}
-		},
-	},
-
 	"maps.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/test/map_test.ez
+++ b/test/map_test.ez
@@ -50,9 +50,9 @@ do main() {
     println("  Users map:", users)
     println("  Scores map:", scores)
 
-    // Test 9: maps.len()
-    println("Test 9: maps.len()")
-    temp userCount int = maps.len(users)
+    // Test 9: len() builtin on maps
+    println("Test 9: len() builtin on maps")
+    temp userCount int = len(users)
     println("  User count:", userCount)
 
     // Test 10: maps.has()


### PR DESCRIPTION
## Summary
- Removed `maps.len()` from `@maps` stdlib
- Removed `arrays.len()` from `@arrays` stdlib
- Updated `map_test.ez` to use builtin `len()`

Now that the builtin `len()` supports maps (#147), these module-specific functions are redundant.

## Test plan
- [x] All map tests pass
- [x] All interpreter tests pass

Closes #148