### PR TITLE
Fix: int() builtin now supports enum value conversion

### DIFF
--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -178,6 +178,29 @@ var StdBuiltins = map[string]*object.Builtin{
 				return &object.Integer{Value: val}
 			case *object.Char:
 				return &object.Integer{Value: int64(arg.Value)}
+			case *object.EnumValue:
+				// Extract the underlying value from the enum
+				switch v := arg.Value.(type) {
+				case *object.Integer:
+					return v
+				case *object.Float:
+					return &object.Integer{Value: int64(v.Value)}
+				case *object.String:
+					cleanedValue := strings.ReplaceAll(v.Value, "_", "")
+					val, err := strconv.ParseInt(cleanedValue, 10, 64)
+					if err != nil {
+						return &object.Error{
+							Code:    "E7005",
+							Message: fmt.Sprintf("cannot convert enum value %q to int: underlying value is not numeric", v.Value),
+						}
+					}
+					return &object.Integer{Value: val}
+				default:
+					return &object.Error{
+						Code:    "E7005",
+						Message: fmt.Sprintf("cannot convert enum %s.%s to int: underlying type %s is not convertible", arg.EnumType, arg.Name, arg.Value.Type()),
+					}
+				}
 			default:
 				if args[0].Type() == object.ARRAY_OBJ {
 					return &object.Error{

--- a/test/int_enum_conversion_test.ez
+++ b/test/int_enum_conversion_test.ez
@@ -1,0 +1,41 @@
+import @std
+
+@(int, skip, 10)
+const Priority enum {
+    LOW
+    MEDIUM
+    HIGH
+    CRITICAL
+}
+
+@(int)
+const Status enum {
+    PENDING
+    ACTIVE
+    DONE
+}
+
+do main() {
+    using std
+
+    println("=== int() Enum Conversion Tests ===")
+    println("")
+
+    println("Test 1: int() on @(int, skip, 10) enum")
+    println("  int(Priority.LOW) = ${int(Priority.LOW)}")
+    println("  int(Priority.MEDIUM) = ${int(Priority.MEDIUM)}")
+    println("  int(Priority.HIGH) = ${int(Priority.HIGH)}")
+    println("  int(Priority.CRITICAL) = ${int(Priority.CRITICAL)}")
+
+    println("Test 2: int() on @(int) enum (0-indexed)")
+    println("  int(Status.PENDING) = ${int(Status.PENDING)}")
+    println("  int(Status.ACTIVE) = ${int(Status.ACTIVE)}")
+    println("  int(Status.DONE) = ${int(Status.DONE)}")
+
+    println("Test 3: Using converted enum in arithmetic")
+    temp val int = int(Priority.HIGH) + 5
+    println("  int(Priority.HIGH) + 5 = ${val}")
+
+    println("")
+    println("=== All int() Enum Conversion Tests Passed! ===")
+}


### PR DESCRIPTION
## Summary
- Added `*object.EnumValue` case to `int()` builtin in `pkg/stdlib/builtins.go`
- Extracts underlying value from enums and converts to integer
- Works with `@(int)`, `@(int, skip, N)`, and numeric string enums

## Test plan
- [x] Added `test/int_enum_conversion_test.ez`
- [x] All interpreter tests pass

Closes #154