### PR TITLE
Add W3003 warning for fixed-size array not fully initialized

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -271,6 +271,7 @@ var (
 	// Code Quality Warnings (W3xxx)
 	W3001 = ErrorCode{"W3001", "empty-block", "block statement is empty"}
 	W3002 = ErrorCode{"W3002", "redundant-condition", "condition is always true/false"}
+	W3003 = ErrorCode{"W3003", "array-size-mismatch", "fixed-size array not fully initialized"}
 
 	// Module Warnings (W6xxx)
 	W6001 = ErrorCode{"W6001", "module-name-mismatch", "module name does not match directory name"}

--- a/test/array_size_warning_test.ez
+++ b/test/array_size_warning_test.ez
@@ -1,0 +1,33 @@
+import @std
+
+do main() {
+    using std
+
+    println("=== Array Size Warning Tests ===")
+    println("")
+
+    // Test 1: Fully initialized array (no warning)
+    println("Test 1: Fully initialized array")
+    const full [int, 3] = {1, 2, 3}
+    println("  full array length: ${len(full)}")
+
+    // Test 2: Suppressed warning with code
+    println("Test 2: Suppressed warning with W3003")
+    @suppress(W3003)
+    const partial1 [int, 5] = {1, 2}
+    println("  partial1 length: ${len(partial1)}")
+
+    // Test 3: Suppressed warning with alternate name
+    println("Test 3: Suppressed warning with array_size_mismatch")
+    @suppress(array_size_mismatch)
+    const partial2 [int, 5] = {1, 2, 3}
+    println("  partial2 length: ${len(partial2)}")
+
+    // Test 4: Dynamic array (no warning)
+    println("Test 4: Dynamic array (no size specified)")
+    temp dynamic [int] = {1, 2}
+    println("  dynamic length: ${len(dynamic)}")
+
+    println("")
+    println("=== All Array Size Warning Tests Passed! ===")
+}


### PR DESCRIPTION
## Summary
- Added `W3003` warning code for `array-size-mismatch`
- Added `extractArraySize()` helper in typechecker
- Warning emits when fixed-size array has fewer elements than declared size
- Suppression supported via `@suppress(W3003)` or `@suppress(array_size_mismatch)`

## Example
```ez
const arr [int, 10] = {1, 2, 3}  // Warning: size 10, only 3 elements

@suppress(W3003)
const arr2 [int, 10] = {1, 2, 3}  // No warning
```

## Test plan
- [x] Added `test/array_size_warning_test.ez`
- [x] All interpreter tests pass

Closes #164