### PR TITLE
Fix: range() now supports 1, 2, or 3 arguments

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -241,11 +241,12 @@ type NewExpression struct {
 func (n *NewExpression) expressionNode()      {}
 func (n *NewExpression) TokenLiteral() string { return n.Token.Literal }
 
-// RangeExpression represents range(start, end)
+// RangeExpression represents range(end), range(start, end), or range(start, end, step)
 type RangeExpression struct {
 	Token Token
-	Start Expression
+	Start Expression // nil for range(end) form, defaults to 0
 	End   Expression
+	Step  Expression // nil for default step of 1
 }
 
 func (r *RangeExpression) expressionNode()      {}

--- a/test/range_variants_test.ez
+++ b/test/range_variants_test.ez
@@ -1,0 +1,53 @@
+import @std
+
+do main() {
+    using std
+
+    println("=== Range Variants Tests ===")
+    println("")
+
+    println("Test 1: range(5) - single argument (0 to 4)")
+    print("  ")
+    for i in range(5) {
+        print("${i} ")
+    }
+    println("")
+
+    println("Test 2: range(2, 7) - two arguments (2 to 6)")
+    print("  ")
+    for i in range(2, 7) {
+        print("${i} ")
+    }
+    println("")
+
+    println("Test 3: range(0, 10, 2) - step of 2")
+    print("  ")
+    for i in range(0, 10, 2) {
+        print("${i} ")
+    }
+    println("")
+
+    println("Test 4: range(0, 10, 3) - step of 3")
+    print("  ")
+    for i in range(0, 10, 3) {
+        print("${i} ")
+    }
+    println("")
+
+    println("Test 5: range(10, 0, -2) - negative step (countdown)")
+    print("  ")
+    for i in range(10, 0, -2) {
+        print("${i} ")
+    }
+    println("")
+
+    println("Test 6: range(5, 0, -1) - countdown by 1")
+    print("  ")
+    for i in range(5, 0, -1) {
+        print("${i} ")
+    }
+    println("")
+
+    println("")
+    println("=== All Range Variants Tests Passed! ===")
+}


### PR DESCRIPTION
## Summary
- Added `Step` field to `RangeExpression` AST node
- Updated parser to accept 1, 2, or 3 arguments for `range()`
- Updated interpreter to handle step values and negative steps

## Supported forms
```ez
range(5)           // 0, 1, 2, 3, 4
range(2, 7)        // 2, 3, 4, 5, 6
range(0, 10, 2)    // 0, 2, 4, 6, 8
range(10, 0, -2)   // 10, 8, 6, 4, 2 (countdown)
```

## Test plan
- [x] Added `test/range_variants_test.ez`
- [x] All interpreter tests pass

Closes #143, closes #144