### PR TITLE
Fix: Typed tuple unpacking now parses correctly

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -258,11 +258,13 @@ func (r *RangeExpression) TokenLiteral() string { return r.Token.Literal }
 
 // VariableDeclaration represents temp x int = 5 or const y int = 10
 // Also supports multiple assignment: temp result, err = divide(10, 0)
+// And typed tuple unpacking: temp a int, b string = getValues()
 type VariableDeclaration struct {
 	Token      Token // temp or const
 	Name       *Label
 	Names      []*Label // for multiple assignment (result, err)
 	TypeName   string
+	TypeNames  []string // for typed tuple unpacking (int, string)
 	Value      Expression
 	Mutable    bool
 	Attributes []*Attribute // @suppress(...) attributes

--- a/test/tuple_unpacking_test.ez
+++ b/test/tuple_unpacking_test.ez
@@ -1,0 +1,43 @@
+import @std
+
+do getTwo() -> (int, string) {
+    return 42, "hello"
+}
+
+do getThree() -> (int, string, bool) {
+    return 1, "test", true
+}
+
+do getNumbers() -> (int, int, int) {
+    return 10, 20, 30
+}
+
+do main() {
+    using std
+
+    println("=== Tuple Unpacking Tests ===")
+    println("")
+
+    println("Test 1: Typed tuple unpacking (two values)")
+    temp a int, b string = getTwo()
+    println("  a = ${a}")
+    println("  b = ${b}")
+
+    println("Test 2: Typed tuple unpacking (three values)")
+    temp x int, y string, z bool = getThree()
+    println("  x = ${x}")
+    println("  y = ${y}")
+    println("  z = ${z}")
+
+    println("Test 3: Untyped tuple unpacking (type inference)")
+    temp p, q = getTwo()
+    println("  p = ${p}")
+    println("  q = ${q}")
+
+    println("Test 4: Three integers")
+    temp n1 int, n2 int, n3 int = getNumbers()
+    println("  n1 = ${n1}, n2 = ${n2}, n3 = ${n3}")
+
+    println("")
+    println("=== All Tuple Unpacking Tests Passed! ===")
+}


### PR DESCRIPTION
## Summary
- Added `TypeNames []string` field to `VariableDeclaration` AST node
- Updated parser to handle comma-separated `(name type)` pairs

## Supported syntax
```ez
// Typed tuple unpacking
temp a int, b string = getValues()
temp x int, y string, z bool = getThree()

// Untyped (type inference) still works
temp a, b = getValues()
```

## Test plan
- [x] Added `test/tuple_unpacking_test.ez`
- [x] All interpreter tests pass
- [x] Untyped tuple unpacking still works

Closes #145