### PR TITLE
fix(stdlib): strings.join no longer includes quotes around elements

### DIFF
--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -120,7 +120,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 			}
 			parts := make([]string, len(arr.Elements))
 			for i, el := range arr.Elements {
-				parts[i] = el.Inspect()
+				// Extract raw string value without quotes
+				if str, ok := el.(*object.String); ok {
+					parts[i] = str.Value
+				} else {
+					parts[i] = el.Inspect()
+				}
 			}
 			return &object.String{Value: strings.Join(parts, sep.Value)}
 		},


### PR DESCRIPTION
## Summary
- Fixed `strings.join()` to extract raw string values instead of using `Inspect()` which wraps strings in quotes

## Before
```
strings.join({"apple", "banana", "cherry"}, " | ")
// Output: "apple" | "banana" | "cherry"
```

## After
```
strings.join({"apple", "banana", "cherry"}, " | ")
// Output: apple | banana | cherry
```

## Test plan
- [x] `./ez run examples/using_stdlib.ez` - verified correct output
- [x] `./ez run tests/comprehensive.ez` - all 80 tests pass

Fixes #205