### PR TITLE
fix(interpreter): auto-detect descending range when start > end

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1055,7 +1055,7 @@ func evalForStatement(node *ast.ForStatement, env *Environment) Object {
 	}
 	end := endInt.Value
 
-	// Handle step - defaults to 1 if nil
+	// Handle step - defaults to 1 (or -1 for descending ranges)
 	var step int64 = 1
 	if rangeExpr.Step != nil {
 		stepObj := Eval(rangeExpr.Step, env)
@@ -1070,6 +1070,9 @@ func evalForStatement(node *ast.ForStatement, env *Environment) Object {
 		if step == 0 {
 			return newError("range step cannot be zero")
 		}
+	} else if start > end {
+		// Auto-detect descending range when no step is provided
+		step = -1
 	}
 
 	loopEnv := NewEnclosedEnvironment(env)


### PR DESCRIPTION
## Summary
When `range(5, 0)` is used without an explicit step, the step now automatically defaults to -1 instead of 1, allowing descending iteration to work as expected.

## Before
```ez
for i in range(5, 0) {
    println(i)  // Nothing printed
}
```

## After
```ez
for i in range(5, 0) {
    println(i)  // Prints: 5, 4, 3, 2, 1
}
```

## Test plan
- [x] Descending range works: `range(5, 0)` → 5, 4, 3, 2, 1
- [x] Ascending range still works: `range(0, 5)` → 0, 1, 2, 3, 4
- [x] All 80 comprehensive tests pass

Fixes #197