### PR TITLE
fix(stdlib): add strings.slice() function

### DIFF
--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -228,4 +228,51 @@ var StringsBuiltins = map[string]*object.Builtin{
 			return &object.String{Value: strings.Repeat(str.Value, int(count.Value))}
 		},
 	},
+
+	"strings.slice": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) < 2 || len(args) > 3 {
+				return &object.Error{Code: "E10001", Message: "strings.slice() takes 2 or 3 arguments"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E10003", Message: "strings.slice() requires a string as first argument"}
+			}
+			start, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E10006", Message: "strings.slice() requires integer indices"}
+			}
+			startIdx := int(start.Value)
+			if startIdx < 0 {
+				startIdx = len(str.Value) + startIdx
+			}
+			if startIdx < 0 {
+				startIdx = 0
+			}
+
+			endIdx := len(str.Value)
+			if len(args) == 3 {
+				end, ok := args[2].(*object.Integer)
+				if !ok {
+					return &object.Error{Code: "E10006", Message: "strings.slice() requires integer indices"}
+				}
+				endIdx = int(end.Value)
+				if endIdx < 0 {
+					endIdx = len(str.Value) + endIdx
+				}
+			}
+
+			if startIdx > len(str.Value) {
+				startIdx = len(str.Value)
+			}
+			if endIdx > len(str.Value) {
+				endIdx = len(str.Value)
+			}
+			if startIdx > endIdx {
+				return &object.String{Value: ""}
+			}
+
+			return &object.String{Value: str.Value[startIdx:endIdx]}
+		},
+	},
 }


### PR DESCRIPTION
## Summary
- Add `strings.slice(str, start, end?)` to extract substrings
- Supports negative indices for counting from end of string
- If end is omitted, slices to end of string

## Test plan
- [x] Build passes
- [x] Tested basic slicing: `strings.slice("Hello, World!", 0, 5)` → `"Hello"`
- [x] Tested slice to end: `strings.slice("Hello, World!", 7)` → `"World!"`
- [x] Tested negative indices: `strings.slice("Hello, World!", -6)` → `"World!"`

Closes #201