### PR TITLE
fix(interpreter): add helpful suggestions for common function mistakes

### DIFF
--- a/examples/using_stdlib.ez
+++ b/examples/using_stdlib.ez
@@ -41,7 +41,7 @@ do main() {
     println("strings.trim() = '${strings.trim(text)}'")
     println("strings.upper() = '${strings.upper(text)}'")
     println("strings.lower() = '${strings.lower(text)}'")
-    println("strings.len() = ${strings.len(text)}")
+    println("len(text) = ${len(text)}")
     println("")
 
     temp csv string = "apple,banana,cherry"

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1686,6 +1686,21 @@ func evalMemberCall(member *ast.MemberExpression, args []ast.Expression, env *En
 		return result
 	}
 
+	// Provide helpful suggestions for common function name mistakes
+	suggestions := map[string]string{
+		"arrays.push":       "use arrays.append() instead",
+		"strings.substring": "use strings.slice() instead",
+		"strings.substr":    "use strings.slice() instead",
+		"strings.length":    "use len() instead",
+		"strings.size":      "use len() instead",
+		"arrays.length":     "use len() instead",
+		"arrays.size":       "use len() instead",
+	}
+
+	if suggestion, ok := suggestions[fullName]; ok {
+		return newError("function not found: %s\n  help: %s", fullName, suggestion)
+	}
+
 	return newError("function not found: %s", fullName)
 }
 

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -11,19 +11,6 @@ import (
 
 // StringsBuiltins contains the strings module functions
 var StringsBuiltins = map[string]*object.Builtin{
-	"strings.len": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return &object.Error{Code: "E10001", Message: "strings.len() takes exactly 1 argument"}
-			}
-			str, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Code: "E10003", Message: "strings.len() requires a string argument"}
-			}
-			return &object.Integer{Value: int64(len(str.Value))}
-		},
-	},
-
 	"strings.upper": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -719,7 +719,7 @@ do test_stdlib_strings() -> TestResult {
     println("  strings.trim(s) = '${strings.trim(s)}'")
     println("  strings.upper(s) = '${strings.upper(s)}'")
     println("  strings.lower(s) = '${strings.lower(s)}'")
-    println("  strings.len(s) = ${strings.len(s)}")
+    println("  len(s) = ${len(s)}")
     passed += 1
 
     temp csv string = "apple,banana,cherry"


### PR DESCRIPTION
## Summary
- Add helpful suggestions when users try common but non-existent functions:
  - `arrays.push` → suggests `arrays.append()`
  - `strings.substring`/`strings.substr` → suggests `strings.slice()`
  - `strings.length`/`strings.size` → suggests `len()`
  - `arrays.length`/`arrays.size` → suggests `len()`
- Remove `strings.len()` to keep things uniform (use builtin `len()` for all length operations)
- Update examples and tests to use `len()` instead of `strings.len()`

## Test plan
- [x] Build passes
- [x] `arrays.push()` shows helpful suggestion
- [x] `strings.substring()` shows helpful suggestion
- [x] `using_stdlib.ez` example runs correctly with `len()`
- [x] Comprehensive tests updated and pass

Closes #199