### PR TITLE
fix(loader): properly format parse errors from imported modules

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -112,7 +112,13 @@ func loadUserModule(importPath string, token ast.Node, env *Environment) (*Modul
 	// Load the module (this handles parsing and caching)
 	mod, err := globalEvalContext.Loader.Load(importPath)
 	if err != nil {
-		return nil, newError("E6001: %s", err.Error())
+		// Check if this is a ModuleError with rich parse errors
+		if modErr, ok := err.(*ModuleError); ok && modErr.EZErrors != nil && modErr.EZErrors.HasErrors() {
+			// Return the formatted errors directly without wrapping
+			return nil, &Error{Message: modErr.Error(), PreFormatted: true}
+		}
+		// ModuleError.Error() already includes the error code, so pass it through directly
+		return nil, &Error{Message: err.Error()}
 	}
 
 	// If module is already fully loaded, return cached ModuleObject

--- a/pkg/interpreter/loader.go
+++ b/pkg/interpreter/loader.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/marshallburns/ez/pkg/ast"
+	"github.com/marshallburns/ez/pkg/errors"
 	"github.com/marshallburns/ez/pkg/lexer"
 	"github.com/marshallburns/ez/pkg/parser"
 )
@@ -193,9 +194,10 @@ func (l *ModuleLoader) loadFileModule(mod *Module, filePath string) error {
 
 	if len(p.Errors()) > 0 {
 		return &ModuleError{
-			Code:    "E6002",
-			Message: "parse error in module: " + strings.Join(p.Errors(), "; "),
-			Path:    filePath,
+			Code:     "E6002",
+			Message:  "parse error in module",
+			Path:     filePath,
+			EZErrors: p.EZErrors(),
 		}
 	}
 
@@ -268,9 +270,10 @@ func (l *ModuleLoader) loadDirectoryModule(mod *Module) error {
 
 		if len(p.Errors()) > 0 {
 			return &ModuleError{
-				Code:    "E6002",
-				Message: "parse error in module file: " + strings.Join(p.Errors(), "; "),
-				Path:    filePath,
+				Code:     "E6002",
+				Message:  "parse error in module file",
+				Path:     filePath,
+				EZErrors: p.EZErrors(),
 			}
 		}
 
@@ -374,11 +377,16 @@ func (l *ModuleLoader) ClearCache() {
 
 // ModuleError represents a module loading error
 type ModuleError struct {
-	Code    string
-	Message string
-	Path    string
+	Code     string
+	Message  string
+	Path     string
+	EZErrors *errors.EZErrorList // Rich parse errors (if any)
 }
 
 func (e *ModuleError) Error() string {
+	// If we have rich parse errors, format them properly
+	if e.EZErrors != nil && e.EZErrors.HasErrors() {
+		return errors.FormatErrorList(e.EZErrors)
+	}
 	return e.Code + ": " + e.Message
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -116,15 +116,21 @@ func (rv *ReturnValue) Inspect() string {
 
 // Error represents an error
 type Error struct {
-	Message string
-	Code    string
-	Line    int
-	Column  int
-	Help    string
+	Message      string
+	Code         string
+	Line         int
+	Column       int
+	Help         string
+	PreFormatted bool // If true, Message is already formatted and shouldn't be wrapped
 }
 
 func (e *Error) Type() ObjectType { return ERROR_OBJ }
-func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
+func (e *Error) Inspect() string {
+	if e.PreFormatted {
+		return e.Message
+	}
+	return "ERROR: " + e.Message
+}
 
 // Function represents a user-defined function
 type Function struct {


### PR DESCRIPTION
## Summary
- Parse errors from imported modules now display with proper formatting
- Each error shows file path, line number, source context, and error pointer
- Fixed duplicate error code prefix issue
- Added `PreFormatted` field to Error object for rich error output

## Before
```
ERROR: E6001: E6002: parse error in module: expected {, got IDENT instead; expected expression, found end of block
```

## After
```
error[E2002]: expected {, got IDENT instead
  --> /tmp/broken_mod.ez:5:9
   |
5 |         println("missing brace")
   |         ^^^^^^^ expected token not found
   |

error[E2003]: expected expression, found end of block
  --> /tmp/broken_mod.ez:7:1
   |
7 | }
   | ^ expected expression
   |

summary: generated 2 errors
```

## Test plan
- [x] Test parse error in imported module shows formatted output
- [x] Test module not found error still works
- [x] Test normal imports still work

Fixes #203