### PR TITLE
feat(stdlib): expand time module with arithmetic and utilities

### DIFF
--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -313,6 +313,58 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: ts.Value + days.Value*86400}
 		},
 	},
+	"time.add_weeks": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E11001", Message: "time.add_weeks() takes exactly 2 arguments"}
+			}
+			ts, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.add_weeks() requires integer timestamp"}
+			}
+			weeks, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.add_weeks() requires integer weeks"}
+			}
+			return &object.Integer{Value: ts.Value + weeks.Value*604800}
+		},
+	},
+	"time.add_months": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E11001", Message: "time.add_months() takes exactly 2 arguments"}
+			}
+			ts, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.add_months() requires integer timestamp"}
+			}
+			months, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.add_months() requires integer months"}
+			}
+			t := time.Unix(ts.Value, 0)
+			t = t.AddDate(0, int(months.Value), 0)
+			return &object.Integer{Value: t.Unix()}
+		},
+	},
+	"time.add_years": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E11001", Message: "time.add_years() takes exactly 2 arguments"}
+			}
+			ts, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.add_years() requires integer timestamp"}
+			}
+			years, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.add_years() requires integer years"}
+			}
+			t := time.Unix(ts.Value, 0)
+			t = t.AddDate(int(years.Value), 0, 0)
+			return &object.Integer{Value: t.Unix()}
+		},
+	},
 
 	// Differences
 	"time.diff": {
@@ -345,6 +397,38 @@ var TimeBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E11003", Message: "time.diff_days() requires integer timestamps"}
 			}
 			return &object.Integer{Value: (ts1.Value - ts2.Value) / 86400}
+		},
+	},
+	"time.diff_hours": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E11001", Message: "time.diff_hours() takes exactly 2 arguments"}
+			}
+			ts1, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.diff_hours() requires integer timestamps"}
+			}
+			ts2, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.diff_hours() requires integer timestamps"}
+			}
+			return &object.Integer{Value: (ts1.Value - ts2.Value) / 3600}
+		},
+	},
+	"time.diff_minutes": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E11001", Message: "time.diff_minutes() takes exactly 2 arguments"}
+			}
+			ts1, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.diff_minutes() requires integer timestamps"}
+			}
+			ts2, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E11003", Message: "time.diff_minutes() requires integer timestamps"}
+			}
+			return &object.Integer{Value: (ts1.Value - ts2.Value) / 60}
 		},
 	},
 
@@ -489,6 +573,23 @@ var TimeBuiltins = map[string]*object.Builtin{
 			t := getTime(args)
 			end := time.Date(t.Year(), 12, 31, 23, 59, 59, 0, t.Location())
 			return &object.Integer{Value: end.Unix()}
+		},
+	},
+
+	// Calendar utilities
+	"time.quarter": {
+		Fn: func(args ...object.Object) object.Object {
+			t := getTime(args)
+			month := int(t.Month())
+			quarter := (month-1)/3 + 1
+			return &object.Integer{Value: int64(quarter)}
+		},
+	},
+	"time.week_of_year": {
+		Fn: func(args ...object.Object) object.Object {
+			t := getTime(args)
+			_, week := t.ISOWeek()
+			return &object.Integer{Value: int64(week)}
 		},
 	},
 

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -971,6 +971,26 @@ do test_stdlib_time() -> TestResult {
     println("  time.add_days(now, 7) - now = ${diff} days")
     passed += 1
 
+    // New time arithmetic
+    temp week_later int = time.add_weeks(now, 1)
+    temp month_later int = time.add_months(now, 1)
+    temp year_later int = time.add_years(now, 1)
+    println("  time.add_weeks(now, 1) adds 7 days: ${time.diff_days(week_later, now)}")
+    println("  time.add_months(now, 1) works: ${time.month(month_later)}")
+    println("  time.add_years(now, 1) works: ${time.year(year_later)}")
+    passed += 1
+
+    // New time differences
+    temp five_hours int = time.add_hours(now, 5)
+    println("  time.diff_hours(+5h, now) = ${time.diff_hours(five_hours, now)}")
+    println("  time.diff_minutes(+5h, now) = ${time.diff_minutes(five_hours, now)}")
+    passed += 1
+
+    // Calendar utilities
+    println("  time.quarter() = Q${time.quarter()}")
+    println("  time.week_of_year() = ${time.week_of_year()}")
+    passed += 1
+
     println("  PASSED: ${passed}, FAILED: ${failed}")
     return TestResult{passed: passed, failed: failed}
 }


### PR DESCRIPTION
## Summary

Add new functions to the `@time` module for time arithmetic and calendar utilities.

### New Time Arithmetic

| Function | Description |
|----------|-------------|
| `add_weeks(ts, n)` | Add n weeks to timestamp |
| `add_months(ts, n)` | Add n months to timestamp |
| `add_years(ts, n)` | Add n years to timestamp |

### New Time Differences

| Function | Description |
|----------|-------------|
| `diff_hours(ts1, ts2)` | Difference in hours |
| `diff_minutes(ts1, ts2)` | Difference in minutes |

### New Calendar Utilities

| Function | Description |
|----------|-------------|
| `quarter(ts)` | Get quarter of year (1-4) |
| `week_of_year(ts)` | Get ISO week number |

## Test Plan

- [x] All 7 new functions tested
- [x] All 96 tests pass
- [x] Existing functionality unchanged

Partial fix for #228