### PR TITLE
feat(stdlib): implement @os module

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -36,6 +36,7 @@ var validModules = map[string]bool{
 	"maps":    true, // Map utilities
 	"time":    true, // Time functions
 	"io":      true, // File system and I/O operations
+	"os":      true, // Operating system and environment
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -24,11 +24,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.read_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.read_file() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.read_file() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.read_file() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.read_file() requires a string path"}
 			}
 
 			content, err := os.ReadFile(path.Value)
@@ -52,15 +52,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.write_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.write_file() takes exactly 2 arguments (path, content)"}
+				return &object.Error{Code: "E7001", Message: "io.write_file() takes exactly 2 arguments (path, content)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.write_file() requires a string path as first argument"}
+				return &object.Error{Code: "E7003", Message: "io.write_file() requires a string path as first argument"}
 			}
 			content, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8003", Message: "io.write_file() requires a string content as second argument"}
+				return &object.Error{Code: "E7003", Message: "io.write_file() requires a string content as second argument"}
 			}
 
 			err := os.WriteFile(path.Value, []byte(content.Value), 0644)
@@ -80,15 +80,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.append_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.append_file() takes exactly 2 arguments (path, content)"}
+				return &object.Error{Code: "E7001", Message: "io.append_file() takes exactly 2 arguments (path, content)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.append_file() requires a string path as first argument"}
+				return &object.Error{Code: "E7003", Message: "io.append_file() requires a string path as first argument"}
 			}
 			content, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8003", Message: "io.append_file() requires a string content as second argument"}
+				return &object.Error{Code: "E7003", Message: "io.append_file() requires a string content as second argument"}
 			}
 
 			f, err := os.OpenFile(path.Value, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -117,11 +117,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.exists": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.exists() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.exists() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.exists() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.exists() requires a string path"}
 			}
 
 			_, err := os.Stat(path.Value)
@@ -140,11 +140,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.is_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.is_file() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.is_file() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.is_file() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.is_file() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -162,11 +162,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.is_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.is_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.is_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.is_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.is_dir() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -189,11 +189,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.remove() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.remove() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.remove() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.remove() requires a string path"}
 			}
 
 			// Check if it's a directory - if so, don't allow removal with this function
@@ -204,7 +204,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if info.IsDir() {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8006", "io.remove() cannot remove directories, use io.remove_dir() instead"),
+					createIOError("E7018", "io.remove() cannot remove directories, use io.remove_dir() instead"),
 				}}
 			}
 
@@ -225,11 +225,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.remove_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.remove_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.remove_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.remove_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.remove_dir() requires a string path"}
 			}
 
 			// Check if it's actually a directory
@@ -240,7 +240,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if !info.IsDir() {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8007", "io.remove_dir() can only remove directories, use io.remove() for files"),
+					createIOError("E7019", "io.remove_dir() can only remove directories, use io.remove() for files"),
 				}}
 			}
 
@@ -261,11 +261,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.remove_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.remove_all() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.remove_all() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.remove_all() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.remove_all() requires a string path"}
 			}
 
 			// Safety check: don't allow removing root or home directory
@@ -278,7 +278,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if absPath == "/" || absPath == filepath.Clean(os.Getenv("HOME")) {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8008", "io.remove_all() cannot remove root or home directory for safety"),
+					createIOError("E7020", "io.remove_all() cannot remove root or home directory for safety"),
 				}}
 			}
 
@@ -299,15 +299,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.rename": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.rename() takes exactly 2 arguments (old_path, new_path)"}
+				return &object.Error{Code: "E7001", Message: "io.rename() takes exactly 2 arguments (old_path, new_path)"}
 			}
 			oldPath, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.rename() requires a string as first argument (old_path)"}
+				return &object.Error{Code: "E7003", Message: "io.rename() requires a string as first argument (old_path)"}
 			}
 			newPath, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.rename() requires a string as second argument (new_path)"}
+				return &object.Error{Code: "E7003", Message: "io.rename() requires a string as second argument (new_path)"}
 			}
 
 			err := os.Rename(oldPath.Value, newPath.Value)
@@ -327,15 +327,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.copy": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.copy() takes exactly 2 arguments (source, destination)"}
+				return &object.Error{Code: "E7001", Message: "io.copy() takes exactly 2 arguments (source, destination)"}
 			}
 			srcPath, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.copy() requires a string as first argument (source)"}
+				return &object.Error{Code: "E7003", Message: "io.copy() requires a string as first argument (source)"}
 			}
 			dstPath, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.copy() requires a string as second argument (destination)"}
+				return &object.Error{Code: "E7003", Message: "io.copy() requires a string as second argument (destination)"}
 			}
 
 			// Check source exists and is a file
@@ -346,7 +346,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if srcInfo.IsDir() {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8009", "io.copy() cannot copy directories, only files"),
+					createIOError("E7021", "io.copy() cannot copy directories, only files"),
 				}}
 			}
 
@@ -393,11 +393,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.mkdir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.mkdir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.mkdir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.mkdir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.mkdir() requires a string path"}
 			}
 
 			err := os.Mkdir(path.Value, 0755)
@@ -417,11 +417,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.mkdir_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.mkdir_all() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.mkdir_all() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.mkdir_all() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.mkdir_all() requires a string path"}
 			}
 
 			err := os.MkdirAll(path.Value, 0755)
@@ -441,11 +441,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.read_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.read_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.read_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.read_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.read_dir() requires a string path"}
 			}
 
 			entries, err := os.ReadDir(path.Value)
@@ -474,11 +474,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.file_size": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.file_size() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.file_size() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.file_size() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.file_size() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -498,11 +498,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.file_mod_time": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.file_mod_time() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.file_mod_time() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.file_mod_time() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.file_mod_time() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -525,14 +525,14 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_join() takes at least 1 argument"}
+				return &object.Error{Code: "E7001", Message: "io.path_join() takes at least 1 argument"}
 			}
 
 			parts := make([]string, len(args))
 			for i, arg := range args {
 				str, ok := arg.(*object.String)
 				if !ok {
-					return &object.Error{Code: "E8002", Message: fmt.Sprintf("io.path_join() argument %d must be a string", i+1)}
+					return &object.Error{Code: "E7003", Message: fmt.Sprintf("io.path_join() argument %d must be a string", i+1)}
 				}
 				parts[i] = str.Value
 			}
@@ -545,11 +545,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_base": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_base() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_base() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_base() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_base() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Base(path.Value)}
@@ -560,11 +560,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_dir() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Dir(path.Value)}
@@ -575,11 +575,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_ext": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_ext() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_ext() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_ext() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_ext() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Ext(path.Value)}
@@ -591,11 +591,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_abs": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_abs() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_abs() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_abs() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_abs() requires a string path"}
 			}
 
 			absPath, err := filepath.Abs(path.Value)
@@ -614,11 +614,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_clean": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_clean() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_clean() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_clean() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_clean() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Clean(path.Value)}
@@ -651,19 +651,19 @@ func createIOErrorResult(err error, operation string) *object.ReturnValue {
 
 	// Determine error code based on error type
 	if os.IsNotExist(err) {
-		code = "E8004"
+		code = "E7016"
 		message = fmt.Sprintf("file or directory not found: %s", err.Error())
 	} else if os.IsPermission(err) {
-		code = "E8005"
+		code = "E7017"
 		message = fmt.Sprintf("permission denied: %s", err.Error())
 	} else if os.IsExist(err) {
-		code = "E8010"
+		code = "E7022"
 		message = fmt.Sprintf("file or directory already exists: %s", err.Error())
 	} else if strings.Contains(err.Error(), "directory not empty") {
-		code = "E8011"
+		code = "E7023"
 		message = fmt.Sprintf("directory not empty: %s", err.Error())
 	} else {
-		code = "E8099"
+		code = "E7099"
 		message = fmt.Sprintf("io error during %s: %s", operation, err.Error())
 	}
 

--- a/pkg/stdlib/io_test.go
+++ b/pkg/stdlib/io_test.go
@@ -113,8 +113,8 @@ func TestIOReadFile(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, ok := errStruct.Fields["code"].(*object.String)
-		if !ok || code.Value != "E8004" {
-			t.Errorf("expected error code E8004, got %v", errStruct.Fields["code"])
+		if !ok || code.Value != "E7016" {
+			t.Errorf("expected error code E7016, got %v", errStruct.Fields["code"])
 		}
 	})
 
@@ -328,8 +328,8 @@ func TestIORemove(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8006" {
-			t.Errorf("expected E8006, got %s", code.Value)
+		if code.Value != "E7018" {
+			t.Errorf("expected E7018, got %s", code.Value)
 		}
 	})
 }
@@ -359,8 +359,8 @@ func TestIORemoveDir(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8007" {
-			t.Errorf("expected E8007, got %s", code.Value)
+		if code.Value != "E7019" {
+			t.Errorf("expected E7019, got %s", code.Value)
 		}
 	})
 
@@ -399,8 +399,8 @@ func TestIORemoveAll(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8008" {
-			t.Errorf("expected E8008 safety error, got %s", code.Value)
+		if code.Value != "E7020" {
+			t.Errorf("expected E7020 safety error, got %s", code.Value)
 		}
 	})
 }
@@ -465,8 +465,8 @@ func TestIOCopy(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8009" {
-			t.Errorf("expected E8009, got %s", code.Value)
+		if code.Value != "E7021" {
+			t.Errorf("expected E7021, got %s", code.Value)
 		}
 	})
 }

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -1,0 +1,407 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// CommandLineArgs stores the command-line arguments passed to the EZ program
+// This should be set by the main package before evaluation
+var CommandLineArgs []string
+
+// OSBuiltins contains the os module functions for system operations
+var OSBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// Environment Variables
+	// ============================================================================
+
+	// Gets an environment variable by name
+	// Returns the value as a string, or nil if not set
+	"os.get_env": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "os.get_env() takes exactly 1 argument (name)"}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.get_env() requires a string argument"}
+			}
+
+			value, exists := os.LookupEnv(name.Value)
+			if !exists {
+				return object.NIL
+			}
+			return &object.String{Value: value}
+		},
+	},
+
+	// Sets an environment variable (process-scoped only)
+	// Returns true on success, (false, error) on failure
+	"os.set_env": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "os.set_env() takes exactly 2 arguments (name, value)"}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.set_env() requires a string name as first argument"}
+			}
+			value, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.set_env() requires a string value as second argument"}
+			}
+
+			err := os.Setenv(name.Value, value.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createOSError("E7024", fmt.Sprintf("failed to set environment variable: %s", err.Error())),
+				}}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Unsets an environment variable
+	// Returns true on success, (false, error) on failure
+	"os.unset_env": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "os.unset_env() takes exactly 1 argument (name)"}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.unset_env() requires a string argument"}
+			}
+
+			err := os.Unsetenv(name.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createOSError("E7024", fmt.Sprintf("failed to unset environment variable: %s", err.Error())),
+				}}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns all environment variables as a map
+	"os.env": {
+		Fn: func(args ...object.Object) object.Object {
+			envMap := object.NewMap()
+			for _, entry := range os.Environ() {
+				// Find the first = to split key and value
+				for i := 0; i < len(entry); i++ {
+					if entry[i] == '=' {
+						key := entry[:i]
+						value := entry[i+1:]
+						envMap.Set(&object.String{Value: key}, &object.String{Value: value})
+						break
+					}
+				}
+			}
+			envMap.Mutable = false
+			return envMap
+		},
+	},
+
+	// Returns command-line arguments as an array
+	// First element is the program name/path
+	"os.args": {
+		Fn: func(args ...object.Object) object.Object {
+			// Use CommandLineArgs if set, otherwise fall back to os.Args
+			sourceArgs := CommandLineArgs
+			if len(sourceArgs) == 0 {
+				sourceArgs = os.Args
+			}
+
+			elements := make([]object.Object, len(sourceArgs))
+			for i, arg := range sourceArgs {
+				elements[i] = &object.String{Value: arg}
+			}
+			return &object.Array{Elements: elements, Mutable: false}
+		},
+	},
+
+	// ============================================================================
+	// Process / System
+	// ============================================================================
+
+	// Exits the program with the given status code
+	"os.exit": {
+		Fn: func(args ...object.Object) object.Object {
+			code := 0
+			if len(args) > 0 {
+				if codeObj, ok := args[0].(*object.Integer); ok {
+					code = int(codeObj.Value)
+				} else {
+					return &object.Error{Code: "E7003", Message: "os.exit() requires an integer exit code"}
+				}
+			}
+			os.Exit(code)
+			return object.NIL // Never reached
+		},
+	},
+
+	// Returns the current working directory
+	// Returns (path, error) tuple
+	"os.cwd": {
+		Fn: func(args ...object.Object) object.Object {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7025", fmt.Sprintf("failed to get current directory: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: cwd},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Changes the current working directory
+	// Returns (success, error) tuple
+	"os.chdir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "os.chdir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.chdir() requires a string path"}
+			}
+
+			err := os.Chdir(path.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createOSError("E7026", fmt.Sprintf("failed to change directory: %s", err.Error())),
+				}}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the hostname of the machine
+	// Returns (hostname, error) tuple
+	"os.hostname": {
+		Fn: func(args ...object.Object) object.Object {
+			hostname, err := os.Hostname()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7027", fmt.Sprintf("failed to get hostname: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: hostname},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the current user's username
+	// Returns (username, error) tuple
+	"os.username": {
+		Fn: func(args ...object.Object) object.Object {
+			currentUser, err := user.Current()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7028", fmt.Sprintf("failed to get username: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: currentUser.Username},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the current user's home directory
+	// Returns (path, error) tuple
+	"os.home_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7029", fmt.Sprintf("failed to get home directory: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: homeDir},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the system's temporary directory
+	"os.temp_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: os.TempDir()}
+		},
+	},
+
+	// Returns the process ID of the current process
+	"os.pid": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: int64(os.Getpid())}
+		},
+	},
+
+	// Returns the parent process ID
+	"os.ppid": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: int64(os.Getppid())}
+		},
+	},
+
+	// ============================================================================
+	// Platform Detection
+	// ============================================================================
+
+	// OS Constants - use these for comparison with CURRENT_OS
+	"os.MAC_OS": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: 0}
+		},
+	},
+	"os.LINUX": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: 1}
+		},
+	},
+	"os.WINDOWS": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: 2}
+		},
+	},
+
+	// Returns the current OS as a constant (matches os.MAC_OS, os.LINUX, or os.WINDOWS)
+	"os.CURRENT_OS": {
+		Fn: func(args ...object.Object) object.Object {
+			switch runtime.GOOS {
+			case "darwin":
+				return &object.Integer{Value: 0} // MAC_OS
+			case "linux":
+				return &object.Integer{Value: 1} // LINUX
+			case "windows":
+				return &object.Integer{Value: 2} // WINDOWS
+			default:
+				return &object.Integer{Value: -1} // Unknown
+			}
+		},
+	},
+
+	// Returns the operating system name as a string
+	// Possible values: "darwin", "linux", "windows", "freebsd", etc.
+	"os.platform": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: runtime.GOOS}
+		},
+	},
+
+	// Returns the CPU architecture
+	// Possible values: "amd64", "arm64", "386", "arm", etc.
+	"os.arch": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: runtime.GOARCH}
+		},
+	},
+
+	// Returns true if running on Windows
+	"os.is_windows": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "windows" {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Returns true if running on Linux
+	"os.is_linux": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "linux" {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Returns true if running on macOS
+	"os.is_macos": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "darwin" {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Returns the number of CPUs available
+	"os.num_cpu": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: int64(runtime.NumCPU())}
+		},
+	},
+
+	// ============================================================================
+	// Platform Constants
+	// ============================================================================
+
+	// Returns the line separator for the current platform
+	// "\r\n" on Windows, "\n" on Unix-like systems
+	"os.line_separator": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "windows" {
+				return &object.String{Value: "\r\n"}
+			}
+			return &object.String{Value: "\n"}
+		},
+	},
+
+	// Returns the null device path for the current platform
+	// "NUL" on Windows, "/dev/null" on Unix-like systems
+	"os.dev_null": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "windows" {
+				return &object.String{Value: "NUL"}
+			}
+			return &object.String{Value: "/dev/null"}
+		},
+	},
+}
+
+// createOSError creates an Error struct for OS operations
+func createOSError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -1,0 +1,584 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// ============================================================================
+// Environment Variables Tests
+// ============================================================================
+
+func TestOSGetEnv(t *testing.T) {
+	fn := OSBuiltins["os.get_env"]
+
+	// Set a test environment variable
+	os.Setenv("EZ_TEST_VAR", "test_value")
+	defer os.Unsetenv("EZ_TEST_VAR")
+
+	// Test getting existing variable
+	result := fn.Fn(&object.String{Value: "EZ_TEST_VAR"})
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+	if strResult.Value != "test_value" {
+		t.Errorf("Expected 'test_value', got '%s'", strResult.Value)
+	}
+
+	// Test getting non-existent variable
+	result = fn.Fn(&object.String{Value: "EZ_NONEXISTENT_VAR_12345"})
+	if result != object.NIL {
+		t.Errorf("Expected NIL for non-existent var, got %T", result)
+	}
+
+	// Test wrong argument count
+	result = fn.Fn()
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7001" {
+		t.Errorf("Expected error code E7001, got %s", errResult.Code)
+	}
+
+	// Test wrong argument type
+	result = fn.Fn(&object.Integer{Value: 123})
+	errResult, ok = result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7003" {
+		t.Errorf("Expected error code E7003, got %s", errResult.Code)
+	}
+}
+
+func TestOSSetEnv(t *testing.T) {
+	fn := OSBuiltins["os.set_env"]
+
+	// Test setting a new variable
+	result := fn.Fn(&object.String{Value: "EZ_SET_TEST"}, &object.String{Value: "new_value"})
+	defer os.Unsetenv("EZ_SET_TEST")
+
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+	if retVal.Values[0] != object.TRUE {
+		t.Errorf("Expected TRUE, got %v", retVal.Values[0])
+	}
+
+	// Verify it was actually set
+	if os.Getenv("EZ_SET_TEST") != "new_value" {
+		t.Errorf("Environment variable was not set correctly")
+	}
+
+	// Test wrong argument count
+	result = fn.Fn(&object.String{Value: "test"})
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7001" {
+		t.Errorf("Expected error code E7001, got %s", errResult.Code)
+	}
+}
+
+func TestOSUnsetEnv(t *testing.T) {
+	fn := OSBuiltins["os.unset_env"]
+
+	// Set then unset a variable
+	os.Setenv("EZ_UNSET_TEST", "to_be_removed")
+
+	result := fn.Fn(&object.String{Value: "EZ_UNSET_TEST"})
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if retVal.Values[0] != object.TRUE {
+		t.Errorf("Expected TRUE, got %v", retVal.Values[0])
+	}
+
+	// Verify it was unset
+	if _, exists := os.LookupEnv("EZ_UNSET_TEST"); exists {
+		t.Errorf("Environment variable should have been unset")
+	}
+}
+
+func TestOSEnv(t *testing.T) {
+	fn := OSBuiltins["os.env"]
+
+	// Set a known test variable
+	os.Setenv("EZ_ENV_TEST", "test123")
+	defer os.Unsetenv("EZ_ENV_TEST")
+
+	result := fn.Fn()
+	mapResult, ok := result.(*object.Map)
+	if !ok {
+		t.Fatalf("Expected Map, got %T", result)
+	}
+
+	// Check that it contains our test variable
+	key := &object.String{Value: "EZ_ENV_TEST"}
+	val, _ := mapResult.Get(key)
+	strVal, ok := val.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String value for EZ_ENV_TEST, got %T", val)
+	}
+	if strVal.Value != "test123" {
+		t.Errorf("Expected 'test123', got '%s'", strVal.Value)
+	}
+
+	// Check that the map is immutable
+	if mapResult.Mutable {
+		t.Errorf("Environment map should be immutable")
+	}
+}
+
+func TestOSArgs(t *testing.T) {
+	fn := OSBuiltins["os.args"]
+
+	// Set CommandLineArgs for testing
+	originalArgs := CommandLineArgs
+	CommandLineArgs = []string{"program", "arg1", "arg2"}
+	defer func() { CommandLineArgs = originalArgs }()
+
+	result := fn.Fn()
+	arrResult, ok := result.(*object.Array)
+	if !ok {
+		t.Fatalf("Expected Array, got %T", result)
+	}
+
+	if len(arrResult.Elements) != 3 {
+		t.Fatalf("Expected 3 elements, got %d", len(arrResult.Elements))
+	}
+
+	expectedArgs := []string{"program", "arg1", "arg2"}
+	for i, expected := range expectedArgs {
+		strElem, ok := arrResult.Elements[i].(*object.String)
+		if !ok {
+			t.Fatalf("Expected String at index %d, got %T", i, arrResult.Elements[i])
+		}
+		if strElem.Value != expected {
+			t.Errorf("At index %d: expected '%s', got '%s'", i, expected, strElem.Value)
+		}
+	}
+
+	// Check that the array is immutable
+	if arrResult.Mutable {
+		t.Errorf("Args array should be immutable")
+	}
+}
+
+// ============================================================================
+// Process / System Tests
+// ============================================================================
+
+func TestOSCwd(t *testing.T) {
+	fn := OSBuiltins["os.cwd"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	// Get actual cwd
+	expectedCwd, _ := os.Getwd()
+	if strResult.Value != expectedCwd {
+		t.Errorf("Expected '%s', got '%s'", expectedCwd, strResult.Value)
+	}
+
+	// Error should be nil
+	if retVal.Values[1] != object.NIL {
+		t.Errorf("Expected NIL error, got %v", retVal.Values[1])
+	}
+}
+
+func TestOSChdir(t *testing.T) {
+	fn := OSBuiltins["os.chdir"]
+
+	// Save current directory
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	// Change to temp dir
+	tempDir := os.TempDir()
+	result := fn.Fn(&object.String{Value: tempDir})
+
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	if retVal.Values[0] != object.TRUE {
+		t.Errorf("Expected TRUE, got %v", retVal.Values[0])
+	}
+
+	// Test changing to non-existent directory
+	result = fn.Fn(&object.String{Value: "/nonexistent/path/12345"})
+	retVal, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	if retVal.Values[0] != object.FALSE {
+		t.Errorf("Expected FALSE for invalid path, got %v", retVal.Values[0])
+	}
+
+	// Test wrong argument count
+	result = fn.Fn()
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7001" {
+		t.Errorf("Expected error code E7001, got %s", errResult.Code)
+	}
+}
+
+func TestOSHostname(t *testing.T) {
+	fn := OSBuiltins["os.hostname"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	expectedHostname, _ := os.Hostname()
+	if strResult.Value != expectedHostname {
+		t.Errorf("Expected '%s', got '%s'", expectedHostname, strResult.Value)
+	}
+}
+
+func TestOSUsername(t *testing.T) {
+	fn := OSBuiltins["os.username"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	currentUser, _ := user.Current()
+	if strResult.Value != currentUser.Username {
+		t.Errorf("Expected '%s', got '%s'", currentUser.Username, strResult.Value)
+	}
+}
+
+func TestOSHomeDir(t *testing.T) {
+	fn := OSBuiltins["os.home_dir"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	expectedHome, _ := os.UserHomeDir()
+	if strResult.Value != expectedHome {
+		t.Errorf("Expected '%s', got '%s'", expectedHome, strResult.Value)
+	}
+}
+
+func TestOSTempDir(t *testing.T) {
+	fn := OSBuiltins["os.temp_dir"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	if strResult.Value != os.TempDir() {
+		t.Errorf("Expected '%s', got '%s'", os.TempDir(), strResult.Value)
+	}
+}
+
+func TestOSPid(t *testing.T) {
+	fn := OSBuiltins["os.pid"]
+
+	result := fn.Fn()
+	intResult, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("Expected Integer, got %T", result)
+	}
+
+	if intResult.Value != int64(os.Getpid()) {
+		t.Errorf("Expected %d, got %d", os.Getpid(), intResult.Value)
+	}
+}
+
+func TestOSPpid(t *testing.T) {
+	fn := OSBuiltins["os.ppid"]
+
+	result := fn.Fn()
+	intResult, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("Expected Integer, got %T", result)
+	}
+
+	if intResult.Value != int64(os.Getppid()) {
+		t.Errorf("Expected %d, got %d", os.Getppid(), intResult.Value)
+	}
+}
+
+// ============================================================================
+// Platform Detection Tests
+// ============================================================================
+
+func TestOSConstants(t *testing.T) {
+	macOS := OSBuiltins["os.MAC_OS"]
+	linux := OSBuiltins["os.LINUX"]
+	windows := OSBuiltins["os.WINDOWS"]
+	currentOS := OSBuiltins["os.CURRENT_OS"]
+
+	// Check constants have expected values
+	macResult := macOS.Fn().(*object.Integer)
+	linuxResult := linux.Fn().(*object.Integer)
+	windowsResult := windows.Fn().(*object.Integer)
+
+	if macResult.Value != 0 {
+		t.Errorf("Expected MAC_OS = 0, got %d", macResult.Value)
+	}
+	if linuxResult.Value != 1 {
+		t.Errorf("Expected LINUX = 1, got %d", linuxResult.Value)
+	}
+	if windowsResult.Value != 2 {
+		t.Errorf("Expected WINDOWS = 2, got %d", windowsResult.Value)
+	}
+
+	// Check CURRENT_OS matches expected constant for this platform
+	currentResult := currentOS.Fn().(*object.Integer)
+	switch runtime.GOOS {
+	case "darwin":
+		if currentResult.Value != 0 {
+			t.Errorf("Expected CURRENT_OS = MAC_OS (0) on darwin, got %d", currentResult.Value)
+		}
+	case "linux":
+		if currentResult.Value != 1 {
+			t.Errorf("Expected CURRENT_OS = LINUX (1) on linux, got %d", currentResult.Value)
+		}
+	case "windows":
+		if currentResult.Value != 2 {
+			t.Errorf("Expected CURRENT_OS = WINDOWS (2) on windows, got %d", currentResult.Value)
+		}
+	}
+}
+
+func TestOSPlatform(t *testing.T) {
+	fn := OSBuiltins["os.platform"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	if strResult.Value != runtime.GOOS {
+		t.Errorf("Expected '%s', got '%s'", runtime.GOOS, strResult.Value)
+	}
+}
+
+func TestOSArch(t *testing.T) {
+	fn := OSBuiltins["os.arch"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	if strResult.Value != runtime.GOARCH {
+		t.Errorf("Expected '%s', got '%s'", runtime.GOARCH, strResult.Value)
+	}
+}
+
+func TestOSIsWindows(t *testing.T) {
+	fn := OSBuiltins["os.is_windows"]
+
+	result := fn.Fn()
+	boolResult, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("Expected Boolean, got %T", result)
+	}
+
+	expected := runtime.GOOS == "windows"
+	if boolResult.Value != expected {
+		t.Errorf("Expected %v, got %v", expected, boolResult.Value)
+	}
+}
+
+func TestOSIsLinux(t *testing.T) {
+	fn := OSBuiltins["os.is_linux"]
+
+	result := fn.Fn()
+	boolResult, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("Expected Boolean, got %T", result)
+	}
+
+	expected := runtime.GOOS == "linux"
+	if boolResult.Value != expected {
+		t.Errorf("Expected %v, got %v", expected, boolResult.Value)
+	}
+}
+
+func TestOSIsMacos(t *testing.T) {
+	fn := OSBuiltins["os.is_macos"]
+
+	result := fn.Fn()
+	boolResult, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("Expected Boolean, got %T", result)
+	}
+
+	expected := runtime.GOOS == "darwin"
+	if boolResult.Value != expected {
+		t.Errorf("Expected %v, got %v", expected, boolResult.Value)
+	}
+}
+
+func TestOSNumCpu(t *testing.T) {
+	fn := OSBuiltins["os.num_cpu"]
+
+	result := fn.Fn()
+	intResult, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("Expected Integer, got %T", result)
+	}
+
+	if intResult.Value != int64(runtime.NumCPU()) {
+		t.Errorf("Expected %d, got %d", runtime.NumCPU(), intResult.Value)
+	}
+}
+
+// ============================================================================
+// Platform Constants Tests
+// ============================================================================
+
+func TestOSLineSeparator(t *testing.T) {
+	fn := OSBuiltins["os.line_separator"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	var expected string
+	if runtime.GOOS == "windows" {
+		expected = "\r\n"
+	} else {
+		expected = "\n"
+	}
+
+	if strResult.Value != expected {
+		t.Errorf("Expected '%q', got '%q'", expected, strResult.Value)
+	}
+}
+
+func TestOSDevNull(t *testing.T) {
+	fn := OSBuiltins["os.dev_null"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	var expected string
+	if runtime.GOOS == "windows" {
+		expected = "NUL"
+	} else {
+		expected = "/dev/null"
+	}
+
+	if strResult.Value != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, strResult.Value)
+	}
+}
+
+// ============================================================================
+// Exit function test (cannot test os.Exit directly, just verify function exists)
+// ============================================================================
+
+func TestOSExitExists(t *testing.T) {
+	fn := OSBuiltins["os.exit"]
+	if fn == nil {
+		t.Error("os.exit function should exist")
+	}
+
+	// Test wrong argument type (we can test error handling but not actual exit)
+	result := fn.Fn(&object.String{Value: "not a number"})
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error for wrong type, got %T", result)
+	}
+	if errResult.Code != "E7003" {
+		t.Errorf("Expected error code E7003, got %s", errResult.Code)
+	}
+}
+
+// ============================================================================
+// Helper function tests
+// ============================================================================
+
+func TestCreateOSError(t *testing.T) {
+	err := createOSError("E9999", "test error message")
+
+	if err.TypeName != "Error" {
+		t.Errorf("Expected TypeName 'Error', got '%s'", err.TypeName)
+	}
+
+	msgField, ok := err.Fields["message"].(*object.String)
+	if !ok {
+		t.Fatalf("Expected message field to be String, got %T", err.Fields["message"])
+	}
+	if msgField.Value != "test error message" {
+		t.Errorf("Expected message 'test error message', got '%s'", msgField.Value)
+	}
+
+	codeField, ok := err.Fields["code"].(*object.String)
+	if !ok {
+		t.Fatalf("Expected code field to be String, got %T", err.Fields["code"])
+	}
+	if codeField.Value != "E9999" {
+		t.Errorf("Expected code 'E9999', got '%s'", codeField.Value)
+	}
+}

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -37,6 +37,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range IOBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range OSBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -17,7 +17,7 @@
 // IMPORTS
 // ==================================================
 
-import @std, @math, @arrays, @strings, @maps, @time, @io
+import @std, @math, @arrays, @strings, @maps, @time, @io, @os
 
 using std
 
@@ -149,6 +149,10 @@ do main() {
     total_failed += result.failed
 
     result = test_stdlib_io()
+    total_passed += result.passed
+    total_failed += result.failed
+
+    result = test_stdlib_os()
     total_passed += result.passed
     total_failed += result.failed
 
@@ -1265,6 +1269,315 @@ do test_stdlib_io() -> TestResult {
         passed += 1
     } otherwise {
         println("  Cleanup incomplete")
+        failed += 1
+    }
+
+    println("  PASSED: ${passed}, FAILED: ${failed}")
+    return TestResult{passed: passed, failed: failed}
+}
+
+do test_stdlib_os() -> TestResult {
+    print_section("Standard Library: @os")
+    temp passed int = 0
+    temp failed int = 0
+
+    // ============================================================================
+    // Environment Variables
+    // ============================================================================
+    println("  Environment Variables:")
+
+    // Test os.get_env - this should work on any system
+    temp path_value = os.get_env("PATH")
+    if path_value != nil {
+        println("  os.get_env('PATH') = [value present, ${len(path_value)} chars]")
+        passed += 1
+    } otherwise {
+        println("  os.get_env('PATH') = nil (unexpected)")
+        failed += 1
+    }
+
+    // Test os.get_env for non-existent variable
+    temp nonexistent = os.get_env("EZ_NONEXISTENT_VAR_12345")
+    if nonexistent == nil {
+        println("  os.get_env('EZ_NONEXISTENT_VAR_12345') = nil (correct)")
+        passed += 1
+    } otherwise {
+        println("  os.get_env('EZ_NONEXISTENT_VAR_12345') should be nil")
+        failed += 1
+    }
+
+    // Test os.set_env
+    temp set_ok, set_err = os.set_env("EZ_TEST_VAR", "test_value_123")
+    if set_err == nil {
+        println("  os.set_env('EZ_TEST_VAR', 'test_value_123') = success")
+        passed += 1
+
+        // Verify it was set
+        temp verify_value = os.get_env("EZ_TEST_VAR")
+        if verify_value == "test_value_123" {
+            println("  os.get_env('EZ_TEST_VAR') = '${verify_value}' (verified)")
+            passed += 1
+        } otherwise {
+            println("  Verification failed")
+            failed += 1
+        }
+    } otherwise {
+        println("  os.set_env() = FAILED")
+        failed += 1
+    }
+
+    // Test os.unset_env
+    temp unset_ok, unset_err = os.unset_env("EZ_TEST_VAR")
+    if unset_err == nil {
+        println("  os.unset_env('EZ_TEST_VAR') = success")
+        passed += 1
+
+        // Verify it was unset
+        temp after_unset = os.get_env("EZ_TEST_VAR")
+        if after_unset == nil {
+            println("  Variable correctly unset (verified)")
+            passed += 1
+        } otherwise {
+            println("  Variable should have been unset")
+            failed += 1
+        }
+    } otherwise {
+        println("  os.unset_env() = FAILED")
+        failed += 1
+    }
+
+    // Test os.env - get all environment variables
+    temp all_env = os.env()
+    temp env_count int = len(all_env)
+    if env_count > 0 {
+        println("  os.env() = [map with ${env_count} entries]")
+        passed += 1
+    } otherwise {
+        println("  os.env() returned empty map (unexpected)")
+        failed += 1
+    }
+
+    // Test os.args
+    temp args = os.args()
+    println("  os.args() = [array with ${len(args)} entries]")
+    passed += 1
+
+    // ============================================================================
+    // Process / System
+    // ============================================================================
+    println("")
+    println("  Process / System:")
+
+    // Test os.cwd
+    temp cwd, cwd_err = os.cwd()
+    if cwd_err == nil {
+        println("  os.cwd() = '${cwd}'")
+        passed += 1
+    } otherwise {
+        println("  os.cwd() = FAILED")
+        failed += 1
+    }
+
+    // Test os.hostname
+    temp hostname, host_err = os.hostname()
+    if host_err == nil {
+        println("  os.hostname() = '${hostname}'")
+        passed += 1
+    } otherwise {
+        println("  os.hostname() = FAILED")
+        failed += 1
+    }
+
+    // Test os.username
+    temp username, user_err = os.username()
+    if user_err == nil {
+        println("  os.username() = '${username}'")
+        passed += 1
+    } otherwise {
+        println("  os.username() = FAILED")
+        failed += 1
+    }
+
+    // Test os.home_dir
+    temp home, home_err = os.home_dir()
+    if home_err == nil {
+        println("  os.home_dir() = '${home}'")
+        passed += 1
+    } otherwise {
+        println("  os.home_dir() = FAILED")
+        failed += 1
+    }
+
+    // Test os.temp_dir
+    temp temp_dir string = os.temp_dir()
+    println("  os.temp_dir() = '${temp_dir}'")
+    passed += 1
+
+    // Test os.pid
+    temp pid int = os.pid()
+    println("  os.pid() = ${pid}")
+    passed += 1
+
+    // Test os.ppid
+    temp ppid int = os.ppid()
+    println("  os.ppid() = ${ppid}")
+    passed += 1
+
+    // ============================================================================
+    // OS Constants
+    // ============================================================================
+    println("")
+    println("  OS Constants:")
+
+    // Test that constants have expected values
+    println("  os.MAC_OS = ${os.MAC_OS}")
+    println("  os.LINUX = ${os.LINUX}")
+    println("  os.WINDOWS = ${os.WINDOWS}")
+    println("  os.CURRENT_OS = ${os.CURRENT_OS}")
+    passed += 1
+
+    // Test CURRENT_OS matches one of the constants
+    if os.CURRENT_OS == os.MAC_OS {
+        println("  os.CURRENT_OS == os.MAC_OS (correct for macOS)")
+        passed += 1
+    }
+    if os.CURRENT_OS == os.LINUX {
+        println("  os.CURRENT_OS == os.LINUX (correct for Linux)")
+        passed += 1
+    }
+    if os.CURRENT_OS == os.WINDOWS {
+        println("  os.CURRENT_OS == os.WINDOWS (correct for Windows)")
+        passed += 1
+    }
+
+    // ============================================================================
+    // Platform Detection
+    // ============================================================================
+    println("")
+    println("  Platform Detection:")
+
+    // Test os.platform
+    temp platform string = os.platform()
+    println("  os.platform() = '${platform}'")
+    passed += 1
+
+    // Test os.arch
+    temp arch string = os.arch()
+    println("  os.arch() = '${arch}'")
+    passed += 1
+
+    // Test os.is_windows
+    temp is_win bool = os.is_windows()
+    println("  os.is_windows() = ${is_win}")
+    passed += 1
+
+    // Test os.is_linux
+    temp is_lin bool = os.is_linux()
+    println("  os.is_linux() = ${is_lin}")
+    passed += 1
+
+    // Test os.is_macos
+    temp is_mac bool = os.is_macos()
+    println("  os.is_macos() = ${is_mac}")
+    passed += 1
+
+    // Verify platform consistency
+    temp platform_verified bool = false
+    if platform == "darwin" && is_mac {
+        println("  Platform consistency: darwin == is_macos (verified)")
+        platform_verified = true
+    }
+    if platform == "linux" && is_lin {
+        println("  Platform consistency: linux == is_linux (verified)")
+        platform_verified = true
+    }
+    if platform == "windows" && is_win {
+        println("  Platform consistency: windows == is_windows (verified)")
+        platform_verified = true
+    }
+    if !platform_verified {
+        println("  Platform consistency check: passed")
+    }
+    passed += 1
+
+    // Test os.num_cpu
+    temp num_cpus int = os.num_cpu()
+    if num_cpus > 0 {
+        println("  os.num_cpu() = ${num_cpus}")
+        passed += 1
+    } otherwise {
+        println("  os.num_cpu() should be > 0")
+        failed += 1
+    }
+
+    // ============================================================================
+    // Platform Constants
+    // ============================================================================
+    println("")
+    println("  Platform Constants:")
+
+    // Test os.line_separator - just check that it returns a non-empty string
+    temp line_sep string = os.line_separator()
+    temp line_sep_len int = len(line_sep)
+    if line_sep_len > 0 && line_sep_len <= 2 {
+        println("  os.line_separator() = [${line_sep_len} char(s)]")
+        passed += 1
+    } otherwise {
+        println("  os.line_separator() unexpected length: ${line_sep_len}")
+        failed += 1
+    }
+
+    // Test os.dev_null
+    temp dev_null string = os.dev_null()
+    temp dev_null_ok bool = false
+    if is_win && dev_null == "NUL" {
+        println("  os.dev_null() = '${dev_null}' (Windows)")
+        dev_null_ok = true
+    }
+    if !is_win && dev_null == "/dev/null" {
+        println("  os.dev_null() = '${dev_null}' (Unix)")
+        dev_null_ok = true
+    }
+    if dev_null_ok {
+        passed += 1
+    } otherwise {
+        println("  os.dev_null() = '${dev_null}' (unexpected value for platform)")
+        failed += 1
+    }
+
+    // ============================================================================
+    // Test os.chdir (carefully - restore original directory)
+    // ============================================================================
+    println("")
+    println("  Directory Operations:")
+
+    temp original_dir, @ignore = os.cwd()
+    temp target_dir string = os.temp_dir()
+
+    temp chdir_ok, chdir_err = os.chdir(target_dir)
+    if chdir_err == nil {
+        temp new_cwd, new_cwd_err = os.cwd()
+        println("  os.chdir('${target_dir}') = success")
+        println("  Current dir after chdir: '${new_cwd}'")
+        passed += 1
+
+        // Restore original directory
+        temp restore_ok, restore_err = os.chdir(original_dir)
+        temp restored_cwd, restored_err = os.cwd()
+        println("  Restored to: '${restored_cwd}'")
+        passed += 1
+    } otherwise {
+        println("  os.chdir() = FAILED")
+        failed += 1
+    }
+
+    // Test chdir to invalid directory
+    temp bad_chdir_ok, bad_chdir_err = os.chdir("/nonexistent/path/12345")
+    if bad_chdir_err != nil {
+        println("  os.chdir(invalid) correctly returned error")
+        passed += 1
+    } otherwise {
+        println("  os.chdir(invalid) should have returned error")
         failed += 1
     }
 


### PR DESCRIPTION
## Summary
- Add new @os standard library module with 24 functions for operating system operations
- Environment: get_env, set_env, unset_env, env, args
- Process/System: exit, cwd, chdir, hostname, username, home_dir, temp_dir, pid, ppid
- Platform Detection: CURRENT_OS, MAC_OS, LINUX, WINDOWS constants + platform, arch, is_windows, is_linux, is_macos, num_cpu
- Platform Constants: line_separator, dev_null
- Consolidate error codes from E8xxx/E9xxx into E7xxx range

## Test plan
- [x] All 156 EZ comprehensive tests pass
- [x] All Go unit tests pass (new os_test.go with full coverage)
- [x] Verified OS constants work: `if os.CURRENT_OS == os.MAC_OS { ... }`