### PR TITLE
feat(stdlib): implement `@bytes` module for binary data operations

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -37,6 +37,7 @@ var validModules = map[string]bool{
 	"time":    true, // Time functions
 	"io":      true, // File system and I/O operations
 	"os":      true, // Operating system and environment
+	"bytes":   true, // Binary data operations
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/stdlib/bytes.go
+++ b/pkg/stdlib/bytes.go
@@ -1,0 +1,1040 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// createBytesError creates an Error struct for recoverable errors in tuple returns
+func createBytesError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}
+
+// BytesBuiltins contains the bytes module functions for binary data operations
+var BytesBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// Creation Functions
+	// ============================================================================
+
+	// Creates bytes from an array of integers (0-255)
+	"bytes.from_array": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_array() takes exactly 1 argument (array)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.from_array() requires an array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i, elem := range arr.Elements {
+				var val int64
+				switch e := elem.(type) {
+				case *object.Integer:
+					val = e.Value
+				case *object.Byte:
+					val = int64(e.Value)
+				default:
+					return &object.Error{Code: "E7004", Message: fmt.Sprintf("bytes.from_array() element %d must be an integer", i)}
+				}
+				if val < 0 || val > 255 {
+					return &object.Error{Code: "E3022", Message: fmt.Sprintf("bytes.from_array() element %d value %d out of range (0-255)", i, val)}
+				}
+				elements[i] = &object.Byte{Value: uint8(val)}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Creates bytes from a UTF-8 encoded string
+	"bytes.from_string": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_string() takes exactly 1 argument (string)"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "bytes.from_string() requires a string argument"}
+			}
+
+			data := []byte(str.Value)
+			elements := make([]object.Object, len(data))
+			for i, b := range data {
+				elements[i] = &object.Byte{Value: b}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Creates bytes from a hexadecimal string
+	// Returns (bytes, error)
+	"bytes.from_hex": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_hex() takes exactly 1 argument (hex string)"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "bytes.from_hex() requires a string argument"}
+			}
+
+			data, err := hex.DecodeString(str.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7014", fmt.Sprintf("bytes.from_hex() invalid hex string: %s", err.Error())),
+				}}
+			}
+
+			elements := make([]object.Object, len(data))
+			for i, b := range data {
+				elements[i] = &object.Byte{Value: b}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Array{Elements: elements, ElementType: "byte"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Creates bytes from a base64 encoded string
+	// Returns (bytes, error)
+	"bytes.from_base64": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_base64() takes exactly 1 argument (base64 string)"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "bytes.from_base64() requires a string argument"}
+			}
+
+			data, err := base64.StdEncoding.DecodeString(str.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7014", fmt.Sprintf("bytes.from_base64() invalid base64 string: %s", err.Error())),
+				}}
+			}
+
+			elements := make([]object.Object, len(data))
+			for i, b := range data {
+				elements[i] = &object.Byte{Value: b}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Array{Elements: elements, ElementType: "byte"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Conversion Functions
+	// ============================================================================
+
+	// Converts bytes to UTF-8 string
+	"bytes.to_string": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_string() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.to_string() requires a byte array argument"}
+			}
+
+			data := make([]byte, len(arr.Elements))
+			for i, elem := range arr.Elements {
+				b, ok := elem.(*object.Byte)
+				if !ok {
+					// Try integer for backwards compatibility
+					if intVal, ok := elem.(*object.Integer); ok {
+						data[i] = byte(intVal.Value)
+						continue
+					}
+					return &object.Error{Code: "E7002", Message: "bytes.to_string() requires a byte array"}
+				}
+				data[i] = b.Value
+			}
+			return &object.String{Value: string(data)}
+		},
+	},
+
+	// Converts bytes to array of integers
+	"bytes.to_array": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_array() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.to_array() requires a byte array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i, elem := range arr.Elements {
+				switch e := elem.(type) {
+				case *object.Byte:
+					elements[i] = &object.Integer{Value: int64(e.Value)}
+				case *object.Integer:
+					elements[i] = e
+				default:
+					return &object.Error{Code: "E7002", Message: "bytes.to_array() requires a byte array"}
+				}
+			}
+			return &object.Array{Elements: elements, ElementType: "int"}
+		},
+	},
+
+	// Converts bytes to lowercase hexadecimal string
+	"bytes.to_hex": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_hex() takes exactly 1 argument (bytes)"}
+			}
+			data, err := bytesArgToSlice(args[0], "bytes.to_hex()")
+			if err != nil {
+				return err
+			}
+			return &object.String{Value: hex.EncodeToString(data)}
+		},
+	},
+
+	// Converts bytes to uppercase hexadecimal string
+	"bytes.to_hex_upper": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_hex_upper() takes exactly 1 argument (bytes)"}
+			}
+			data, err := bytesArgToSlice(args[0], "bytes.to_hex_upper()")
+			if err != nil {
+				return err
+			}
+			hexStr := hex.EncodeToString(data)
+			upper := ""
+			for _, c := range hexStr {
+				if c >= 'a' && c <= 'f' {
+					upper += string(c - 32)
+				} else {
+					upper += string(c)
+				}
+			}
+			return &object.String{Value: upper}
+		},
+	},
+
+	// Converts bytes to base64 encoded string
+	"bytes.to_base64": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_base64() takes exactly 1 argument (bytes)"}
+			}
+			data, err := bytesArgToSlice(args[0], "bytes.to_base64()")
+			if err != nil {
+				return err
+			}
+			return &object.String{Value: base64.StdEncoding.EncodeToString(data)}
+		},
+	},
+
+	// ============================================================================
+	// Operations
+	// ============================================================================
+
+	// Extracts a portion of bytes (end is exclusive, supports negative indices)
+	"bytes.slice": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.slice() takes exactly 3 arguments (bytes, start, end)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.slice() requires a byte array as first argument"}
+			}
+			startArg, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.slice() requires an integer start index"}
+			}
+			endArg, ok := args[2].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.slice() requires an integer end index"}
+			}
+
+			length := int64(len(arr.Elements))
+			start := startArg.Value
+			end := endArg.Value
+
+			// Handle negative indices
+			if start < 0 {
+				start = length + start
+			}
+			if end < 0 {
+				end = length + end
+			}
+
+			// Clamp to valid range
+			if start < 0 {
+				start = 0
+			}
+			if end > length {
+				end = length
+			}
+			if start > end {
+				start = end
+			}
+
+			elements := make([]object.Object, end-start)
+			copy(elements, arr.Elements[start:end])
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Concatenates two byte sequences
+	"bytes.concat": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.concat() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			arr1, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.concat() requires byte arrays"}
+			}
+			arr2, ok := args[1].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.concat() requires byte arrays"}
+			}
+
+			elements := make([]object.Object, len(arr1.Elements)+len(arr2.Elements))
+			copy(elements, arr1.Elements)
+			copy(elements[len(arr1.Elements):], arr2.Elements)
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Joins array of bytes with separator
+	"bytes.join": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.join() takes exactly 2 arguments (array, separator)"}
+			}
+			partsArr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.join() requires an array of byte arrays as first argument"}
+			}
+			sep, ok := args[1].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.join() requires a byte array separator"}
+			}
+
+			if len(partsArr.Elements) == 0 {
+				return &object.Array{Elements: []object.Object{}, ElementType: "byte"}
+			}
+
+			var result []object.Object
+			for i, part := range partsArr.Elements {
+				partArr, ok := part.(*object.Array)
+				if !ok {
+					return &object.Error{Code: "E7002", Message: "bytes.join() array elements must be byte arrays"}
+				}
+				result = append(result, partArr.Elements...)
+				if i < len(partsArr.Elements)-1 {
+					result = append(result, sep.Elements...)
+				}
+			}
+			return &object.Array{Elements: result, ElementType: "byte"}
+		},
+	},
+
+	// Splits bytes by separator
+	"bytes.split": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.split() takes exactly 2 arguments (bytes, separator)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.split()")
+			if errObj != nil {
+				return errObj
+			}
+			sep, errObj := bytesArgToSlice(args[1], "bytes.split()")
+			if errObj != nil {
+				return errObj
+			}
+
+			parts := bytes.Split(data, sep)
+			elements := make([]object.Object, len(parts))
+			for i, part := range parts {
+				partElements := make([]object.Object, len(part))
+				for j, b := range part {
+					partElements[j] = &object.Byte{Value: b}
+				}
+				elements[i] = &object.Array{Elements: partElements, ElementType: "byte"}
+			}
+			return &object.Array{Elements: elements}
+		},
+	},
+
+	// Checks if bytes contain a pattern
+	"bytes.contains": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.contains() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.contains()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.contains()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.Contains(data, pattern) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Finds first index of pattern, or -1 if not found
+	"bytes.index": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.index() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.index()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.index()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.Index(data, pattern))}
+		},
+	},
+
+	// Finds last index of pattern, or -1 if not found
+	"bytes.last_index": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.last_index() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.last_index()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.last_index()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.LastIndex(data, pattern))}
+		},
+	},
+
+	// Counts non-overlapping occurrences of pattern
+	"bytes.count": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.count() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.count()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.count()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.Count(data, pattern))}
+		},
+	},
+
+	// Lexicographically compares two byte sequences (-1, 0, 1)
+	"bytes.compare": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.compare() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.compare()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.compare()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.Compare(data1, data2))}
+		},
+	},
+
+	// Checks if two byte sequences are equal
+	"bytes.equals": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.equals() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.equals()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.equals()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.Equal(data1, data2) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// ============================================================================
+	// Inspection Functions
+	// ============================================================================
+
+	// Checks if bytes are empty (length 0)
+	"bytes.is_empty": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.is_empty() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.is_empty() requires a byte array argument"}
+			}
+
+			if len(arr.Elements) == 0 {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Checks if bytes start with prefix
+	"bytes.starts_with": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.starts_with() takes exactly 2 arguments (bytes, prefix)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.starts_with()")
+			if errObj != nil {
+				return errObj
+			}
+			prefix, errObj := bytesArgToSlice(args[1], "bytes.starts_with()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.HasPrefix(data, prefix) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Checks if bytes end with suffix
+	"bytes.ends_with": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.ends_with() takes exactly 2 arguments (bytes, suffix)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.ends_with()")
+			if errObj != nil {
+				return errObj
+			}
+			suffix, errObj := bytesArgToSlice(args[1], "bytes.ends_with()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.HasSuffix(data, suffix) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// ============================================================================
+	// Manipulation Functions
+	// ============================================================================
+
+	// Returns reversed copy of bytes
+	"bytes.reverse": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.reverse() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.reverse() requires a byte array argument"}
+			}
+
+			length := len(arr.Elements)
+			elements := make([]object.Object, length)
+			for i, elem := range arr.Elements {
+				elements[length-1-i] = elem
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Repeats bytes N times
+	"bytes.repeat": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.repeat() takes exactly 2 arguments (bytes, count)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.repeat() requires a byte array as first argument"}
+			}
+			count, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.repeat() requires an integer count"}
+			}
+			if count.Value < 0 {
+				return &object.Error{Code: "E7011", Message: "bytes.repeat() count cannot be negative"}
+			}
+
+			elements := make([]object.Object, 0, len(arr.Elements)*int(count.Value))
+			for i := int64(0); i < count.Value; i++ {
+				elements = append(elements, arr.Elements...)
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Replaces all occurrences of old with new
+	"bytes.replace": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.replace() takes exactly 3 arguments (bytes, old, new)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.replace()")
+			if errObj != nil {
+				return errObj
+			}
+			old, errObj := bytesArgToSlice(args[1], "bytes.replace()")
+			if errObj != nil {
+				return errObj
+			}
+			newBytes, errObj := bytesArgToSlice(args[2], "bytes.replace()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.ReplaceAll(data, old, newBytes)
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Replaces first N occurrences of old with new
+	"bytes.replace_n": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 4 {
+				return &object.Error{Code: "E7001", Message: "bytes.replace_n() takes exactly 4 arguments (bytes, old, new, n)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.replace_n()")
+			if errObj != nil {
+				return errObj
+			}
+			old, errObj := bytesArgToSlice(args[1], "bytes.replace_n()")
+			if errObj != nil {
+				return errObj
+			}
+			newBytes, errObj := bytesArgToSlice(args[2], "bytes.replace_n()")
+			if errObj != nil {
+				return errObj
+			}
+			n, ok := args[3].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.replace_n() requires an integer count"}
+			}
+
+			result := bytes.Replace(data, old, newBytes, int(n.Value))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Removes leading and trailing bytes that appear in cutset
+	"bytes.trim": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.trim() takes exactly 2 arguments (bytes, cutset)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.trim()")
+			if errObj != nil {
+				return errObj
+			}
+			cutset, errObj := bytesArgToSlice(args[1], "bytes.trim()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.Trim(data, string(cutset))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Removes leading bytes that appear in cutset
+	"bytes.trim_left": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.trim_left() takes exactly 2 arguments (bytes, cutset)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.trim_left()")
+			if errObj != nil {
+				return errObj
+			}
+			cutset, errObj := bytesArgToSlice(args[1], "bytes.trim_left()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.TrimLeft(data, string(cutset))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Removes trailing bytes that appear in cutset
+	"bytes.trim_right": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.trim_right() takes exactly 2 arguments (bytes, cutset)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.trim_right()")
+			if errObj != nil {
+				return errObj
+			}
+			cutset, errObj := bytesArgToSlice(args[1], "bytes.trim_right()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.TrimRight(data, string(cutset))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Pads bytes on the left to reach specified length
+	"bytes.pad_left": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.pad_left() takes exactly 3 arguments (bytes, length, pad_byte)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.pad_left() requires a byte array as first argument"}
+			}
+			length, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.pad_left() requires an integer length"}
+			}
+			padByte, err := getByteValue(args[2], "bytes.pad_left()")
+			if err != nil {
+				return err
+			}
+
+			currentLen := int64(len(arr.Elements))
+			if currentLen >= length.Value {
+				// Return copy of original
+				elements := make([]object.Object, len(arr.Elements))
+				copy(elements, arr.Elements)
+				return &object.Array{Elements: elements, ElementType: "byte"}
+			}
+
+			padCount := length.Value - currentLen
+			elements := make([]object.Object, length.Value)
+			for i := int64(0); i < padCount; i++ {
+				elements[i] = &object.Byte{Value: padByte}
+			}
+			copy(elements[padCount:], arr.Elements)
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Pads bytes on the right to reach specified length
+	"bytes.pad_right": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.pad_right() takes exactly 3 arguments (bytes, length, pad_byte)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.pad_right() requires a byte array as first argument"}
+			}
+			length, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.pad_right() requires an integer length"}
+			}
+			padByte, err := getByteValue(args[2], "bytes.pad_right()")
+			if err != nil {
+				return err
+			}
+
+			currentLen := int64(len(arr.Elements))
+			if currentLen >= length.Value {
+				// Return copy of original
+				elements := make([]object.Object, len(arr.Elements))
+				copy(elements, arr.Elements)
+				return &object.Array{Elements: elements, ElementType: "byte"}
+			}
+
+			elements := make([]object.Object, length.Value)
+			copy(elements, arr.Elements)
+			for i := currentLen; i < length.Value; i++ {
+				elements[i] = &object.Byte{Value: padByte}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// ============================================================================
+	// Bitwise Operations
+	// ============================================================================
+
+	// Bitwise AND of two byte sequences (must be same length)
+	"bytes.and": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.and() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.and()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.and()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if len(data1) != len(data2) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7010", "bytes.and() requires byte arrays of equal length"),
+				}}
+			}
+
+			result := make([]byte, len(data1))
+			for i := range data1 {
+				result[i] = data1[i] & data2[i]
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToByteArray(result),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Bitwise OR of two byte sequences (must be same length)
+	"bytes.or": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.or() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.or()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.or()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if len(data1) != len(data2) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7010", "bytes.or() requires byte arrays of equal length"),
+				}}
+			}
+
+			result := make([]byte, len(data1))
+			for i := range data1 {
+				result[i] = data1[i] | data2[i]
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToByteArray(result),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Bitwise XOR of two byte sequences (must be same length)
+	"bytes.xor": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.xor() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.xor()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.xor()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if len(data1) != len(data2) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7010", "bytes.xor() requires byte arrays of equal length"),
+				}}
+			}
+
+			result := make([]byte, len(data1))
+			for i := range data1 {
+				result[i] = data1[i] ^ data2[i]
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToByteArray(result),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Bitwise NOT (complement) of bytes
+	"bytes.not": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.not() takes exactly 1 argument (bytes)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.not()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := make([]byte, len(data))
+			for i := range data {
+				result[i] = ^data[i]
+			}
+			return sliceToByteArray(result)
+		},
+	},
+
+	// ============================================================================
+	// Utility Functions
+	// ============================================================================
+
+	// Fills all bytes with a single value
+	"bytes.fill": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.fill() takes exactly 2 arguments (bytes, value)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.fill() requires a byte array as first argument"}
+			}
+			fillByte, err := getByteValue(args[1], "bytes.fill()")
+			if err != nil {
+				return err
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i := range elements {
+				elements[i] = &object.Byte{Value: fillByte}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Creates a copy of bytes
+	"bytes.copy": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.copy() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.copy() requires a byte array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			copy(elements, arr.Elements)
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Fills all bytes with zero (for securely clearing sensitive data)
+	"bytes.zero": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.zero() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.zero() requires a byte array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i := range elements {
+				elements[i] = &object.Byte{Value: 0}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+}
+
+// Helper function to convert a byte array argument to []byte
+func bytesArgToSlice(arg object.Object, funcName string) ([]byte, *object.Error) {
+	arr, ok := arg.(*object.Array)
+	if !ok {
+		return nil, &object.Error{Code: "E7002", Message: fmt.Sprintf("%s requires a byte array argument", funcName)}
+	}
+
+	data := make([]byte, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		switch e := elem.(type) {
+		case *object.Byte:
+			data[i] = e.Value
+		case *object.Integer:
+			data[i] = byte(e.Value)
+		default:
+			return nil, &object.Error{Code: "E7002", Message: fmt.Sprintf("%s requires a byte array", funcName)}
+		}
+	}
+	return data, nil
+}
+
+// Helper function to convert []byte to object.Array of Bytes
+func sliceToByteArray(data []byte) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, b := range data {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper function to get a byte value from an object
+func getByteValue(arg object.Object, funcName string) (uint8, *object.Error) {
+	switch v := arg.(type) {
+	case *object.Byte:
+		return v.Value, nil
+	case *object.Integer:
+		if v.Value < 0 || v.Value > 255 {
+			return 0, &object.Error{Code: "E3021", Message: fmt.Sprintf("%s byte value %d out of range (0-255)", funcName, v.Value)}
+		}
+		return uint8(v.Value), nil
+	default:
+		return 0, &object.Error{Code: "E7004", Message: fmt.Sprintf("%s requires a byte or integer value", funcName)}
+	}
+}

--- a/pkg/stdlib/bytes_test.go
+++ b/pkg/stdlib/bytes_test.go
@@ -1,0 +1,720 @@
+package stdlib
+
+import (
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// Helper to create a byte array from Go []byte
+func makeByteArray(data []byte) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, b := range data {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper to create an integer array
+func makeIntArray(data []int64) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, v := range data {
+		elements[i] = &object.Integer{Value: v}
+	}
+	return &object.Array{Elements: elements}
+}
+
+// Helper to extract byte slice from result
+func getByteSlice(obj object.Object) []byte {
+	arr, ok := obj.(*object.Array)
+	if !ok {
+		return nil
+	}
+	result := make([]byte, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		switch e := elem.(type) {
+		case *object.Byte:
+			result[i] = e.Value
+		case *object.Integer:
+			result[i] = byte(e.Value)
+		}
+	}
+	return result
+}
+
+// ============================================================================
+// Creation Functions Tests
+// ============================================================================
+
+func TestBytesFromArray(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_array"].Fn
+
+	tests := []struct {
+		name     string
+		input    []int64
+		expected []byte
+		wantErr  bool
+	}{
+		{"empty array", []int64{}, []byte{}, false},
+		{"simple bytes", []int64{72, 101, 108, 108, 111}, []byte("Hello"), false},
+		{"boundary values", []int64{0, 127, 255}, []byte{0, 127, 255}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fn(makeIntArray(tt.input))
+			if tt.wantErr {
+				if _, ok := result.(*object.Error); !ok {
+					t.Errorf("expected error, got %T", result)
+				}
+				return
+			}
+			got := getByteSlice(result)
+			if string(got) != string(tt.expected) {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBytesFromArrayErrors(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_array"].Fn
+
+	// Value out of range
+	result := fn(makeIntArray([]int64{256}))
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for value > 255, got %T", result)
+	}
+
+	// Negative value
+	result = fn(makeIntArray([]int64{-1}))
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for negative value, got %T", result)
+	}
+
+	// Wrong argument type
+	result = fn(&object.String{Value: "not an array"})
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for wrong type, got %T", result)
+	}
+
+	// Wrong argument count
+	result = fn()
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for no args, got %T", result)
+	}
+}
+
+func TestBytesFromString(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_string"].Fn
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []byte
+	}{
+		{"empty string", "", []byte{}},
+		{"hello", "Hello", []byte("Hello")},
+		{"unicode", "こんにちは", []byte("こんにちは")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fn(&object.String{Value: tt.input})
+			got := getByteSlice(result)
+			if string(got) != string(tt.expected) {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBytesFromHex(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_hex"].Fn
+
+	// Valid hex
+	result := fn(&object.String{Value: "48656c6c6f"})
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	got := getByteSlice(rv.Values[0])
+	if string(got) != "Hello" {
+		t.Errorf("got %s, want Hello", string(got))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Errorf("expected nil error, got %v", rv.Values[1])
+	}
+
+	// Invalid hex
+	result = fn(&object.String{Value: "GGGG"})
+	rv, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if rv.Values[0] != object.NIL {
+		t.Errorf("expected nil value for invalid hex")
+	}
+	if _, ok := rv.Values[1].(*object.Struct); !ok {
+		t.Errorf("expected error struct, got %T", rv.Values[1])
+	}
+}
+
+func TestBytesFromBase64(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_base64"].Fn
+
+	// Valid base64
+	result := fn(&object.String{Value: "SGVsbG8="})
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	got := getByteSlice(rv.Values[0])
+	if string(got) != "Hello" {
+		t.Errorf("got %s, want Hello", string(got))
+	}
+
+	// Invalid base64
+	result = fn(&object.String{Value: "!!!!"})
+	rv, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if rv.Values[0] != object.NIL {
+		t.Errorf("expected nil value for invalid base64")
+	}
+}
+
+// ============================================================================
+// Conversion Functions Tests
+// ============================================================================
+
+func TestBytesToString(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_string"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "Hello" {
+		t.Errorf("got %s, want Hello", str.Value)
+	}
+}
+
+func TestBytesToArray(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_array"].Fn
+
+	result := fn(makeByteArray([]byte{72, 101}))
+	arr, ok := result.(*object.Array)
+	if !ok {
+		t.Fatalf("expected Array, got %T", result)
+	}
+	if len(arr.Elements) != 2 {
+		t.Errorf("got len %d, want 2", len(arr.Elements))
+	}
+	if arr.Elements[0].(*object.Integer).Value != 72 {
+		t.Errorf("got %d, want 72", arr.Elements[0].(*object.Integer).Value)
+	}
+}
+
+func TestBytesToHex(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_hex"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "48656c6c6f" {
+		t.Errorf("got %s, want 48656c6c6f", str.Value)
+	}
+}
+
+func TestBytesToHexUpper(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_hex_upper"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "48656C6C6F" {
+		t.Errorf("got %s, want 48656C6C6F", str.Value)
+	}
+}
+
+func TestBytesToBase64(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_base64"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "SGVsbG8=" {
+		t.Errorf("got %s, want SGVsbG8=", str.Value)
+	}
+}
+
+// ============================================================================
+// Operations Tests
+// ============================================================================
+
+func TestBytesSlice(t *testing.T) {
+	fn := BytesBuiltins["bytes.slice"].Fn
+
+	input := makeByteArray([]byte("Hello"))
+
+	// Normal slice
+	result := fn(input, &object.Integer{Value: 1}, &object.Integer{Value: 4})
+	got := getByteSlice(result)
+	if string(got) != "ell" {
+		t.Errorf("got %s, want ell", string(got))
+	}
+
+	// Negative indices
+	result = fn(input, &object.Integer{Value: -3}, &object.Integer{Value: -1})
+	got = getByteSlice(result)
+	if string(got) != "ll" {
+		t.Errorf("got %s, want ll", string(got))
+	}
+}
+
+func TestBytesConcat(t *testing.T) {
+	fn := BytesBuiltins["bytes.concat"].Fn
+
+	a := makeByteArray([]byte("Hello"))
+	b := makeByteArray([]byte(" World"))
+
+	result := fn(a, b)
+	got := getByteSlice(result)
+	if string(got) != "Hello World" {
+		t.Errorf("got %s, want Hello World", string(got))
+	}
+}
+
+func TestBytesContains(t *testing.T) {
+	fn := BytesBuiltins["bytes.contains"].Fn
+
+	haystack := makeByteArray([]byte("Hello World"))
+	needle := makeByteArray([]byte("World"))
+	missing := makeByteArray([]byte("xyz"))
+
+	result := fn(haystack, needle)
+	if result != object.TRUE {
+		t.Errorf("expected true for contains")
+	}
+
+	result = fn(haystack, missing)
+	if result != object.FALSE {
+		t.Errorf("expected false for not contains")
+	}
+}
+
+func TestBytesIndex(t *testing.T) {
+	fn := BytesBuiltins["bytes.index"].Fn
+
+	haystack := makeByteArray([]byte("Hello World"))
+	needle := makeByteArray([]byte("World"))
+	missing := makeByteArray([]byte("xyz"))
+
+	result := fn(haystack, needle)
+	idx := result.(*object.Integer).Value
+	if idx != 6 {
+		t.Errorf("got %d, want 6", idx)
+	}
+
+	result = fn(haystack, missing)
+	idx = result.(*object.Integer).Value
+	if idx != -1 {
+		t.Errorf("got %d, want -1", idx)
+	}
+}
+
+func TestBytesLastIndex(t *testing.T) {
+	fn := BytesBuiltins["bytes.last_index"].Fn
+
+	haystack := makeByteArray([]byte("abcabc"))
+	needle := makeByteArray([]byte("bc"))
+
+	result := fn(haystack, needle)
+	idx := result.(*object.Integer).Value
+	if idx != 4 {
+		t.Errorf("got %d, want 4", idx)
+	}
+}
+
+func TestBytesCount(t *testing.T) {
+	fn := BytesBuiltins["bytes.count"].Fn
+
+	haystack := makeByteArray([]byte("abababab"))
+	needle := makeByteArray([]byte("ab"))
+
+	result := fn(haystack, needle)
+	count := result.(*object.Integer).Value
+	if count != 4 {
+		t.Errorf("got %d, want 4", count)
+	}
+}
+
+func TestBytesCompare(t *testing.T) {
+	fn := BytesBuiltins["bytes.compare"].Fn
+
+	a := makeByteArray([]byte("aaa"))
+	b := makeByteArray([]byte("bbb"))
+
+	result := fn(a, b)
+	if result.(*object.Integer).Value != -1 {
+		t.Errorf("expected -1 for a < b")
+	}
+
+	result = fn(b, a)
+	if result.(*object.Integer).Value != 1 {
+		t.Errorf("expected 1 for b > a")
+	}
+
+	result = fn(a, a)
+	if result.(*object.Integer).Value != 0 {
+		t.Errorf("expected 0 for a == a")
+	}
+}
+
+func TestBytesEquals(t *testing.T) {
+	fn := BytesBuiltins["bytes.equals"].Fn
+
+	a := makeByteArray([]byte("Hello"))
+	b := makeByteArray([]byte("Hello"))
+	c := makeByteArray([]byte("World"))
+
+	if fn(a, b) != object.TRUE {
+		t.Errorf("expected true for equal bytes")
+	}
+
+	if fn(a, c) != object.FALSE {
+		t.Errorf("expected false for different bytes")
+	}
+}
+
+// ============================================================================
+// Inspection Tests
+// ============================================================================
+
+func TestBytesIsEmpty(t *testing.T) {
+	fn := BytesBuiltins["bytes.is_empty"].Fn
+
+	empty := makeByteArray([]byte{})
+	notEmpty := makeByteArray([]byte("Hi"))
+
+	if fn(empty) != object.TRUE {
+		t.Errorf("expected true for empty")
+	}
+
+	if fn(notEmpty) != object.FALSE {
+		t.Errorf("expected false for not empty")
+	}
+}
+
+func TestBytesStartsWith(t *testing.T) {
+	fn := BytesBuiltins["bytes.starts_with"].Fn
+
+	data := makeByteArray([]byte("Hello World"))
+	prefix := makeByteArray([]byte("Hello"))
+	notPrefix := makeByteArray([]byte("World"))
+
+	if fn(data, prefix) != object.TRUE {
+		t.Errorf("expected true for starts_with")
+	}
+
+	if fn(data, notPrefix) != object.FALSE {
+		t.Errorf("expected false for not starts_with")
+	}
+}
+
+func TestBytesEndsWith(t *testing.T) {
+	fn := BytesBuiltins["bytes.ends_with"].Fn
+
+	data := makeByteArray([]byte("Hello World"))
+	suffix := makeByteArray([]byte("World"))
+	notSuffix := makeByteArray([]byte("Hello"))
+
+	if fn(data, suffix) != object.TRUE {
+		t.Errorf("expected true for ends_with")
+	}
+
+	if fn(data, notSuffix) != object.FALSE {
+		t.Errorf("expected false for not ends_with")
+	}
+}
+
+// ============================================================================
+// Manipulation Tests
+// ============================================================================
+
+func TestBytesReverse(t *testing.T) {
+	fn := BytesBuiltins["bytes.reverse"].Fn
+
+	input := makeByteArray([]byte("Hello"))
+	result := fn(input)
+	got := getByteSlice(result)
+	if string(got) != "olleH" {
+		t.Errorf("got %s, want olleH", string(got))
+	}
+}
+
+func TestBytesRepeat(t *testing.T) {
+	fn := BytesBuiltins["bytes.repeat"].Fn
+
+	input := makeByteArray([]byte("ab"))
+
+	result := fn(input, &object.Integer{Value: 3})
+	got := getByteSlice(result)
+	if string(got) != "ababab" {
+		t.Errorf("got %s, want ababab", string(got))
+	}
+
+	result = fn(input, &object.Integer{Value: 0})
+	got = getByteSlice(result)
+	if len(got) != 0 {
+		t.Errorf("got len %d, want 0", len(got))
+	}
+}
+
+func TestBytesReplace(t *testing.T) {
+	fn := BytesBuiltins["bytes.replace"].Fn
+
+	input := makeByteArray([]byte("hello hello"))
+	old := makeByteArray([]byte("hello"))
+	new := makeByteArray([]byte("hi"))
+
+	result := fn(input, old, new)
+	got := getByteSlice(result)
+	if string(got) != "hi hi" {
+		t.Errorf("got %s, want hi hi", string(got))
+	}
+}
+
+func TestBytesReplaceN(t *testing.T) {
+	fn := BytesBuiltins["bytes.replace_n"].Fn
+
+	input := makeByteArray([]byte("hello hello hello"))
+	old := makeByteArray([]byte("hello"))
+	new := makeByteArray([]byte("hi"))
+
+	result := fn(input, old, new, &object.Integer{Value: 2})
+	got := getByteSlice(result)
+	if string(got) != "hi hi hello" {
+		t.Errorf("got %s, want hi hi hello", string(got))
+	}
+}
+
+func TestBytesTrim(t *testing.T) {
+	fn := BytesBuiltins["bytes.trim"].Fn
+
+	input := makeByteArray([]byte{0, 0, 65, 66, 0, 0})
+	cutset := makeByteArray([]byte{0})
+
+	result := fn(input, cutset)
+	got := getByteSlice(result)
+	if string(got) != "AB" {
+		t.Errorf("got %v, want AB", got)
+	}
+}
+
+func TestBytesPadLeft(t *testing.T) {
+	fn := BytesBuiltins["bytes.pad_left"].Fn
+
+	input := makeByteArray([]byte("Hi"))
+
+	result := fn(input, &object.Integer{Value: 5}, &object.Integer{Value: 0})
+	got := getByteSlice(result)
+	expected := []byte{0, 0, 0, 'H', 'i'}
+	if string(got) != string(expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+
+	// No padding needed
+	result = fn(input, &object.Integer{Value: 2}, &object.Integer{Value: 0})
+	got = getByteSlice(result)
+	if string(got) != "Hi" {
+		t.Errorf("got %s, want Hi", string(got))
+	}
+}
+
+func TestBytesPadRight(t *testing.T) {
+	fn := BytesBuiltins["bytes.pad_right"].Fn
+
+	input := makeByteArray([]byte("Hi"))
+
+	result := fn(input, &object.Integer{Value: 5}, &object.Integer{Value: 0})
+	got := getByteSlice(result)
+	expected := []byte{'H', 'i', 0, 0, 0}
+	if string(got) != string(expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+// ============================================================================
+// Bitwise Operations Tests
+// ============================================================================
+
+func TestBytesAnd(t *testing.T) {
+	fn := BytesBuiltins["bytes.and"].Fn
+
+	a := makeByteArray([]byte{0xFF, 0x0F})
+	b := makeByteArray([]byte{0xF0, 0xFF})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	got := getByteSlice(rv.Values[0])
+	expected := []byte{0xF0, 0x0F}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestBytesAndLengthMismatch(t *testing.T) {
+	fn := BytesBuiltins["bytes.and"].Fn
+
+	a := makeByteArray([]byte{0xFF})
+	b := makeByteArray([]byte{0xF0, 0xFF})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	if rv.Values[0] != object.NIL {
+		t.Errorf("expected nil for length mismatch")
+	}
+	if _, ok := rv.Values[1].(*object.Struct); !ok {
+		t.Errorf("expected error struct, got %T", rv.Values[1])
+	}
+}
+
+func TestBytesOr(t *testing.T) {
+	fn := BytesBuiltins["bytes.or"].Fn
+
+	a := makeByteArray([]byte{0xF0, 0x00})
+	b := makeByteArray([]byte{0x0F, 0xFF})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	got := getByteSlice(rv.Values[0])
+	expected := []byte{0xFF, 0xFF}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestBytesXor(t *testing.T) {
+	fn := BytesBuiltins["bytes.xor"].Fn
+
+	a := makeByteArray([]byte{0xFF, 0x00})
+	b := makeByteArray([]byte{0xF0, 0x0F})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	got := getByteSlice(rv.Values[0])
+	expected := []byte{0x0F, 0x0F}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestBytesNot(t *testing.T) {
+	fn := BytesBuiltins["bytes.not"].Fn
+
+	a := makeByteArray([]byte{0xFF, 0x00})
+
+	result := fn(a)
+	got := getByteSlice(result)
+	expected := []byte{0x00, 0xFF}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+// ============================================================================
+// Utility Tests
+// ============================================================================
+
+func TestBytesFill(t *testing.T) {
+	fn := BytesBuiltins["bytes.fill"].Fn
+
+	input := makeByteArray([]byte{1, 2, 3, 4, 5})
+
+	result := fn(input, &object.Integer{Value: 0xFF})
+	got := getByteSlice(result)
+	for i, b := range got {
+		if b != 0xFF {
+			t.Errorf("got[%d] = %d, want 255", i, b)
+		}
+	}
+}
+
+func TestBytesCopy(t *testing.T) {
+	fn := BytesBuiltins["bytes.copy"].Fn
+
+	input := makeByteArray([]byte("Hello"))
+
+	result := fn(input)
+	arr := result.(*object.Array)
+
+	// Verify it's a copy (different slice)
+	if &arr.Elements == &input.Elements {
+		t.Errorf("expected different slice, got same reference")
+	}
+
+	got := getByteSlice(result)
+	if string(got) != "Hello" {
+		t.Errorf("got %s, want Hello", string(got))
+	}
+}
+
+func TestBytesZero(t *testing.T) {
+	fn := BytesBuiltins["bytes.zero"].Fn
+
+	input := makeByteArray([]byte("secret"))
+
+	result := fn(input)
+	got := getByteSlice(result)
+	for i, b := range got {
+		if b != 0 {
+			t.Errorf("got[%d] = %d, want 0", i, b)
+		}
+	}
+}
+
+// ============================================================================
+// Split and Join Tests
+// ============================================================================
+
+func TestBytesSplit(t *testing.T) {
+	fn := BytesBuiltins["bytes.split"].Fn
+
+	input := makeByteArray([]byte("a,b,c"))
+	sep := makeByteArray([]byte(","))
+
+	result := fn(input, sep)
+	arr := result.(*object.Array)
+	if len(arr.Elements) != 3 {
+		t.Errorf("got %d parts, want 3", len(arr.Elements))
+	}
+}
+
+func TestBytesJoin(t *testing.T) {
+	fn := BytesBuiltins["bytes.join"].Fn
+
+	parts := &object.Array{
+		Elements: []object.Object{
+			makeByteArray([]byte("a")),
+			makeByteArray([]byte("b")),
+			makeByteArray([]byte("c")),
+		},
+	}
+	sep := makeByteArray([]byte("-"))
+
+	result := fn(parts, sep)
+	got := getByteSlice(result)
+	if string(got) != "a-b-c" {
+		t.Errorf("got %s, want a-b-c", string(got))
+	}
+}

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -40,6 +40,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range OSBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range BytesBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }


### PR DESCRIPTION
## Summary

Implements the `@bytes` standard library module for working with raw binary data, as specified in issue #250.

## Functions Implemented (36 total)

### Creation
- `bytes.from_array(arr)` - from integer array (0-255)
- `bytes.from_string(s)` - from UTF-8 string
- `bytes.from_hex(s)` - from hex string (returns tuple)
- `bytes.from_base64(s)` - from base64 (returns tuple)

### Conversion
- `bytes.to_string(b)` - to UTF-8 string
- `bytes.to_array(b)` - to integer array
- `bytes.to_hex(b)` - to lowercase hex
- `bytes.to_hex_upper(b)` - to uppercase hex
- `bytes.to_base64(b)` - to base64

### Operations
- `bytes.slice(b, start, end)` - extract portion (supports negative indices)
- `bytes.concat(b1, b2)` - concatenate
- `bytes.join(arr, sep)` - join with separator
- `bytes.split(b, sep)` - split by separator
- `bytes.contains(b, pattern)` - check contains
- `bytes.index(b, pattern)` - find first index
- `bytes.last_index(b, pattern)` - find last index
- `bytes.count(b, pattern)` - count occurrences
- `bytes.compare(b1, b2)` - lexicographic compare (-1, 0, 1)
- `bytes.equals(b1, b2)` - check equality

### Inspection
- `bytes.is_empty(b)` - check if empty
- `bytes.starts_with(b, prefix)` - check prefix
- `bytes.ends_with(b, suffix)` - check suffix

### Manipulation
- `bytes.reverse(b)` - reverse copy
- `bytes.repeat(b, n)` - repeat N times
- `bytes.replace(b, old, new)` - replace all
- `bytes.replace_n(b, old, new, n)` - replace first N
- `bytes.trim(b, cutset)` - trim both ends
- `bytes.trim_left(b, cutset)` - trim left
- `bytes.trim_right(b, cutset)` - trim right
- `bytes.pad_left(b, len, byte)` - pad left
- `bytes.pad_right(b, len, byte)` - pad right

### Bitwise
- `bytes.and(b1, b2)` - bitwise AND (returns tuple, requires equal length)
- `bytes.or(b1, b2)` - bitwise OR (returns tuple, requires equal length)
- `bytes.xor(b1, b2)` - bitwise XOR (returns tuple, requires equal length)
- `bytes.not(b)` - bitwise NOT

### Utility
- `bytes.fill(b, value)` - fill with value
- `bytes.copy(b)` - create copy
- `bytes.zero(b)` - fill with zeros (security feature)

## Test Plan

- [x] 38 Go unit tests in `pkg/stdlib/bytes_test.go`
- [x] All existing tests pass
- [x] Manual integration testing with EZ test file

## Notes

- `bytes.new(size)` was intentionally omitted - use `temp arr [byte] = {}` instead
- Error handling uses `object.Struct` for recoverable errors in tuples (consistent with @io)
- Follows existing stdlib patterns from @io and @os modules

Closes #250