### PR TITLE
Feature: Add support for byte/byte array types / Add `@io`, `@os`, and `@bytes` stdlibs

### DIFF
--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -403,11 +403,11 @@ func TestProgramStructure(t *testing.T) {
 
 func TestVariableDeclarationStructure(t *testing.T) {
 	v := &VariableDeclaration{
-		Token:    tok(tokenizer.TEMP, "temp"),
-		Name:     &Label{Value: "x"},
-		TypeName: "int",
-		Value:    &IntegerValue{Value: 42},
-		Mutable:  true,
+		Token:      tok(tokenizer.TEMP, "temp"),
+		Name:       &Label{Value: "x"},
+		TypeName:   "int",
+		Value:      &IntegerValue{Value: 42},
+		Mutable:    true,
 		Visibility: VisibilityPublic,
 	}
 

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -94,6 +94,8 @@ var (
 	E3018 = ErrorCode{"E3018", "array-literal-required", "array type requires array literal"}
 	E3019 = ErrorCode{"E3019", "signed-to-unsigned", "cannot assign signed type to unsigned"}
 	E3020 = ErrorCode{"E3020", "negative-to-unsigned", "cannot assign negative value to unsigned type"}
+	E3021 = ErrorCode{"E3021", "byte-value-out-of-range", "byte value must be between 0 and 255"}
+	E3022 = ErrorCode{"E3022", "byte-array-element-out-of-range", "byte array element must be between 0 and 255"}
 )
 
 // =============================================================================
@@ -246,6 +248,7 @@ var (
 	W2003 = ErrorCode{"W2003", "missing-return", "function may not return value"}
 	W2004 = ErrorCode{"W2004", "implicit-type-conversion", "implicit type conversion occurring"}
 	W2005 = ErrorCode{"W2005", "deprecated-feature", "using deprecated feature"}
+	W2006 = ErrorCode{"W2006", "byte-overflow-potential", "byte arithmetic may overflow"}
 
 	// Code Quality Warnings (W3xxx)
 	W3001 = ErrorCode{"W3001", "empty-block", "block statement is empty"}

--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -31,6 +31,8 @@ func getEZTypeName(obj Object) string {
 		return "bool"
 	case *Char:
 		return "char"
+	case *Byte:
+		return "byte"
 	case *Array:
 		return "array"
 	case *Map:

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -37,6 +37,7 @@ var validModules = map[string]bool{
 	"time":    true, // Time functions
 	"io":      true, // File system and I/O operations
 	"os":      true, // Operating system and environment
+	"bytes":   true, // Binary data operations
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -29,12 +29,13 @@ var globalEvalContext *EvalContext
 // validModules lists all available standard library modules
 var validModules = map[string]bool{
 	"std":     true, // Standard I/O functions (println, print, read_int)
-	"math":    true, // Math functions (upcoming)
-	"string":  true, // String manipulation (upcoming)
-	"strings": true, // String utilities (upcoming)
-	"arrays":  true, // Array utilities (upcoming)
+	"math":    true, // Math functions
+	"string":  true, // String manipulation (alias for strings)
+	"strings": true, // String utilities
+	"arrays":  true, // Array utilities
 	"maps":    true, // Map utilities
-	"time":    true, // Time functions (upcoming)
+	"time":    true, // Time functions
+	"io":      true, // File system and I/O operations
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -36,6 +36,7 @@ var validModules = map[string]bool{
 	"maps":    true, // Map utilities
 	"time":    true, // Time functions
 	"io":      true, // File system and I/O operations
+	"os":      true, // Operating system and environment
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -18,6 +18,7 @@ type (
 	Float           = object.Float
 	String          = object.String
 	Char            = object.Char
+	Byte            = object.Byte
 	Boolean         = object.Boolean
 	Nil             = object.Nil
 	ReturnValue     = object.ReturnValue
@@ -44,6 +45,7 @@ const (
 	FLOAT_OBJ        = object.FLOAT_OBJ
 	STRING_OBJ       = object.STRING_OBJ
 	CHAR_OBJ         = object.CHAR_OBJ
+	BYTE_OBJ         = object.BYTE_OBJ
 	BOOLEAN_OBJ      = object.BOOLEAN_OBJ
 	NIL_OBJ          = object.NIL_OBJ
 	RETURN_VALUE_OBJ = object.RETURN_VALUE_OBJ

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -17,6 +17,7 @@ const (
 	FLOAT_OBJ        ObjectType = "FLOAT"
 	STRING_OBJ       ObjectType = "STRING"
 	CHAR_OBJ         ObjectType = "CHAR"
+	BYTE_OBJ         ObjectType = "BYTE"
 	BOOLEAN_OBJ      ObjectType = "BOOLEAN"
 	NIL_OBJ          ObjectType = "NIL"
 	RETURN_VALUE_OBJ ObjectType = "RETURN_VALUE"
@@ -85,6 +86,14 @@ type Char struct {
 
 func (c *Char) Type() ObjectType { return CHAR_OBJ }
 func (c *Char) Inspect() string  { return string(c.Value) }
+
+// Byte wraps uint8 (0-255)
+type Byte struct {
+	Value uint8
+}
+
+func (b *Byte) Type() ObjectType { return BYTE_OBJ }
+func (b *Byte) Inspect() string  { return fmt.Sprintf("%d", b.Value) }
 
 // Boolean wraps bool
 type Boolean struct {
@@ -206,6 +215,8 @@ func HashKey(obj Object) (string, bool) {
 		return "b:false", true
 	case *Char:
 		return fmt.Sprintf("c:%d", o.Value), true
+	case *Byte:
+		return fmt.Sprintf("y:%d", o.Value), true
 	default:
 		return "", false
 	}

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -533,7 +533,7 @@ func TestEnvironmentScopeChain(t *testing.T) {
 
 func TestEnvironmentUpdate(t *testing.T) {
 	env := NewEnvironment()
-	env.Set("x", &Integer{Value: 1}, true) // mutable
+	env.Set("x", &Integer{Value: 1}, true)  // mutable
 	env.Set("y", &Integer{Value: 2}, false) // immutable
 
 	// Update mutable

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -28,7 +28,7 @@ var reservedKeywords = map[string]bool{
 // Builtin function names that cannot be redefined
 var builtinNames = map[string]bool{
 	"len": true, "typeof": true, "input": true,
-	"int": true, "float": true, "string": true, "bool": true, "char": true,
+	"int": true, "float": true, "string": true, "bool": true, "char": true, "byte": true,
 	"println": true, "print": true, "read_int": true,
 }
 

--- a/pkg/stdlib/bytes.go
+++ b/pkg/stdlib/bytes.go
@@ -1,0 +1,1040 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// createBytesError creates an Error struct for recoverable errors in tuple returns
+func createBytesError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}
+
+// BytesBuiltins contains the bytes module functions for binary data operations
+var BytesBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// Creation Functions
+	// ============================================================================
+
+	// Creates bytes from an array of integers (0-255)
+	"bytes.from_array": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_array() takes exactly 1 argument (array)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.from_array() requires an array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i, elem := range arr.Elements {
+				var val int64
+				switch e := elem.(type) {
+				case *object.Integer:
+					val = e.Value
+				case *object.Byte:
+					val = int64(e.Value)
+				default:
+					return &object.Error{Code: "E7004", Message: fmt.Sprintf("bytes.from_array() element %d must be an integer", i)}
+				}
+				if val < 0 || val > 255 {
+					return &object.Error{Code: "E3022", Message: fmt.Sprintf("bytes.from_array() element %d value %d out of range (0-255)", i, val)}
+				}
+				elements[i] = &object.Byte{Value: uint8(val)}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Creates bytes from a UTF-8 encoded string
+	"bytes.from_string": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_string() takes exactly 1 argument (string)"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "bytes.from_string() requires a string argument"}
+			}
+
+			data := []byte(str.Value)
+			elements := make([]object.Object, len(data))
+			for i, b := range data {
+				elements[i] = &object.Byte{Value: b}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Creates bytes from a hexadecimal string
+	// Returns (bytes, error)
+	"bytes.from_hex": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_hex() takes exactly 1 argument (hex string)"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "bytes.from_hex() requires a string argument"}
+			}
+
+			data, err := hex.DecodeString(str.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7014", fmt.Sprintf("bytes.from_hex() invalid hex string: %s", err.Error())),
+				}}
+			}
+
+			elements := make([]object.Object, len(data))
+			for i, b := range data {
+				elements[i] = &object.Byte{Value: b}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Array{Elements: elements, ElementType: "byte"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Creates bytes from a base64 encoded string
+	// Returns (bytes, error)
+	"bytes.from_base64": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.from_base64() takes exactly 1 argument (base64 string)"}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "bytes.from_base64() requires a string argument"}
+			}
+
+			data, err := base64.StdEncoding.DecodeString(str.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7014", fmt.Sprintf("bytes.from_base64() invalid base64 string: %s", err.Error())),
+				}}
+			}
+
+			elements := make([]object.Object, len(data))
+			for i, b := range data {
+				elements[i] = &object.Byte{Value: b}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Array{Elements: elements, ElementType: "byte"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Conversion Functions
+	// ============================================================================
+
+	// Converts bytes to UTF-8 string
+	"bytes.to_string": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_string() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.to_string() requires a byte array argument"}
+			}
+
+			data := make([]byte, len(arr.Elements))
+			for i, elem := range arr.Elements {
+				b, ok := elem.(*object.Byte)
+				if !ok {
+					// Try integer for backwards compatibility
+					if intVal, ok := elem.(*object.Integer); ok {
+						data[i] = byte(intVal.Value)
+						continue
+					}
+					return &object.Error{Code: "E7002", Message: "bytes.to_string() requires a byte array"}
+				}
+				data[i] = b.Value
+			}
+			return &object.String{Value: string(data)}
+		},
+	},
+
+	// Converts bytes to array of integers
+	"bytes.to_array": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_array() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.to_array() requires a byte array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i, elem := range arr.Elements {
+				switch e := elem.(type) {
+				case *object.Byte:
+					elements[i] = &object.Integer{Value: int64(e.Value)}
+				case *object.Integer:
+					elements[i] = e
+				default:
+					return &object.Error{Code: "E7002", Message: "bytes.to_array() requires a byte array"}
+				}
+			}
+			return &object.Array{Elements: elements, ElementType: "int"}
+		},
+	},
+
+	// Converts bytes to lowercase hexadecimal string
+	"bytes.to_hex": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_hex() takes exactly 1 argument (bytes)"}
+			}
+			data, err := bytesArgToSlice(args[0], "bytes.to_hex()")
+			if err != nil {
+				return err
+			}
+			return &object.String{Value: hex.EncodeToString(data)}
+		},
+	},
+
+	// Converts bytes to uppercase hexadecimal string
+	"bytes.to_hex_upper": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_hex_upper() takes exactly 1 argument (bytes)"}
+			}
+			data, err := bytesArgToSlice(args[0], "bytes.to_hex_upper()")
+			if err != nil {
+				return err
+			}
+			hexStr := hex.EncodeToString(data)
+			upper := ""
+			for _, c := range hexStr {
+				if c >= 'a' && c <= 'f' {
+					upper += string(c - 32)
+				} else {
+					upper += string(c)
+				}
+			}
+			return &object.String{Value: upper}
+		},
+	},
+
+	// Converts bytes to base64 encoded string
+	"bytes.to_base64": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.to_base64() takes exactly 1 argument (bytes)"}
+			}
+			data, err := bytesArgToSlice(args[0], "bytes.to_base64()")
+			if err != nil {
+				return err
+			}
+			return &object.String{Value: base64.StdEncoding.EncodeToString(data)}
+		},
+	},
+
+	// ============================================================================
+	// Operations
+	// ============================================================================
+
+	// Extracts a portion of bytes (end is exclusive, supports negative indices)
+	"bytes.slice": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.slice() takes exactly 3 arguments (bytes, start, end)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.slice() requires a byte array as first argument"}
+			}
+			startArg, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.slice() requires an integer start index"}
+			}
+			endArg, ok := args[2].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.slice() requires an integer end index"}
+			}
+
+			length := int64(len(arr.Elements))
+			start := startArg.Value
+			end := endArg.Value
+
+			// Handle negative indices
+			if start < 0 {
+				start = length + start
+			}
+			if end < 0 {
+				end = length + end
+			}
+
+			// Clamp to valid range
+			if start < 0 {
+				start = 0
+			}
+			if end > length {
+				end = length
+			}
+			if start > end {
+				start = end
+			}
+
+			elements := make([]object.Object, end-start)
+			copy(elements, arr.Elements[start:end])
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Concatenates two byte sequences
+	"bytes.concat": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.concat() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			arr1, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.concat() requires byte arrays"}
+			}
+			arr2, ok := args[1].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.concat() requires byte arrays"}
+			}
+
+			elements := make([]object.Object, len(arr1.Elements)+len(arr2.Elements))
+			copy(elements, arr1.Elements)
+			copy(elements[len(arr1.Elements):], arr2.Elements)
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Joins array of bytes with separator
+	"bytes.join": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.join() takes exactly 2 arguments (array, separator)"}
+			}
+			partsArr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.join() requires an array of byte arrays as first argument"}
+			}
+			sep, ok := args[1].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.join() requires a byte array separator"}
+			}
+
+			if len(partsArr.Elements) == 0 {
+				return &object.Array{Elements: []object.Object{}, ElementType: "byte"}
+			}
+
+			var result []object.Object
+			for i, part := range partsArr.Elements {
+				partArr, ok := part.(*object.Array)
+				if !ok {
+					return &object.Error{Code: "E7002", Message: "bytes.join() array elements must be byte arrays"}
+				}
+				result = append(result, partArr.Elements...)
+				if i < len(partsArr.Elements)-1 {
+					result = append(result, sep.Elements...)
+				}
+			}
+			return &object.Array{Elements: result, ElementType: "byte"}
+		},
+	},
+
+	// Splits bytes by separator
+	"bytes.split": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.split() takes exactly 2 arguments (bytes, separator)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.split()")
+			if errObj != nil {
+				return errObj
+			}
+			sep, errObj := bytesArgToSlice(args[1], "bytes.split()")
+			if errObj != nil {
+				return errObj
+			}
+
+			parts := bytes.Split(data, sep)
+			elements := make([]object.Object, len(parts))
+			for i, part := range parts {
+				partElements := make([]object.Object, len(part))
+				for j, b := range part {
+					partElements[j] = &object.Byte{Value: b}
+				}
+				elements[i] = &object.Array{Elements: partElements, ElementType: "byte"}
+			}
+			return &object.Array{Elements: elements}
+		},
+	},
+
+	// Checks if bytes contain a pattern
+	"bytes.contains": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.contains() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.contains()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.contains()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.Contains(data, pattern) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Finds first index of pattern, or -1 if not found
+	"bytes.index": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.index() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.index()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.index()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.Index(data, pattern))}
+		},
+	},
+
+	// Finds last index of pattern, or -1 if not found
+	"bytes.last_index": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.last_index() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.last_index()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.last_index()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.LastIndex(data, pattern))}
+		},
+	},
+
+	// Counts non-overlapping occurrences of pattern
+	"bytes.count": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.count() takes exactly 2 arguments (bytes, pattern)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.count()")
+			if errObj != nil {
+				return errObj
+			}
+			pattern, errObj := bytesArgToSlice(args[1], "bytes.count()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.Count(data, pattern))}
+		},
+	},
+
+	// Lexicographically compares two byte sequences (-1, 0, 1)
+	"bytes.compare": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.compare() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.compare()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.compare()")
+			if errObj != nil {
+				return errObj
+			}
+
+			return &object.Integer{Value: int64(bytes.Compare(data1, data2))}
+		},
+	},
+
+	// Checks if two byte sequences are equal
+	"bytes.equals": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.equals() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.equals()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.equals()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.Equal(data1, data2) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// ============================================================================
+	// Inspection Functions
+	// ============================================================================
+
+	// Checks if bytes are empty (length 0)
+	"bytes.is_empty": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.is_empty() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.is_empty() requires a byte array argument"}
+			}
+
+			if len(arr.Elements) == 0 {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Checks if bytes start with prefix
+	"bytes.starts_with": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.starts_with() takes exactly 2 arguments (bytes, prefix)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.starts_with()")
+			if errObj != nil {
+				return errObj
+			}
+			prefix, errObj := bytesArgToSlice(args[1], "bytes.starts_with()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.HasPrefix(data, prefix) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Checks if bytes end with suffix
+	"bytes.ends_with": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.ends_with() takes exactly 2 arguments (bytes, suffix)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.ends_with()")
+			if errObj != nil {
+				return errObj
+			}
+			suffix, errObj := bytesArgToSlice(args[1], "bytes.ends_with()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if bytes.HasSuffix(data, suffix) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// ============================================================================
+	// Manipulation Functions
+	// ============================================================================
+
+	// Returns reversed copy of bytes
+	"bytes.reverse": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.reverse() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.reverse() requires a byte array argument"}
+			}
+
+			length := len(arr.Elements)
+			elements := make([]object.Object, length)
+			for i, elem := range arr.Elements {
+				elements[length-1-i] = elem
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Repeats bytes N times
+	"bytes.repeat": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.repeat() takes exactly 2 arguments (bytes, count)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.repeat() requires a byte array as first argument"}
+			}
+			count, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.repeat() requires an integer count"}
+			}
+			if count.Value < 0 {
+				return &object.Error{Code: "E7011", Message: "bytes.repeat() count cannot be negative"}
+			}
+
+			elements := make([]object.Object, 0, len(arr.Elements)*int(count.Value))
+			for i := int64(0); i < count.Value; i++ {
+				elements = append(elements, arr.Elements...)
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Replaces all occurrences of old with new
+	"bytes.replace": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.replace() takes exactly 3 arguments (bytes, old, new)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.replace()")
+			if errObj != nil {
+				return errObj
+			}
+			old, errObj := bytesArgToSlice(args[1], "bytes.replace()")
+			if errObj != nil {
+				return errObj
+			}
+			newBytes, errObj := bytesArgToSlice(args[2], "bytes.replace()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.ReplaceAll(data, old, newBytes)
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Replaces first N occurrences of old with new
+	"bytes.replace_n": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 4 {
+				return &object.Error{Code: "E7001", Message: "bytes.replace_n() takes exactly 4 arguments (bytes, old, new, n)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.replace_n()")
+			if errObj != nil {
+				return errObj
+			}
+			old, errObj := bytesArgToSlice(args[1], "bytes.replace_n()")
+			if errObj != nil {
+				return errObj
+			}
+			newBytes, errObj := bytesArgToSlice(args[2], "bytes.replace_n()")
+			if errObj != nil {
+				return errObj
+			}
+			n, ok := args[3].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.replace_n() requires an integer count"}
+			}
+
+			result := bytes.Replace(data, old, newBytes, int(n.Value))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Removes leading and trailing bytes that appear in cutset
+	"bytes.trim": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.trim() takes exactly 2 arguments (bytes, cutset)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.trim()")
+			if errObj != nil {
+				return errObj
+			}
+			cutset, errObj := bytesArgToSlice(args[1], "bytes.trim()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.Trim(data, string(cutset))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Removes leading bytes that appear in cutset
+	"bytes.trim_left": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.trim_left() takes exactly 2 arguments (bytes, cutset)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.trim_left()")
+			if errObj != nil {
+				return errObj
+			}
+			cutset, errObj := bytesArgToSlice(args[1], "bytes.trim_left()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.TrimLeft(data, string(cutset))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Removes trailing bytes that appear in cutset
+	"bytes.trim_right": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.trim_right() takes exactly 2 arguments (bytes, cutset)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.trim_right()")
+			if errObj != nil {
+				return errObj
+			}
+			cutset, errObj := bytesArgToSlice(args[1], "bytes.trim_right()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := bytes.TrimRight(data, string(cutset))
+			return sliceToByteArray(result)
+		},
+	},
+
+	// Pads bytes on the left to reach specified length
+	"bytes.pad_left": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.pad_left() takes exactly 3 arguments (bytes, length, pad_byte)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.pad_left() requires a byte array as first argument"}
+			}
+			length, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.pad_left() requires an integer length"}
+			}
+			padByte, err := getByteValue(args[2], "bytes.pad_left()")
+			if err != nil {
+				return err
+			}
+
+			currentLen := int64(len(arr.Elements))
+			if currentLen >= length.Value {
+				// Return copy of original
+				elements := make([]object.Object, len(arr.Elements))
+				copy(elements, arr.Elements)
+				return &object.Array{Elements: elements, ElementType: "byte"}
+			}
+
+			padCount := length.Value - currentLen
+			elements := make([]object.Object, length.Value)
+			for i := int64(0); i < padCount; i++ {
+				elements[i] = &object.Byte{Value: padByte}
+			}
+			copy(elements[padCount:], arr.Elements)
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Pads bytes on the right to reach specified length
+	"bytes.pad_right": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 3 {
+				return &object.Error{Code: "E7001", Message: "bytes.pad_right() takes exactly 3 arguments (bytes, length, pad_byte)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.pad_right() requires a byte array as first argument"}
+			}
+			length, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "bytes.pad_right() requires an integer length"}
+			}
+			padByte, err := getByteValue(args[2], "bytes.pad_right()")
+			if err != nil {
+				return err
+			}
+
+			currentLen := int64(len(arr.Elements))
+			if currentLen >= length.Value {
+				// Return copy of original
+				elements := make([]object.Object, len(arr.Elements))
+				copy(elements, arr.Elements)
+				return &object.Array{Elements: elements, ElementType: "byte"}
+			}
+
+			elements := make([]object.Object, length.Value)
+			copy(elements, arr.Elements)
+			for i := currentLen; i < length.Value; i++ {
+				elements[i] = &object.Byte{Value: padByte}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// ============================================================================
+	// Bitwise Operations
+	// ============================================================================
+
+	// Bitwise AND of two byte sequences (must be same length)
+	"bytes.and": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.and() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.and()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.and()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if len(data1) != len(data2) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7010", "bytes.and() requires byte arrays of equal length"),
+				}}
+			}
+
+			result := make([]byte, len(data1))
+			for i := range data1 {
+				result[i] = data1[i] & data2[i]
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToByteArray(result),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Bitwise OR of two byte sequences (must be same length)
+	"bytes.or": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.or() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.or()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.or()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if len(data1) != len(data2) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7010", "bytes.or() requires byte arrays of equal length"),
+				}}
+			}
+
+			result := make([]byte, len(data1))
+			for i := range data1 {
+				result[i] = data1[i] | data2[i]
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToByteArray(result),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Bitwise XOR of two byte sequences (must be same length)
+	"bytes.xor": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.xor() takes exactly 2 arguments (bytes1, bytes2)"}
+			}
+			data1, errObj := bytesArgToSlice(args[0], "bytes.xor()")
+			if errObj != nil {
+				return errObj
+			}
+			data2, errObj := bytesArgToSlice(args[1], "bytes.xor()")
+			if errObj != nil {
+				return errObj
+			}
+
+			if len(data1) != len(data2) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBytesError("E7010", "bytes.xor() requires byte arrays of equal length"),
+				}}
+			}
+
+			result := make([]byte, len(data1))
+			for i := range data1 {
+				result[i] = data1[i] ^ data2[i]
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToByteArray(result),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Bitwise NOT (complement) of bytes
+	"bytes.not": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.not() takes exactly 1 argument (bytes)"}
+			}
+			data, errObj := bytesArgToSlice(args[0], "bytes.not()")
+			if errObj != nil {
+				return errObj
+			}
+
+			result := make([]byte, len(data))
+			for i := range data {
+				result[i] = ^data[i]
+			}
+			return sliceToByteArray(result)
+		},
+	},
+
+	// ============================================================================
+	// Utility Functions
+	// ============================================================================
+
+	// Fills all bytes with a single value
+	"bytes.fill": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "bytes.fill() takes exactly 2 arguments (bytes, value)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.fill() requires a byte array as first argument"}
+			}
+			fillByte, err := getByteValue(args[1], "bytes.fill()")
+			if err != nil {
+				return err
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i := range elements {
+				elements[i] = &object.Byte{Value: fillByte}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Creates a copy of bytes
+	"bytes.copy": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.copy() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.copy() requires a byte array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			copy(elements, arr.Elements)
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+
+	// Fills all bytes with zero (for securely clearing sensitive data)
+	"bytes.zero": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "bytes.zero() takes exactly 1 argument (bytes)"}
+			}
+			arr, ok := args[0].(*object.Array)
+			if !ok {
+				return &object.Error{Code: "E7002", Message: "bytes.zero() requires a byte array argument"}
+			}
+
+			elements := make([]object.Object, len(arr.Elements))
+			for i := range elements {
+				elements[i] = &object.Byte{Value: 0}
+			}
+			return &object.Array{Elements: elements, ElementType: "byte"}
+		},
+	},
+}
+
+// Helper function to convert a byte array argument to []byte
+func bytesArgToSlice(arg object.Object, funcName string) ([]byte, *object.Error) {
+	arr, ok := arg.(*object.Array)
+	if !ok {
+		return nil, &object.Error{Code: "E7002", Message: fmt.Sprintf("%s requires a byte array argument", funcName)}
+	}
+
+	data := make([]byte, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		switch e := elem.(type) {
+		case *object.Byte:
+			data[i] = e.Value
+		case *object.Integer:
+			data[i] = byte(e.Value)
+		default:
+			return nil, &object.Error{Code: "E7002", Message: fmt.Sprintf("%s requires a byte array", funcName)}
+		}
+	}
+	return data, nil
+}
+
+// Helper function to convert []byte to object.Array of Bytes
+func sliceToByteArray(data []byte) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, b := range data {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper function to get a byte value from an object
+func getByteValue(arg object.Object, funcName string) (uint8, *object.Error) {
+	switch v := arg.(type) {
+	case *object.Byte:
+		return v.Value, nil
+	case *object.Integer:
+		if v.Value < 0 || v.Value > 255 {
+			return 0, &object.Error{Code: "E3021", Message: fmt.Sprintf("%s byte value %d out of range (0-255)", funcName, v.Value)}
+		}
+		return uint8(v.Value), nil
+	default:
+		return 0, &object.Error{Code: "E7004", Message: fmt.Sprintf("%s requires a byte or integer value", funcName)}
+	}
+}

--- a/pkg/stdlib/bytes_test.go
+++ b/pkg/stdlib/bytes_test.go
@@ -1,0 +1,720 @@
+package stdlib
+
+import (
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// Helper to create a byte array from Go []byte
+func makeByteArray(data []byte) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, b := range data {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper to create an integer array
+func makeIntArray(data []int64) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, v := range data {
+		elements[i] = &object.Integer{Value: v}
+	}
+	return &object.Array{Elements: elements}
+}
+
+// Helper to extract byte slice from result
+func getByteSlice(obj object.Object) []byte {
+	arr, ok := obj.(*object.Array)
+	if !ok {
+		return nil
+	}
+	result := make([]byte, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		switch e := elem.(type) {
+		case *object.Byte:
+			result[i] = e.Value
+		case *object.Integer:
+			result[i] = byte(e.Value)
+		}
+	}
+	return result
+}
+
+// ============================================================================
+// Creation Functions Tests
+// ============================================================================
+
+func TestBytesFromArray(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_array"].Fn
+
+	tests := []struct {
+		name     string
+		input    []int64
+		expected []byte
+		wantErr  bool
+	}{
+		{"empty array", []int64{}, []byte{}, false},
+		{"simple bytes", []int64{72, 101, 108, 108, 111}, []byte("Hello"), false},
+		{"boundary values", []int64{0, 127, 255}, []byte{0, 127, 255}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fn(makeIntArray(tt.input))
+			if tt.wantErr {
+				if _, ok := result.(*object.Error); !ok {
+					t.Errorf("expected error, got %T", result)
+				}
+				return
+			}
+			got := getByteSlice(result)
+			if string(got) != string(tt.expected) {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBytesFromArrayErrors(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_array"].Fn
+
+	// Value out of range
+	result := fn(makeIntArray([]int64{256}))
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for value > 255, got %T", result)
+	}
+
+	// Negative value
+	result = fn(makeIntArray([]int64{-1}))
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for negative value, got %T", result)
+	}
+
+	// Wrong argument type
+	result = fn(&object.String{Value: "not an array"})
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for wrong type, got %T", result)
+	}
+
+	// Wrong argument count
+	result = fn()
+	if _, ok := result.(*object.Error); !ok {
+		t.Errorf("expected error for no args, got %T", result)
+	}
+}
+
+func TestBytesFromString(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_string"].Fn
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []byte
+	}{
+		{"empty string", "", []byte{}},
+		{"hello", "Hello", []byte("Hello")},
+		{"unicode", "こんにちは", []byte("こんにちは")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fn(&object.String{Value: tt.input})
+			got := getByteSlice(result)
+			if string(got) != string(tt.expected) {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBytesFromHex(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_hex"].Fn
+
+	// Valid hex
+	result := fn(&object.String{Value: "48656c6c6f"})
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	got := getByteSlice(rv.Values[0])
+	if string(got) != "Hello" {
+		t.Errorf("got %s, want Hello", string(got))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Errorf("expected nil error, got %v", rv.Values[1])
+	}
+
+	// Invalid hex
+	result = fn(&object.String{Value: "GGGG"})
+	rv, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if rv.Values[0] != object.NIL {
+		t.Errorf("expected nil value for invalid hex")
+	}
+	if _, ok := rv.Values[1].(*object.Struct); !ok {
+		t.Errorf("expected error struct, got %T", rv.Values[1])
+	}
+}
+
+func TestBytesFromBase64(t *testing.T) {
+	fn := BytesBuiltins["bytes.from_base64"].Fn
+
+	// Valid base64
+	result := fn(&object.String{Value: "SGVsbG8="})
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	got := getByteSlice(rv.Values[0])
+	if string(got) != "Hello" {
+		t.Errorf("got %s, want Hello", string(got))
+	}
+
+	// Invalid base64
+	result = fn(&object.String{Value: "!!!!"})
+	rv, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if rv.Values[0] != object.NIL {
+		t.Errorf("expected nil value for invalid base64")
+	}
+}
+
+// ============================================================================
+// Conversion Functions Tests
+// ============================================================================
+
+func TestBytesToString(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_string"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "Hello" {
+		t.Errorf("got %s, want Hello", str.Value)
+	}
+}
+
+func TestBytesToArray(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_array"].Fn
+
+	result := fn(makeByteArray([]byte{72, 101}))
+	arr, ok := result.(*object.Array)
+	if !ok {
+		t.Fatalf("expected Array, got %T", result)
+	}
+	if len(arr.Elements) != 2 {
+		t.Errorf("got len %d, want 2", len(arr.Elements))
+	}
+	if arr.Elements[0].(*object.Integer).Value != 72 {
+		t.Errorf("got %d, want 72", arr.Elements[0].(*object.Integer).Value)
+	}
+}
+
+func TestBytesToHex(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_hex"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "48656c6c6f" {
+		t.Errorf("got %s, want 48656c6c6f", str.Value)
+	}
+}
+
+func TestBytesToHexUpper(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_hex_upper"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "48656C6C6F" {
+		t.Errorf("got %s, want 48656C6C6F", str.Value)
+	}
+}
+
+func TestBytesToBase64(t *testing.T) {
+	fn := BytesBuiltins["bytes.to_base64"].Fn
+
+	result := fn(makeByteArray([]byte("Hello")))
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+	if str.Value != "SGVsbG8=" {
+		t.Errorf("got %s, want SGVsbG8=", str.Value)
+	}
+}
+
+// ============================================================================
+// Operations Tests
+// ============================================================================
+
+func TestBytesSlice(t *testing.T) {
+	fn := BytesBuiltins["bytes.slice"].Fn
+
+	input := makeByteArray([]byte("Hello"))
+
+	// Normal slice
+	result := fn(input, &object.Integer{Value: 1}, &object.Integer{Value: 4})
+	got := getByteSlice(result)
+	if string(got) != "ell" {
+		t.Errorf("got %s, want ell", string(got))
+	}
+
+	// Negative indices
+	result = fn(input, &object.Integer{Value: -3}, &object.Integer{Value: -1})
+	got = getByteSlice(result)
+	if string(got) != "ll" {
+		t.Errorf("got %s, want ll", string(got))
+	}
+}
+
+func TestBytesConcat(t *testing.T) {
+	fn := BytesBuiltins["bytes.concat"].Fn
+
+	a := makeByteArray([]byte("Hello"))
+	b := makeByteArray([]byte(" World"))
+
+	result := fn(a, b)
+	got := getByteSlice(result)
+	if string(got) != "Hello World" {
+		t.Errorf("got %s, want Hello World", string(got))
+	}
+}
+
+func TestBytesContains(t *testing.T) {
+	fn := BytesBuiltins["bytes.contains"].Fn
+
+	haystack := makeByteArray([]byte("Hello World"))
+	needle := makeByteArray([]byte("World"))
+	missing := makeByteArray([]byte("xyz"))
+
+	result := fn(haystack, needle)
+	if result != object.TRUE {
+		t.Errorf("expected true for contains")
+	}
+
+	result = fn(haystack, missing)
+	if result != object.FALSE {
+		t.Errorf("expected false for not contains")
+	}
+}
+
+func TestBytesIndex(t *testing.T) {
+	fn := BytesBuiltins["bytes.index"].Fn
+
+	haystack := makeByteArray([]byte("Hello World"))
+	needle := makeByteArray([]byte("World"))
+	missing := makeByteArray([]byte("xyz"))
+
+	result := fn(haystack, needle)
+	idx := result.(*object.Integer).Value
+	if idx != 6 {
+		t.Errorf("got %d, want 6", idx)
+	}
+
+	result = fn(haystack, missing)
+	idx = result.(*object.Integer).Value
+	if idx != -1 {
+		t.Errorf("got %d, want -1", idx)
+	}
+}
+
+func TestBytesLastIndex(t *testing.T) {
+	fn := BytesBuiltins["bytes.last_index"].Fn
+
+	haystack := makeByteArray([]byte("abcabc"))
+	needle := makeByteArray([]byte("bc"))
+
+	result := fn(haystack, needle)
+	idx := result.(*object.Integer).Value
+	if idx != 4 {
+		t.Errorf("got %d, want 4", idx)
+	}
+}
+
+func TestBytesCount(t *testing.T) {
+	fn := BytesBuiltins["bytes.count"].Fn
+
+	haystack := makeByteArray([]byte("abababab"))
+	needle := makeByteArray([]byte("ab"))
+
+	result := fn(haystack, needle)
+	count := result.(*object.Integer).Value
+	if count != 4 {
+		t.Errorf("got %d, want 4", count)
+	}
+}
+
+func TestBytesCompare(t *testing.T) {
+	fn := BytesBuiltins["bytes.compare"].Fn
+
+	a := makeByteArray([]byte("aaa"))
+	b := makeByteArray([]byte("bbb"))
+
+	result := fn(a, b)
+	if result.(*object.Integer).Value != -1 {
+		t.Errorf("expected -1 for a < b")
+	}
+
+	result = fn(b, a)
+	if result.(*object.Integer).Value != 1 {
+		t.Errorf("expected 1 for b > a")
+	}
+
+	result = fn(a, a)
+	if result.(*object.Integer).Value != 0 {
+		t.Errorf("expected 0 for a == a")
+	}
+}
+
+func TestBytesEquals(t *testing.T) {
+	fn := BytesBuiltins["bytes.equals"].Fn
+
+	a := makeByteArray([]byte("Hello"))
+	b := makeByteArray([]byte("Hello"))
+	c := makeByteArray([]byte("World"))
+
+	if fn(a, b) != object.TRUE {
+		t.Errorf("expected true for equal bytes")
+	}
+
+	if fn(a, c) != object.FALSE {
+		t.Errorf("expected false for different bytes")
+	}
+}
+
+// ============================================================================
+// Inspection Tests
+// ============================================================================
+
+func TestBytesIsEmpty(t *testing.T) {
+	fn := BytesBuiltins["bytes.is_empty"].Fn
+
+	empty := makeByteArray([]byte{})
+	notEmpty := makeByteArray([]byte("Hi"))
+
+	if fn(empty) != object.TRUE {
+		t.Errorf("expected true for empty")
+	}
+
+	if fn(notEmpty) != object.FALSE {
+		t.Errorf("expected false for not empty")
+	}
+}
+
+func TestBytesStartsWith(t *testing.T) {
+	fn := BytesBuiltins["bytes.starts_with"].Fn
+
+	data := makeByteArray([]byte("Hello World"))
+	prefix := makeByteArray([]byte("Hello"))
+	notPrefix := makeByteArray([]byte("World"))
+
+	if fn(data, prefix) != object.TRUE {
+		t.Errorf("expected true for starts_with")
+	}
+
+	if fn(data, notPrefix) != object.FALSE {
+		t.Errorf("expected false for not starts_with")
+	}
+}
+
+func TestBytesEndsWith(t *testing.T) {
+	fn := BytesBuiltins["bytes.ends_with"].Fn
+
+	data := makeByteArray([]byte("Hello World"))
+	suffix := makeByteArray([]byte("World"))
+	notSuffix := makeByteArray([]byte("Hello"))
+
+	if fn(data, suffix) != object.TRUE {
+		t.Errorf("expected true for ends_with")
+	}
+
+	if fn(data, notSuffix) != object.FALSE {
+		t.Errorf("expected false for not ends_with")
+	}
+}
+
+// ============================================================================
+// Manipulation Tests
+// ============================================================================
+
+func TestBytesReverse(t *testing.T) {
+	fn := BytesBuiltins["bytes.reverse"].Fn
+
+	input := makeByteArray([]byte("Hello"))
+	result := fn(input)
+	got := getByteSlice(result)
+	if string(got) != "olleH" {
+		t.Errorf("got %s, want olleH", string(got))
+	}
+}
+
+func TestBytesRepeat(t *testing.T) {
+	fn := BytesBuiltins["bytes.repeat"].Fn
+
+	input := makeByteArray([]byte("ab"))
+
+	result := fn(input, &object.Integer{Value: 3})
+	got := getByteSlice(result)
+	if string(got) != "ababab" {
+		t.Errorf("got %s, want ababab", string(got))
+	}
+
+	result = fn(input, &object.Integer{Value: 0})
+	got = getByteSlice(result)
+	if len(got) != 0 {
+		t.Errorf("got len %d, want 0", len(got))
+	}
+}
+
+func TestBytesReplace(t *testing.T) {
+	fn := BytesBuiltins["bytes.replace"].Fn
+
+	input := makeByteArray([]byte("hello hello"))
+	old := makeByteArray([]byte("hello"))
+	new := makeByteArray([]byte("hi"))
+
+	result := fn(input, old, new)
+	got := getByteSlice(result)
+	if string(got) != "hi hi" {
+		t.Errorf("got %s, want hi hi", string(got))
+	}
+}
+
+func TestBytesReplaceN(t *testing.T) {
+	fn := BytesBuiltins["bytes.replace_n"].Fn
+
+	input := makeByteArray([]byte("hello hello hello"))
+	old := makeByteArray([]byte("hello"))
+	new := makeByteArray([]byte("hi"))
+
+	result := fn(input, old, new, &object.Integer{Value: 2})
+	got := getByteSlice(result)
+	if string(got) != "hi hi hello" {
+		t.Errorf("got %s, want hi hi hello", string(got))
+	}
+}
+
+func TestBytesTrim(t *testing.T) {
+	fn := BytesBuiltins["bytes.trim"].Fn
+
+	input := makeByteArray([]byte{0, 0, 65, 66, 0, 0})
+	cutset := makeByteArray([]byte{0})
+
+	result := fn(input, cutset)
+	got := getByteSlice(result)
+	if string(got) != "AB" {
+		t.Errorf("got %v, want AB", got)
+	}
+}
+
+func TestBytesPadLeft(t *testing.T) {
+	fn := BytesBuiltins["bytes.pad_left"].Fn
+
+	input := makeByteArray([]byte("Hi"))
+
+	result := fn(input, &object.Integer{Value: 5}, &object.Integer{Value: 0})
+	got := getByteSlice(result)
+	expected := []byte{0, 0, 0, 'H', 'i'}
+	if string(got) != string(expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+
+	// No padding needed
+	result = fn(input, &object.Integer{Value: 2}, &object.Integer{Value: 0})
+	got = getByteSlice(result)
+	if string(got) != "Hi" {
+		t.Errorf("got %s, want Hi", string(got))
+	}
+}
+
+func TestBytesPadRight(t *testing.T) {
+	fn := BytesBuiltins["bytes.pad_right"].Fn
+
+	input := makeByteArray([]byte("Hi"))
+
+	result := fn(input, &object.Integer{Value: 5}, &object.Integer{Value: 0})
+	got := getByteSlice(result)
+	expected := []byte{'H', 'i', 0, 0, 0}
+	if string(got) != string(expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+// ============================================================================
+// Bitwise Operations Tests
+// ============================================================================
+
+func TestBytesAnd(t *testing.T) {
+	fn := BytesBuiltins["bytes.and"].Fn
+
+	a := makeByteArray([]byte{0xFF, 0x0F})
+	b := makeByteArray([]byte{0xF0, 0xFF})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	got := getByteSlice(rv.Values[0])
+	expected := []byte{0xF0, 0x0F}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestBytesAndLengthMismatch(t *testing.T) {
+	fn := BytesBuiltins["bytes.and"].Fn
+
+	a := makeByteArray([]byte{0xFF})
+	b := makeByteArray([]byte{0xF0, 0xFF})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	if rv.Values[0] != object.NIL {
+		t.Errorf("expected nil for length mismatch")
+	}
+	if _, ok := rv.Values[1].(*object.Struct); !ok {
+		t.Errorf("expected error struct, got %T", rv.Values[1])
+	}
+}
+
+func TestBytesOr(t *testing.T) {
+	fn := BytesBuiltins["bytes.or"].Fn
+
+	a := makeByteArray([]byte{0xF0, 0x00})
+	b := makeByteArray([]byte{0x0F, 0xFF})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	got := getByteSlice(rv.Values[0])
+	expected := []byte{0xFF, 0xFF}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestBytesXor(t *testing.T) {
+	fn := BytesBuiltins["bytes.xor"].Fn
+
+	a := makeByteArray([]byte{0xFF, 0x00})
+	b := makeByteArray([]byte{0xF0, 0x0F})
+
+	result := fn(a, b)
+	rv := result.(*object.ReturnValue)
+	got := getByteSlice(rv.Values[0])
+	expected := []byte{0x0F, 0x0F}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestBytesNot(t *testing.T) {
+	fn := BytesBuiltins["bytes.not"].Fn
+
+	a := makeByteArray([]byte{0xFF, 0x00})
+
+	result := fn(a)
+	got := getByteSlice(result)
+	expected := []byte{0x00, 0xFF}
+	if got[0] != expected[0] || got[1] != expected[1] {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+// ============================================================================
+// Utility Tests
+// ============================================================================
+
+func TestBytesFill(t *testing.T) {
+	fn := BytesBuiltins["bytes.fill"].Fn
+
+	input := makeByteArray([]byte{1, 2, 3, 4, 5})
+
+	result := fn(input, &object.Integer{Value: 0xFF})
+	got := getByteSlice(result)
+	for i, b := range got {
+		if b != 0xFF {
+			t.Errorf("got[%d] = %d, want 255", i, b)
+		}
+	}
+}
+
+func TestBytesCopy(t *testing.T) {
+	fn := BytesBuiltins["bytes.copy"].Fn
+
+	input := makeByteArray([]byte("Hello"))
+
+	result := fn(input)
+	arr := result.(*object.Array)
+
+	// Verify it's a copy (different slice)
+	if &arr.Elements == &input.Elements {
+		t.Errorf("expected different slice, got same reference")
+	}
+
+	got := getByteSlice(result)
+	if string(got) != "Hello" {
+		t.Errorf("got %s, want Hello", string(got))
+	}
+}
+
+func TestBytesZero(t *testing.T) {
+	fn := BytesBuiltins["bytes.zero"].Fn
+
+	input := makeByteArray([]byte("secret"))
+
+	result := fn(input)
+	got := getByteSlice(result)
+	for i, b := range got {
+		if b != 0 {
+			t.Errorf("got[%d] = %d, want 0", i, b)
+		}
+	}
+}
+
+// ============================================================================
+// Split and Join Tests
+// ============================================================================
+
+func TestBytesSplit(t *testing.T) {
+	fn := BytesBuiltins["bytes.split"].Fn
+
+	input := makeByteArray([]byte("a,b,c"))
+	sep := makeByteArray([]byte(","))
+
+	result := fn(input, sep)
+	arr := result.(*object.Array)
+	if len(arr.Elements) != 3 {
+		t.Errorf("got %d parts, want 3", len(arr.Elements))
+	}
+}
+
+func TestBytesJoin(t *testing.T) {
+	fn := BytesBuiltins["bytes.join"].Fn
+
+	parts := &object.Array{
+		Elements: []object.Object{
+			makeByteArray([]byte("a")),
+			makeByteArray([]byte("b")),
+			makeByteArray([]byte("c")),
+		},
+	}
+	sep := makeByteArray([]byte("-"))
+
+	result := fn(parts, sep)
+	got := getByteSlice(result)
+	if string(got) != "a-b-c" {
+		t.Errorf("got %s, want a-b-c", string(got))
+	}
+}

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -1,0 +1,674 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// IOBuiltins contains the io module functions for file system operations
+var IOBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// File Reading
+	// ============================================================================
+
+	// Reads the entire contents of a file as a string
+	// Returns (content, error) tuple - error is nil on success
+	"io.read_file": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.read_file() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.read_file() requires a string path"}
+			}
+
+			content, err := os.ReadFile(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "read")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: string(content)},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// File Writing
+	// ============================================================================
+
+	// Writes content to a file, creating it if it doesn't exist or overwriting if it does
+	// Returns (success, error) tuple
+	"io.write_file": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E8001", Message: "io.write_file() takes exactly 2 arguments (path, content)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.write_file() requires a string path as first argument"}
+			}
+			content, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8003", Message: "io.write_file() requires a string content as second argument"}
+			}
+
+			err := os.WriteFile(path.Value, []byte(content.Value), 0644)
+			if err != nil {
+				return createIOErrorResult(err, "write")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Appends content to a file, creating it if it doesn't exist
+	// Returns (success, error) tuple
+	"io.append_file": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E8001", Message: "io.append_file() takes exactly 2 arguments (path, content)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.append_file() requires a string path as first argument"}
+			}
+			content, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8003", Message: "io.append_file() requires a string content as second argument"}
+			}
+
+			f, err := os.OpenFile(path.Value, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				return createIOErrorResult(err, "open for append")
+			}
+			defer f.Close()
+
+			_, err = f.WriteString(content.Value)
+			if err != nil {
+				return createIOErrorResult(err, "append")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Path Existence and Type Checks
+	// ============================================================================
+
+	// Checks if a path exists (file or directory)
+	"io.exists": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.exists() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.exists() requires a string path"}
+			}
+
+			_, err := os.Stat(path.Value)
+			if err == nil {
+				return object.TRUE
+			}
+			if os.IsNotExist(err) {
+				return object.FALSE
+			}
+			// For other errors (permission denied, etc.), return false
+			return object.FALSE
+		},
+	},
+
+	// Checks if a path is a regular file
+	"io.is_file": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.is_file() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.is_file() requires a string path"}
+			}
+
+			info, err := os.Stat(path.Value)
+			if err != nil {
+				return object.FALSE
+			}
+			if info.Mode().IsRegular() {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Checks if a path is a directory
+	"io.is_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.is_dir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.is_dir() requires a string path"}
+			}
+
+			info, err := os.Stat(path.Value)
+			if err != nil {
+				return object.FALSE
+			}
+			if info.IsDir() {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// ============================================================================
+	// File Operations
+	// ============================================================================
+
+	// Removes a file
+	// Returns (success, error) tuple
+	"io.remove": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.remove() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.remove() requires a string path"}
+			}
+
+			// Check if it's a directory - if so, don't allow removal with this function
+			info, err := os.Stat(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "stat")
+			}
+			if info.IsDir() {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createIOError("E8006", "io.remove() cannot remove directories, use io.remove_dir() instead"),
+				}}
+			}
+
+			err = os.Remove(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "remove")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Removes an empty directory
+	// Returns (success, error) tuple
+	"io.remove_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.remove_dir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.remove_dir() requires a string path"}
+			}
+
+			// Check if it's actually a directory
+			info, err := os.Stat(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "stat")
+			}
+			if !info.IsDir() {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createIOError("E8007", "io.remove_dir() can only remove directories, use io.remove() for files"),
+				}}
+			}
+
+			err = os.Remove(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "remove directory")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Removes a file or directory recursively (DANGEROUS - use with caution)
+	// Returns (success, error) tuple
+	"io.remove_all": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.remove_all() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.remove_all() requires a string path"}
+			}
+
+			// Safety check: don't allow removing root or home directory
+			absPath, err := filepath.Abs(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "resolve path")
+			}
+
+			// Check for dangerous paths
+			if absPath == "/" || absPath == filepath.Clean(os.Getenv("HOME")) {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createIOError("E8008", "io.remove_all() cannot remove root or home directory for safety"),
+				}}
+			}
+
+			err = os.RemoveAll(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "remove all")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Renames or moves a file or directory
+	// Returns (success, error) tuple
+	"io.rename": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E8001", Message: "io.rename() takes exactly 2 arguments (old_path, new_path)"}
+			}
+			oldPath, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.rename() requires a string as first argument (old_path)"}
+			}
+			newPath, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.rename() requires a string as second argument (new_path)"}
+			}
+
+			err := os.Rename(oldPath.Value, newPath.Value)
+			if err != nil {
+				return createIOErrorResult(err, "rename")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Copies a file from source to destination
+	// Returns (success, error) tuple
+	"io.copy": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E8001", Message: "io.copy() takes exactly 2 arguments (source, destination)"}
+			}
+			srcPath, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.copy() requires a string as first argument (source)"}
+			}
+			dstPath, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.copy() requires a string as second argument (destination)"}
+			}
+
+			// Check source exists and is a file
+			srcInfo, err := os.Stat(srcPath.Value)
+			if err != nil {
+				return createIOErrorResult(err, "stat source")
+			}
+			if srcInfo.IsDir() {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createIOError("E8009", "io.copy() cannot copy directories, only files"),
+				}}
+			}
+
+			// Open source file
+			src, err := os.Open(srcPath.Value)
+			if err != nil {
+				return createIOErrorResult(err, "open source")
+			}
+			defer src.Close()
+
+			// Create destination file
+			dst, err := os.Create(dstPath.Value)
+			if err != nil {
+				return createIOErrorResult(err, "create destination")
+			}
+			defer dst.Close()
+
+			// Copy contents
+			_, err = io.Copy(dst, src)
+			if err != nil {
+				return createIOErrorResult(err, "copy contents")
+			}
+
+			// Preserve file mode
+			err = os.Chmod(dstPath.Value, srcInfo.Mode())
+			if err != nil {
+				// Non-fatal on Windows, just continue
+				_ = err
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Directory Operations
+	// ============================================================================
+
+	// Creates a directory (parent must exist)
+	// Returns (success, error) tuple
+	"io.mkdir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.mkdir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.mkdir() requires a string path"}
+			}
+
+			err := os.Mkdir(path.Value, 0755)
+			if err != nil {
+				return createIOErrorResult(err, "mkdir")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Creates a directory and all parent directories as needed
+	// Returns (success, error) tuple
+	"io.mkdir_all": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.mkdir_all() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.mkdir_all() requires a string path"}
+			}
+
+			err := os.MkdirAll(path.Value, 0755)
+			if err != nil {
+				return createIOErrorResult(err, "mkdir_all")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Lists the contents of a directory
+	// Returns (entries, error) tuple where entries is an array of filenames
+	"io.read_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.read_dir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.read_dir() requires a string path"}
+			}
+
+			entries, err := os.ReadDir(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "read directory")
+			}
+
+			elements := make([]object.Object, len(entries))
+			for i, entry := range entries {
+				elements[i] = &object.String{Value: entry.Name()}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Array{Elements: elements, Mutable: false},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// File Metadata
+	// ============================================================================
+
+	// Returns the size of a file in bytes
+	// Returns (size, error) tuple
+	"io.file_size": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.file_size() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.file_size() requires a string path"}
+			}
+
+			info, err := os.Stat(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "stat")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: info.Size()},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the modification time of a file as a Unix timestamp
+	// Returns (timestamp, error) tuple
+	"io.file_mod_time": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.file_mod_time() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.file_mod_time() requires a string path"}
+			}
+
+			info, err := os.Stat(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "stat")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: info.ModTime().Unix()},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Path Utilities
+	// ============================================================================
+
+	// Joins path components using the OS-specific separator
+	"io.path_join": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) < 1 {
+				return &object.Error{Code: "E8001", Message: "io.path_join() takes at least 1 argument"}
+			}
+
+			parts := make([]string, len(args))
+			for i, arg := range args {
+				str, ok := arg.(*object.String)
+				if !ok {
+					return &object.Error{Code: "E8002", Message: fmt.Sprintf("io.path_join() argument %d must be a string", i+1)}
+				}
+				parts[i] = str.Value
+			}
+
+			return &object.String{Value: filepath.Join(parts...)}
+		},
+	},
+
+	// Returns the last element of a path (filename or directory name)
+	"io.path_base": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.path_base() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.path_base() requires a string path"}
+			}
+
+			return &object.String{Value: filepath.Base(path.Value)}
+		},
+	},
+
+	// Returns the directory portion of a path
+	"io.path_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.path_dir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.path_dir() requires a string path"}
+			}
+
+			return &object.String{Value: filepath.Dir(path.Value)}
+		},
+	},
+
+	// Returns the file extension (including the dot)
+	"io.path_ext": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.path_ext() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.path_ext() requires a string path"}
+			}
+
+			return &object.String{Value: filepath.Ext(path.Value)}
+		},
+	},
+
+	// Returns the absolute path
+	// Returns (abs_path, error) tuple
+	"io.path_abs": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.path_abs() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.path_abs() requires a string path"}
+			}
+
+			absPath, err := filepath.Abs(path.Value)
+			if err != nil {
+				return createIOErrorResult(err, "resolve absolute path")
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: absPath},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Cleans a path (removes redundant separators, . and ..)
+	"io.path_clean": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E8001", Message: "io.path_clean() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E8002", Message: "io.path_clean() requires a string path"}
+			}
+
+			return &object.String{Value: filepath.Clean(path.Value)}
+		},
+	},
+
+	// Returns the OS-specific path separator
+	"io.path_separator": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: string(filepath.Separator)}
+		},
+	},
+}
+
+// createIOError creates an Error struct for IO operations
+func createIOError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}
+
+// createIOErrorResult wraps a Go error into an EZ (nil, Error) return tuple
+func createIOErrorResult(err error, operation string) *object.ReturnValue {
+	var code string
+	var message string
+
+	// Determine error code based on error type
+	if os.IsNotExist(err) {
+		code = "E8004"
+		message = fmt.Sprintf("file or directory not found: %s", err.Error())
+	} else if os.IsPermission(err) {
+		code = "E8005"
+		message = fmt.Sprintf("permission denied: %s", err.Error())
+	} else if os.IsExist(err) {
+		code = "E8010"
+		message = fmt.Sprintf("file or directory already exists: %s", err.Error())
+	} else if strings.Contains(err.Error(), "directory not empty") {
+		code = "E8011"
+		message = fmt.Sprintf("directory not empty: %s", err.Error())
+	} else {
+		code = "E8099"
+		message = fmt.Sprintf("io error during %s: %s", operation, err.Error())
+	}
+
+	return &object.ReturnValue{Values: []object.Object{
+		object.NIL,
+		createIOError(code, message),
+	}}
+}

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -24,11 +24,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.read_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.read_file() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.read_file() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.read_file() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.read_file() requires a string path"}
 			}
 
 			content, err := os.ReadFile(path.Value)
@@ -52,15 +52,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.write_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.write_file() takes exactly 2 arguments (path, content)"}
+				return &object.Error{Code: "E7001", Message: "io.write_file() takes exactly 2 arguments (path, content)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.write_file() requires a string path as first argument"}
+				return &object.Error{Code: "E7003", Message: "io.write_file() requires a string path as first argument"}
 			}
 			content, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8003", Message: "io.write_file() requires a string content as second argument"}
+				return &object.Error{Code: "E7003", Message: "io.write_file() requires a string content as second argument"}
 			}
 
 			err := os.WriteFile(path.Value, []byte(content.Value), 0644)
@@ -80,15 +80,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.append_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.append_file() takes exactly 2 arguments (path, content)"}
+				return &object.Error{Code: "E7001", Message: "io.append_file() takes exactly 2 arguments (path, content)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.append_file() requires a string path as first argument"}
+				return &object.Error{Code: "E7003", Message: "io.append_file() requires a string path as first argument"}
 			}
 			content, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8003", Message: "io.append_file() requires a string content as second argument"}
+				return &object.Error{Code: "E7003", Message: "io.append_file() requires a string content as second argument"}
 			}
 
 			f, err := os.OpenFile(path.Value, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -117,11 +117,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.exists": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.exists() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.exists() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.exists() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.exists() requires a string path"}
 			}
 
 			_, err := os.Stat(path.Value)
@@ -140,11 +140,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.is_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.is_file() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.is_file() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.is_file() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.is_file() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -162,11 +162,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.is_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.is_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.is_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.is_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.is_dir() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -189,11 +189,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.remove() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.remove() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.remove() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.remove() requires a string path"}
 			}
 
 			// Check if it's a directory - if so, don't allow removal with this function
@@ -204,7 +204,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if info.IsDir() {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8006", "io.remove() cannot remove directories, use io.remove_dir() instead"),
+					createIOError("E7018", "io.remove() cannot remove directories, use io.remove_dir() instead"),
 				}}
 			}
 
@@ -225,11 +225,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.remove_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.remove_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.remove_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.remove_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.remove_dir() requires a string path"}
 			}
 
 			// Check if it's actually a directory
@@ -240,7 +240,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if !info.IsDir() {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8007", "io.remove_dir() can only remove directories, use io.remove() for files"),
+					createIOError("E7019", "io.remove_dir() can only remove directories, use io.remove() for files"),
 				}}
 			}
 
@@ -261,11 +261,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.remove_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.remove_all() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.remove_all() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.remove_all() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.remove_all() requires a string path"}
 			}
 
 			// Safety check: don't allow removing root or home directory
@@ -278,7 +278,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if absPath == "/" || absPath == filepath.Clean(os.Getenv("HOME")) {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8008", "io.remove_all() cannot remove root or home directory for safety"),
+					createIOError("E7020", "io.remove_all() cannot remove root or home directory for safety"),
 				}}
 			}
 
@@ -299,15 +299,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.rename": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.rename() takes exactly 2 arguments (old_path, new_path)"}
+				return &object.Error{Code: "E7001", Message: "io.rename() takes exactly 2 arguments (old_path, new_path)"}
 			}
 			oldPath, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.rename() requires a string as first argument (old_path)"}
+				return &object.Error{Code: "E7003", Message: "io.rename() requires a string as first argument (old_path)"}
 			}
 			newPath, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.rename() requires a string as second argument (new_path)"}
+				return &object.Error{Code: "E7003", Message: "io.rename() requires a string as second argument (new_path)"}
 			}
 
 			err := os.Rename(oldPath.Value, newPath.Value)
@@ -327,15 +327,15 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.copy": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E8001", Message: "io.copy() takes exactly 2 arguments (source, destination)"}
+				return &object.Error{Code: "E7001", Message: "io.copy() takes exactly 2 arguments (source, destination)"}
 			}
 			srcPath, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.copy() requires a string as first argument (source)"}
+				return &object.Error{Code: "E7003", Message: "io.copy() requires a string as first argument (source)"}
 			}
 			dstPath, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.copy() requires a string as second argument (destination)"}
+				return &object.Error{Code: "E7003", Message: "io.copy() requires a string as second argument (destination)"}
 			}
 
 			// Check source exists and is a file
@@ -346,7 +346,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			if srcInfo.IsDir() {
 				return &object.ReturnValue{Values: []object.Object{
 					object.FALSE,
-					createIOError("E8009", "io.copy() cannot copy directories, only files"),
+					createIOError("E7021", "io.copy() cannot copy directories, only files"),
 				}}
 			}
 
@@ -393,11 +393,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.mkdir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.mkdir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.mkdir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.mkdir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.mkdir() requires a string path"}
 			}
 
 			err := os.Mkdir(path.Value, 0755)
@@ -417,11 +417,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.mkdir_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.mkdir_all() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.mkdir_all() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.mkdir_all() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.mkdir_all() requires a string path"}
 			}
 
 			err := os.MkdirAll(path.Value, 0755)
@@ -441,11 +441,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.read_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.read_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.read_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.read_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.read_dir() requires a string path"}
 			}
 
 			entries, err := os.ReadDir(path.Value)
@@ -474,11 +474,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.file_size": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.file_size() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.file_size() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.file_size() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.file_size() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -498,11 +498,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.file_mod_time": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.file_mod_time() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.file_mod_time() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.file_mod_time() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.file_mod_time() requires a string path"}
 			}
 
 			info, err := os.Stat(path.Value)
@@ -525,14 +525,14 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_join() takes at least 1 argument"}
+				return &object.Error{Code: "E7001", Message: "io.path_join() takes at least 1 argument"}
 			}
 
 			parts := make([]string, len(args))
 			for i, arg := range args {
 				str, ok := arg.(*object.String)
 				if !ok {
-					return &object.Error{Code: "E8002", Message: fmt.Sprintf("io.path_join() argument %d must be a string", i+1)}
+					return &object.Error{Code: "E7003", Message: fmt.Sprintf("io.path_join() argument %d must be a string", i+1)}
 				}
 				parts[i] = str.Value
 			}
@@ -545,11 +545,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_base": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_base() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_base() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_base() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_base() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Base(path.Value)}
@@ -560,11 +560,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_dir() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_dir() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_dir() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_dir() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Dir(path.Value)}
@@ -575,11 +575,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_ext": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_ext() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_ext() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_ext() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_ext() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Ext(path.Value)}
@@ -591,11 +591,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_abs": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_abs() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_abs() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_abs() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_abs() requires a string path"}
 			}
 
 			absPath, err := filepath.Abs(path.Value)
@@ -614,11 +614,11 @@ var IOBuiltins = map[string]*object.Builtin{
 	"io.path_clean": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E8001", Message: "io.path_clean() takes exactly 1 argument (path)"}
+				return &object.Error{Code: "E7001", Message: "io.path_clean() takes exactly 1 argument (path)"}
 			}
 			path, ok := args[0].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E8002", Message: "io.path_clean() requires a string path"}
+				return &object.Error{Code: "E7003", Message: "io.path_clean() requires a string path"}
 			}
 
 			return &object.String{Value: filepath.Clean(path.Value)}
@@ -651,19 +651,19 @@ func createIOErrorResult(err error, operation string) *object.ReturnValue {
 
 	// Determine error code based on error type
 	if os.IsNotExist(err) {
-		code = "E8004"
+		code = "E7016"
 		message = fmt.Sprintf("file or directory not found: %s", err.Error())
 	} else if os.IsPermission(err) {
-		code = "E8005"
+		code = "E7017"
 		message = fmt.Sprintf("permission denied: %s", err.Error())
 	} else if os.IsExist(err) {
-		code = "E8010"
+		code = "E7022"
 		message = fmt.Sprintf("file or directory already exists: %s", err.Error())
 	} else if strings.Contains(err.Error(), "directory not empty") {
-		code = "E8011"
+		code = "E7023"
 		message = fmt.Sprintf("directory not empty: %s", err.Error())
 	} else {
-		code = "E8099"
+		code = "E7099"
 		message = fmt.Sprintf("io error during %s: %s", operation, err.Error())
 	}
 

--- a/pkg/stdlib/io_test.go
+++ b/pkg/stdlib/io_test.go
@@ -113,8 +113,8 @@ func TestIOReadFile(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, ok := errStruct.Fields["code"].(*object.String)
-		if !ok || code.Value != "E8004" {
-			t.Errorf("expected error code E8004, got %v", errStruct.Fields["code"])
+		if !ok || code.Value != "E7016" {
+			t.Errorf("expected error code E7016, got %v", errStruct.Fields["code"])
 		}
 	})
 
@@ -328,8 +328,8 @@ func TestIORemove(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8006" {
-			t.Errorf("expected E8006, got %s", code.Value)
+		if code.Value != "E7018" {
+			t.Errorf("expected E7018, got %s", code.Value)
 		}
 	})
 }
@@ -359,8 +359,8 @@ func TestIORemoveDir(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8007" {
-			t.Errorf("expected E8007, got %s", code.Value)
+		if code.Value != "E7019" {
+			t.Errorf("expected E7019, got %s", code.Value)
 		}
 	})
 
@@ -399,8 +399,8 @@ func TestIORemoveAll(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8008" {
-			t.Errorf("expected E8008 safety error, got %s", code.Value)
+		if code.Value != "E7020" {
+			t.Errorf("expected E7020 safety error, got %s", code.Value)
 		}
 	})
 }
@@ -465,8 +465,8 @@ func TestIOCopy(t *testing.T) {
 		errStruct := assertHasError(t, result)
 
 		code, _ := errStruct.Fields["code"].(*object.String)
-		if code.Value != "E8009" {
-			t.Errorf("expected E8009, got %s", code.Value)
+		if code.Value != "E7021" {
+			t.Errorf("expected E7021, got %s", code.Value)
 		}
 	})
 }

--- a/pkg/stdlib/io_test.go
+++ b/pkg/stdlib/io_test.go
@@ -1,0 +1,867 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// ============================================================================
+// Test Helpers for IO Module
+// ============================================================================
+
+// createTempDir creates a temporary directory for testing and returns its path
+// and a cleanup function
+func createTempDir(t *testing.T) (string, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ez_io_test_*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	return dir, func() {
+		os.RemoveAll(dir)
+	}
+}
+
+// createTempFile creates a temporary file with the given content and returns its path
+func createTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	return path
+}
+
+// getReturnValues extracts values from a ReturnValue object
+func getReturnValues(t *testing.T, obj object.Object) []object.Object {
+	t.Helper()
+	rv, ok := obj.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", obj)
+	}
+	return rv.Values
+}
+
+// assertNoError checks that the second return value is nil (no error)
+func assertNoError(t *testing.T, obj object.Object) {
+	t.Helper()
+	vals := getReturnValues(t, obj)
+	if len(vals) < 2 {
+		t.Fatalf("expected at least 2 return values, got %d", len(vals))
+	}
+	if vals[1] != object.NIL {
+		if errStruct, ok := vals[1].(*object.Struct); ok {
+			if msg, ok := errStruct.Fields["message"].(*object.String); ok {
+				t.Fatalf("expected no error, got: %s", msg.Value)
+			}
+		}
+		t.Fatalf("expected nil error, got %T", vals[1])
+	}
+}
+
+// assertHasError checks that the second return value is an error
+func assertHasError(t *testing.T, obj object.Object) *object.Struct {
+	t.Helper()
+	vals := getReturnValues(t, obj)
+	if len(vals) < 2 {
+		t.Fatalf("expected at least 2 return values, got %d", len(vals))
+	}
+	errStruct, ok := vals[1].(*object.Struct)
+	if !ok || vals[1] == object.NIL {
+		t.Fatalf("expected error struct, got %T", vals[1])
+	}
+	return errStruct
+}
+
+// ============================================================================
+// File Reading Tests
+// ============================================================================
+
+func TestIOReadFile(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	readFileFn := IOBuiltins["io.read_file"].Fn
+
+	t.Run("read existing file", func(t *testing.T) {
+		content := "Hello, EZ!"
+		path := createTempFile(t, dir, "test.txt", content)
+
+		result := readFileFn(&object.String{Value: path})
+		assertNoError(t, result)
+
+		vals := getReturnValues(t, result)
+		str, ok := vals[0].(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", vals[0])
+		}
+		if str.Value != content {
+			t.Errorf("expected %q, got %q", content, str.Value)
+		}
+	})
+
+	t.Run("read non-existent file", func(t *testing.T) {
+		result := readFileFn(&object.String{Value: filepath.Join(dir, "nonexistent.txt")})
+		errStruct := assertHasError(t, result)
+
+		code, ok := errStruct.Fields["code"].(*object.String)
+		if !ok || code.Value != "E8004" {
+			t.Errorf("expected error code E8004, got %v", errStruct.Fields["code"])
+		}
+	})
+
+	t.Run("wrong argument count", func(t *testing.T) {
+		result := readFileFn()
+		if !isErrorObject(result) {
+			t.Error("expected error for no arguments")
+		}
+	})
+
+	t.Run("wrong argument type", func(t *testing.T) {
+		result := readFileFn(&object.Integer{Value: 123})
+		if !isErrorObject(result) {
+			t.Error("expected error for wrong argument type")
+		}
+	})
+}
+
+// ============================================================================
+// File Writing Tests
+// ============================================================================
+
+func TestIOWriteFile(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	writeFileFn := IOBuiltins["io.write_file"].Fn
+
+	t.Run("write new file", func(t *testing.T) {
+		path := filepath.Join(dir, "new_file.txt")
+		content := "Test content"
+
+		result := writeFileFn(&object.String{Value: path}, &object.String{Value: content})
+		assertNoError(t, result)
+
+		// Verify file was created
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read written file: %v", err)
+		}
+		if string(data) != content {
+			t.Errorf("expected %q, got %q", content, string(data))
+		}
+	})
+
+	t.Run("overwrite existing file", func(t *testing.T) {
+		path := createTempFile(t, dir, "existing.txt", "old content")
+		newContent := "new content"
+
+		result := writeFileFn(&object.String{Value: path}, &object.String{Value: newContent})
+		assertNoError(t, result)
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+		if string(data) != newContent {
+			t.Errorf("expected %q, got %q", newContent, string(data))
+		}
+	})
+
+	t.Run("wrong argument count", func(t *testing.T) {
+		result := writeFileFn(&object.String{Value: "path"})
+		if !isErrorObject(result) {
+			t.Error("expected error for missing content argument")
+		}
+	})
+}
+
+func TestIOAppendFile(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	appendFileFn := IOBuiltins["io.append_file"].Fn
+
+	t.Run("append to existing file", func(t *testing.T) {
+		path := createTempFile(t, dir, "append_test.txt", "Hello")
+
+		result := appendFileFn(&object.String{Value: path}, &object.String{Value: " World"})
+		assertNoError(t, result)
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+		if string(data) != "Hello World" {
+			t.Errorf("expected %q, got %q", "Hello World", string(data))
+		}
+	})
+
+	t.Run("append to new file", func(t *testing.T) {
+		path := filepath.Join(dir, "new_append.txt")
+
+		result := appendFileFn(&object.String{Value: path}, &object.String{Value: "New content"})
+		assertNoError(t, result)
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+		if string(data) != "New content" {
+			t.Errorf("expected %q, got %q", "New content", string(data))
+		}
+	})
+}
+
+// ============================================================================
+// Path Existence Tests
+// ============================================================================
+
+func TestIOExists(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	existsFn := IOBuiltins["io.exists"].Fn
+
+	t.Run("existing file", func(t *testing.T) {
+		path := createTempFile(t, dir, "exists.txt", "content")
+		result := existsFn(&object.String{Value: path})
+		testBooleanObject(t, result, true)
+	})
+
+	t.Run("existing directory", func(t *testing.T) {
+		result := existsFn(&object.String{Value: dir})
+		testBooleanObject(t, result, true)
+	})
+
+	t.Run("non-existent path", func(t *testing.T) {
+		result := existsFn(&object.String{Value: filepath.Join(dir, "nonexistent")})
+		testBooleanObject(t, result, false)
+	})
+}
+
+func TestIOIsFile(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	isFileFn := IOBuiltins["io.is_file"].Fn
+
+	t.Run("regular file", func(t *testing.T) {
+		path := createTempFile(t, dir, "file.txt", "content")
+		result := isFileFn(&object.String{Value: path})
+		testBooleanObject(t, result, true)
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		result := isFileFn(&object.String{Value: dir})
+		testBooleanObject(t, result, false)
+	})
+
+	t.Run("non-existent", func(t *testing.T) {
+		result := isFileFn(&object.String{Value: filepath.Join(dir, "nonexistent")})
+		testBooleanObject(t, result, false)
+	})
+}
+
+func TestIOIsDir(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	isDirFn := IOBuiltins["io.is_dir"].Fn
+
+	t.Run("directory", func(t *testing.T) {
+		result := isDirFn(&object.String{Value: dir})
+		testBooleanObject(t, result, true)
+	})
+
+	t.Run("regular file", func(t *testing.T) {
+		path := createTempFile(t, dir, "file.txt", "content")
+		result := isDirFn(&object.String{Value: path})
+		testBooleanObject(t, result, false)
+	})
+
+	t.Run("non-existent", func(t *testing.T) {
+		result := isDirFn(&object.String{Value: filepath.Join(dir, "nonexistent")})
+		testBooleanObject(t, result, false)
+	})
+}
+
+// ============================================================================
+// File Operation Tests
+// ============================================================================
+
+func TestIORemove(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	removeFn := IOBuiltins["io.remove"].Fn
+
+	t.Run("remove existing file", func(t *testing.T) {
+		path := createTempFile(t, dir, "to_remove.txt", "content")
+
+		result := removeFn(&object.String{Value: path})
+		assertNoError(t, result)
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Error("file should have been removed")
+		}
+	})
+
+	t.Run("remove non-existent file", func(t *testing.T) {
+		result := removeFn(&object.String{Value: filepath.Join(dir, "nonexistent.txt")})
+		assertHasError(t, result)
+	})
+
+	t.Run("cannot remove directory", func(t *testing.T) {
+		subdir := filepath.Join(dir, "subdir")
+		os.Mkdir(subdir, 0755)
+
+		result := removeFn(&object.String{Value: subdir})
+		errStruct := assertHasError(t, result)
+
+		code, _ := errStruct.Fields["code"].(*object.String)
+		if code.Value != "E8006" {
+			t.Errorf("expected E8006, got %s", code.Value)
+		}
+	})
+}
+
+func TestIORemoveDir(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	removeDirFn := IOBuiltins["io.remove_dir"].Fn
+
+	t.Run("remove empty directory", func(t *testing.T) {
+		subdir := filepath.Join(dir, "empty_dir")
+		os.Mkdir(subdir, 0755)
+
+		result := removeDirFn(&object.String{Value: subdir})
+		assertNoError(t, result)
+
+		if _, err := os.Stat(subdir); !os.IsNotExist(err) {
+			t.Error("directory should have been removed")
+		}
+	})
+
+	t.Run("cannot remove file", func(t *testing.T) {
+		path := createTempFile(t, dir, "file.txt", "content")
+
+		result := removeDirFn(&object.String{Value: path})
+		errStruct := assertHasError(t, result)
+
+		code, _ := errStruct.Fields["code"].(*object.String)
+		if code.Value != "E8007" {
+			t.Errorf("expected E8007, got %s", code.Value)
+		}
+	})
+
+	t.Run("cannot remove non-empty directory", func(t *testing.T) {
+		subdir := filepath.Join(dir, "non_empty")
+		os.Mkdir(subdir, 0755)
+		createTempFile(t, subdir, "file.txt", "content")
+
+		result := removeDirFn(&object.String{Value: subdir})
+		assertHasError(t, result)
+	})
+}
+
+func TestIORemoveAll(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	removeAllFn := IOBuiltins["io.remove_all"].Fn
+
+	t.Run("remove directory recursively", func(t *testing.T) {
+		subdir := filepath.Join(dir, "recursive")
+		os.MkdirAll(filepath.Join(subdir, "nested"), 0755)
+		createTempFile(t, subdir, "file1.txt", "content")
+		createTempFile(t, filepath.Join(subdir, "nested"), "file2.txt", "content")
+
+		result := removeAllFn(&object.String{Value: subdir})
+		assertNoError(t, result)
+
+		if _, err := os.Stat(subdir); !os.IsNotExist(err) {
+			t.Error("directory should have been removed recursively")
+		}
+	})
+
+	t.Run("safety check for root", func(t *testing.T) {
+		result := removeAllFn(&object.String{Value: "/"})
+		errStruct := assertHasError(t, result)
+
+		code, _ := errStruct.Fields["code"].(*object.String)
+		if code.Value != "E8008" {
+			t.Errorf("expected E8008 safety error, got %s", code.Value)
+		}
+	})
+}
+
+func TestIORename(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	renameFn := IOBuiltins["io.rename"].Fn
+
+	t.Run("rename file", func(t *testing.T) {
+		oldPath := createTempFile(t, dir, "old_name.txt", "content")
+		newPath := filepath.Join(dir, "new_name.txt")
+
+		result := renameFn(&object.String{Value: oldPath}, &object.String{Value: newPath})
+		assertNoError(t, result)
+
+		if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+			t.Error("old file should not exist")
+		}
+		if _, err := os.Stat(newPath); err != nil {
+			t.Error("new file should exist")
+		}
+	})
+
+	t.Run("rename non-existent file", func(t *testing.T) {
+		result := renameFn(
+			&object.String{Value: filepath.Join(dir, "nonexistent.txt")},
+			&object.String{Value: filepath.Join(dir, "new.txt")},
+		)
+		assertHasError(t, result)
+	})
+}
+
+func TestIOCopy(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	copyFn := IOBuiltins["io.copy"].Fn
+
+	t.Run("copy file", func(t *testing.T) {
+		srcPath := createTempFile(t, dir, "source.txt", "Hello, Copy!")
+		dstPath := filepath.Join(dir, "destination.txt")
+
+		result := copyFn(&object.String{Value: srcPath}, &object.String{Value: dstPath})
+		assertNoError(t, result)
+
+		// Both files should exist
+		srcData, _ := os.ReadFile(srcPath)
+		dstData, _ := os.ReadFile(dstPath)
+
+		if string(srcData) != string(dstData) {
+			t.Error("copied file content should match source")
+		}
+	})
+
+	t.Run("cannot copy directory", func(t *testing.T) {
+		subdir := filepath.Join(dir, "subdir")
+		os.Mkdir(subdir, 0755)
+
+		result := copyFn(&object.String{Value: subdir}, &object.String{Value: filepath.Join(dir, "copy")})
+		errStruct := assertHasError(t, result)
+
+		code, _ := errStruct.Fields["code"].(*object.String)
+		if code.Value != "E8009" {
+			t.Errorf("expected E8009, got %s", code.Value)
+		}
+	})
+}
+
+// ============================================================================
+// Directory Operation Tests
+// ============================================================================
+
+func TestIOMkdir(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	mkdirFn := IOBuiltins["io.mkdir"].Fn
+
+	t.Run("create directory", func(t *testing.T) {
+		path := filepath.Join(dir, "new_dir")
+
+		result := mkdirFn(&object.String{Value: path})
+		assertNoError(t, result)
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("directory should exist: %v", err)
+		}
+		if !info.IsDir() {
+			t.Error("should be a directory")
+		}
+	})
+
+	t.Run("cannot create nested without parent", func(t *testing.T) {
+		path := filepath.Join(dir, "parent", "child")
+
+		result := mkdirFn(&object.String{Value: path})
+		assertHasError(t, result)
+	})
+}
+
+func TestIOMkdirAll(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	mkdirAllFn := IOBuiltins["io.mkdir_all"].Fn
+
+	t.Run("create nested directories", func(t *testing.T) {
+		path := filepath.Join(dir, "parent", "child", "grandchild")
+
+		result := mkdirAllFn(&object.String{Value: path})
+		assertNoError(t, result)
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("directory should exist: %v", err)
+		}
+		if !info.IsDir() {
+			t.Error("should be a directory")
+		}
+	})
+}
+
+func TestIOReadDir(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	readDirFn := IOBuiltins["io.read_dir"].Fn
+
+	t.Run("list directory contents", func(t *testing.T) {
+		createTempFile(t, dir, "file1.txt", "content")
+		createTempFile(t, dir, "file2.txt", "content")
+		os.Mkdir(filepath.Join(dir, "subdir"), 0755)
+
+		result := readDirFn(&object.String{Value: dir})
+		assertNoError(t, result)
+
+		vals := getReturnValues(t, result)
+		arr, ok := vals[0].(*object.Array)
+		if !ok {
+			t.Fatalf("expected Array, got %T", vals[0])
+		}
+
+		if len(arr.Elements) != 3 {
+			t.Errorf("expected 3 entries, got %d", len(arr.Elements))
+		}
+	})
+
+	t.Run("read non-existent directory", func(t *testing.T) {
+		result := readDirFn(&object.String{Value: filepath.Join(dir, "nonexistent")})
+		assertHasError(t, result)
+	})
+}
+
+// ============================================================================
+// File Metadata Tests
+// ============================================================================
+
+func TestIOFileSize(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	fileSizeFn := IOBuiltins["io.file_size"].Fn
+
+	t.Run("get file size", func(t *testing.T) {
+		content := "Hello, World!"
+		path := createTempFile(t, dir, "sized.txt", content)
+
+		result := fileSizeFn(&object.String{Value: path})
+		assertNoError(t, result)
+
+		vals := getReturnValues(t, result)
+		size, ok := vals[0].(*object.Integer)
+		if !ok {
+			t.Fatalf("expected Integer, got %T", vals[0])
+		}
+		if size.Value != int64(len(content)) {
+			t.Errorf("expected %d, got %d", len(content), size.Value)
+		}
+	})
+
+	t.Run("non-existent file", func(t *testing.T) {
+		result := fileSizeFn(&object.String{Value: filepath.Join(dir, "nonexistent.txt")})
+		assertHasError(t, result)
+	})
+}
+
+func TestIOFileModTime(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	fileModTimeFn := IOBuiltins["io.file_mod_time"].Fn
+
+	t.Run("get modification time", func(t *testing.T) {
+		path := createTempFile(t, dir, "timed.txt", "content")
+
+		result := fileModTimeFn(&object.String{Value: path})
+		assertNoError(t, result)
+
+		vals := getReturnValues(t, result)
+		timestamp, ok := vals[0].(*object.Integer)
+		if !ok {
+			t.Fatalf("expected Integer, got %T", vals[0])
+		}
+		if timestamp.Value <= 0 {
+			t.Error("timestamp should be positive")
+		}
+	})
+}
+
+// ============================================================================
+// Path Utility Tests
+// ============================================================================
+
+func TestIOPathJoin(t *testing.T) {
+	pathJoinFn := IOBuiltins["io.path_join"].Fn
+
+	t.Run("join multiple parts", func(t *testing.T) {
+		result := pathJoinFn(
+			&object.String{Value: "home"},
+			&object.String{Value: "user"},
+			&object.String{Value: "documents"},
+		)
+
+		str, ok := result.(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", result)
+		}
+
+		expected := filepath.Join("home", "user", "documents")
+		if str.Value != expected {
+			t.Errorf("expected %q, got %q", expected, str.Value)
+		}
+	})
+
+	t.Run("no arguments", func(t *testing.T) {
+		result := pathJoinFn()
+		if !isErrorObject(result) {
+			t.Error("expected error for no arguments")
+		}
+	})
+}
+
+func TestIOPathBase(t *testing.T) {
+	pathBaseFn := IOBuiltins["io.path_base"].Fn
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/home/user/file.txt", "file.txt"},
+		{"/home/user/", "user"},
+		{"file.txt", "file.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := pathBaseFn(&object.String{Value: tt.input})
+			testStringObject(t, result, tt.expected)
+		})
+	}
+}
+
+func TestIOPathDir(t *testing.T) {
+	pathDirFn := IOBuiltins["io.path_dir"].Fn
+
+	t.Run("get directory", func(t *testing.T) {
+		result := pathDirFn(&object.String{Value: "/home/user/file.txt"})
+		str, ok := result.(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", result)
+		}
+		// Normalize for comparison
+		expected := filepath.Dir("/home/user/file.txt")
+		if str.Value != expected {
+			t.Errorf("expected %q, got %q", expected, str.Value)
+		}
+	})
+}
+
+func TestIOPathExt(t *testing.T) {
+	pathExtFn := IOBuiltins["io.path_ext"].Fn
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"file.txt", ".txt"},
+		{"file.tar.gz", ".gz"},
+		{"file", ""},
+		{".hidden", ".hidden"}, // Go's filepath.Ext treats .hidden as extension
+		{"noext", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := pathExtFn(&object.String{Value: tt.input})
+			testStringObject(t, result, tt.expected)
+		})
+	}
+}
+
+func TestIOPathAbs(t *testing.T) {
+	pathAbsFn := IOBuiltins["io.path_abs"].Fn
+
+	t.Run("get absolute path", func(t *testing.T) {
+		result := pathAbsFn(&object.String{Value: "."})
+		assertNoError(t, result)
+
+		vals := getReturnValues(t, result)
+		str, ok := vals[0].(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", vals[0])
+		}
+		if !filepath.IsAbs(str.Value) {
+			t.Error("result should be an absolute path")
+		}
+	})
+}
+
+func TestIOPathClean(t *testing.T) {
+	pathCleanFn := IOBuiltins["io.path_clean"].Fn
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"./foo/bar/../baz", filepath.Clean("./foo/bar/../baz")},
+		{"foo//bar", filepath.Clean("foo//bar")},
+		{"/a/b/../c", filepath.Clean("/a/b/../c")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := pathCleanFn(&object.String{Value: tt.input})
+			testStringObject(t, result, tt.expected)
+		})
+	}
+}
+
+func TestIOPathSeparator(t *testing.T) {
+	pathSeparatorFn := IOBuiltins["io.path_separator"].Fn
+
+	result := pathSeparatorFn()
+	str, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("expected String, got %T", result)
+	}
+
+	expected := string(filepath.Separator)
+	if str.Value != expected {
+		t.Errorf("expected %q, got %q", expected, str.Value)
+	}
+
+	// Platform-specific check
+	if runtime.GOOS == "windows" {
+		if str.Value != "\\" {
+			t.Error("expected backslash on Windows")
+		}
+	} else {
+		if str.Value != "/" {
+			t.Error("expected forward slash on Unix")
+		}
+	}
+}
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+func TestIOIntegration(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	t.Run("write then read", func(t *testing.T) {
+		writeFileFn := IOBuiltins["io.write_file"].Fn
+		readFileFn := IOBuiltins["io.read_file"].Fn
+
+		path := filepath.Join(dir, "integration.txt")
+		content := "Integration test content"
+
+		// Write
+		writeResult := writeFileFn(&object.String{Value: path}, &object.String{Value: content})
+		assertNoError(t, writeResult)
+
+		// Read
+		readResult := readFileFn(&object.String{Value: path})
+		assertNoError(t, readResult)
+
+		vals := getReturnValues(t, readResult)
+		str, _ := vals[0].(*object.String)
+		if str.Value != content {
+			t.Errorf("read content doesn't match written content")
+		}
+	})
+
+	t.Run("mkdir then read_dir", func(t *testing.T) {
+		mkdirFn := IOBuiltins["io.mkdir"].Fn
+		readDirFn := IOBuiltins["io.read_dir"].Fn
+		writeFileFn := IOBuiltins["io.write_file"].Fn
+
+		subdir := filepath.Join(dir, "subdir_test")
+
+		// Create directory
+		mkdirResult := mkdirFn(&object.String{Value: subdir})
+		assertNoError(t, mkdirResult)
+
+		// Create files in directory
+		writeFileFn(&object.String{Value: filepath.Join(subdir, "a.txt")}, &object.String{Value: "a"})
+		writeFileFn(&object.String{Value: filepath.Join(subdir, "b.txt")}, &object.String{Value: "b"})
+
+		// Read directory
+		readResult := readDirFn(&object.String{Value: subdir})
+		assertNoError(t, readResult)
+
+		vals := getReturnValues(t, readResult)
+		arr, _ := vals[0].(*object.Array)
+		if len(arr.Elements) != 2 {
+			t.Errorf("expected 2 files, got %d", len(arr.Elements))
+		}
+	})
+}
+
+// ============================================================================
+// GetAllBuiltins Integration Test
+// ============================================================================
+
+func TestIOBuiltinsRegistered(t *testing.T) {
+	builtins := GetAllBuiltins()
+
+	expectedFunctions := []string{
+		"io.read_file",
+		"io.write_file",
+		"io.append_file",
+		"io.exists",
+		"io.is_file",
+		"io.is_dir",
+		"io.remove",
+		"io.remove_dir",
+		"io.remove_all",
+		"io.rename",
+		"io.copy",
+		"io.mkdir",
+		"io.mkdir_all",
+		"io.read_dir",
+		"io.file_size",
+		"io.file_mod_time",
+		"io.path_join",
+		"io.path_base",
+		"io.path_dir",
+		"io.path_ext",
+		"io.path_abs",
+		"io.path_clean",
+		"io.path_separator",
+	}
+
+	for _, name := range expectedFunctions {
+		if builtins[name] == nil {
+			t.Errorf("expected builtin %q not found in GetAllBuiltins()", name)
+		}
+	}
+}

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -154,7 +154,7 @@ var OSBuiltins = map[string]*object.Builtin{
 				}
 			}
 			os.Exit(code)
-			return object.NIL // Never reached
+			select {} // Unreachable; satisfies compiler requirement
 		},
 	},
 

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -1,0 +1,407 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// CommandLineArgs stores the command-line arguments passed to the EZ program
+// This should be set by the main package before evaluation
+var CommandLineArgs []string
+
+// OSBuiltins contains the os module functions for system operations
+var OSBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// Environment Variables
+	// ============================================================================
+
+	// Gets an environment variable by name
+	// Returns the value as a string, or nil if not set
+	"os.get_env": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "os.get_env() takes exactly 1 argument (name)"}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.get_env() requires a string argument"}
+			}
+
+			value, exists := os.LookupEnv(name.Value)
+			if !exists {
+				return object.NIL
+			}
+			return &object.String{Value: value}
+		},
+	},
+
+	// Sets an environment variable (process-scoped only)
+	// Returns true on success, (false, error) on failure
+	"os.set_env": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "os.set_env() takes exactly 2 arguments (name, value)"}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.set_env() requires a string name as first argument"}
+			}
+			value, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.set_env() requires a string value as second argument"}
+			}
+
+			err := os.Setenv(name.Value, value.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createOSError("E7024", fmt.Sprintf("failed to set environment variable: %s", err.Error())),
+				}}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Unsets an environment variable
+	// Returns true on success, (false, error) on failure
+	"os.unset_env": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "os.unset_env() takes exactly 1 argument (name)"}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.unset_env() requires a string argument"}
+			}
+
+			err := os.Unsetenv(name.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createOSError("E7024", fmt.Sprintf("failed to unset environment variable: %s", err.Error())),
+				}}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns all environment variables as a map
+	"os.env": {
+		Fn: func(args ...object.Object) object.Object {
+			envMap := object.NewMap()
+			for _, entry := range os.Environ() {
+				// Find the first = to split key and value
+				for i := 0; i < len(entry); i++ {
+					if entry[i] == '=' {
+						key := entry[:i]
+						value := entry[i+1:]
+						envMap.Set(&object.String{Value: key}, &object.String{Value: value})
+						break
+					}
+				}
+			}
+			envMap.Mutable = false
+			return envMap
+		},
+	},
+
+	// Returns command-line arguments as an array
+	// First element is the program name/path
+	"os.args": {
+		Fn: func(args ...object.Object) object.Object {
+			// Use CommandLineArgs if set, otherwise fall back to os.Args
+			sourceArgs := CommandLineArgs
+			if len(sourceArgs) == 0 {
+				sourceArgs = os.Args
+			}
+
+			elements := make([]object.Object, len(sourceArgs))
+			for i, arg := range sourceArgs {
+				elements[i] = &object.String{Value: arg}
+			}
+			return &object.Array{Elements: elements, Mutable: false}
+		},
+	},
+
+	// ============================================================================
+	// Process / System
+	// ============================================================================
+
+	// Exits the program with the given status code
+	"os.exit": {
+		Fn: func(args ...object.Object) object.Object {
+			code := 0
+			if len(args) > 0 {
+				if codeObj, ok := args[0].(*object.Integer); ok {
+					code = int(codeObj.Value)
+				} else {
+					return &object.Error{Code: "E7003", Message: "os.exit() requires an integer exit code"}
+				}
+			}
+			os.Exit(code)
+			return object.NIL // Never reached
+		},
+	},
+
+	// Returns the current working directory
+	// Returns (path, error) tuple
+	"os.cwd": {
+		Fn: func(args ...object.Object) object.Object {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7025", fmt.Sprintf("failed to get current directory: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: cwd},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Changes the current working directory
+	// Returns (success, error) tuple
+	"os.chdir": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "os.chdir() takes exactly 1 argument (path)"}
+			}
+			path, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "os.chdir() requires a string path"}
+			}
+
+			err := os.Chdir(path.Value)
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					object.FALSE,
+					createOSError("E7026", fmt.Sprintf("failed to change directory: %s", err.Error())),
+				}}
+			}
+
+			return &object.ReturnValue{Values: []object.Object{
+				object.TRUE,
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the hostname of the machine
+	// Returns (hostname, error) tuple
+	"os.hostname": {
+		Fn: func(args ...object.Object) object.Object {
+			hostname, err := os.Hostname()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7027", fmt.Sprintf("failed to get hostname: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: hostname},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the current user's username
+	// Returns (username, error) tuple
+	"os.username": {
+		Fn: func(args ...object.Object) object.Object {
+			currentUser, err := user.Current()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7028", fmt.Sprintf("failed to get username: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: currentUser.Username},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the current user's home directory
+	// Returns (path, error) tuple
+	"os.home_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7029", fmt.Sprintf("failed to get home directory: %s", err.Error())),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: homeDir},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Returns the system's temporary directory
+	"os.temp_dir": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: os.TempDir()}
+		},
+	},
+
+	// Returns the process ID of the current process
+	"os.pid": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: int64(os.Getpid())}
+		},
+	},
+
+	// Returns the parent process ID
+	"os.ppid": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: int64(os.Getppid())}
+		},
+	},
+
+	// ============================================================================
+	// Platform Detection
+	// ============================================================================
+
+	// OS Constants - use these for comparison with CURRENT_OS
+	"os.MAC_OS": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: 0}
+		},
+	},
+	"os.LINUX": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: 1}
+		},
+	},
+	"os.WINDOWS": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: 2}
+		},
+	},
+
+	// Returns the current OS as a constant (matches os.MAC_OS, os.LINUX, or os.WINDOWS)
+	"os.CURRENT_OS": {
+		Fn: func(args ...object.Object) object.Object {
+			switch runtime.GOOS {
+			case "darwin":
+				return &object.Integer{Value: 0} // MAC_OS
+			case "linux":
+				return &object.Integer{Value: 1} // LINUX
+			case "windows":
+				return &object.Integer{Value: 2} // WINDOWS
+			default:
+				return &object.Integer{Value: -1} // Unknown
+			}
+		},
+	},
+
+	// Returns the operating system name as a string
+	// Possible values: "darwin", "linux", "windows", "freebsd", etc.
+	"os.platform": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: runtime.GOOS}
+		},
+	},
+
+	// Returns the CPU architecture
+	// Possible values: "amd64", "arm64", "386", "arm", etc.
+	"os.arch": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.String{Value: runtime.GOARCH}
+		},
+	},
+
+	// Returns true if running on Windows
+	"os.is_windows": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "windows" {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Returns true if running on Linux
+	"os.is_linux": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "linux" {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Returns true if running on macOS
+	"os.is_macos": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "darwin" {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	// Returns the number of CPUs available
+	"os.num_cpu": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: int64(runtime.NumCPU())}
+		},
+	},
+
+	// ============================================================================
+	// Platform Constants
+	// ============================================================================
+
+	// Returns the line separator for the current platform
+	// "\r\n" on Windows, "\n" on Unix-like systems
+	"os.line_separator": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "windows" {
+				return &object.String{Value: "\r\n"}
+			}
+			return &object.String{Value: "\n"}
+		},
+	},
+
+	// Returns the null device path for the current platform
+	// "NUL" on Windows, "/dev/null" on Unix-like systems
+	"os.dev_null": {
+		Fn: func(args ...object.Object) object.Object {
+			if runtime.GOOS == "windows" {
+				return &object.String{Value: "NUL"}
+			}
+			return &object.String{Value: "/dev/null"}
+		},
+	},
+}
+
+// createOSError creates an Error struct for OS operations
+func createOSError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -1,0 +1,584 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// ============================================================================
+// Environment Variables Tests
+// ============================================================================
+
+func TestOSGetEnv(t *testing.T) {
+	fn := OSBuiltins["os.get_env"]
+
+	// Set a test environment variable
+	os.Setenv("EZ_TEST_VAR", "test_value")
+	defer os.Unsetenv("EZ_TEST_VAR")
+
+	// Test getting existing variable
+	result := fn.Fn(&object.String{Value: "EZ_TEST_VAR"})
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+	if strResult.Value != "test_value" {
+		t.Errorf("Expected 'test_value', got '%s'", strResult.Value)
+	}
+
+	// Test getting non-existent variable
+	result = fn.Fn(&object.String{Value: "EZ_NONEXISTENT_VAR_12345"})
+	if result != object.NIL {
+		t.Errorf("Expected NIL for non-existent var, got %T", result)
+	}
+
+	// Test wrong argument count
+	result = fn.Fn()
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7001" {
+		t.Errorf("Expected error code E7001, got %s", errResult.Code)
+	}
+
+	// Test wrong argument type
+	result = fn.Fn(&object.Integer{Value: 123})
+	errResult, ok = result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7003" {
+		t.Errorf("Expected error code E7003, got %s", errResult.Code)
+	}
+}
+
+func TestOSSetEnv(t *testing.T) {
+	fn := OSBuiltins["os.set_env"]
+
+	// Test setting a new variable
+	result := fn.Fn(&object.String{Value: "EZ_SET_TEST"}, &object.String{Value: "new_value"})
+	defer os.Unsetenv("EZ_SET_TEST")
+
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+	if retVal.Values[0] != object.TRUE {
+		t.Errorf("Expected TRUE, got %v", retVal.Values[0])
+	}
+
+	// Verify it was actually set
+	if os.Getenv("EZ_SET_TEST") != "new_value" {
+		t.Errorf("Environment variable was not set correctly")
+	}
+
+	// Test wrong argument count
+	result = fn.Fn(&object.String{Value: "test"})
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7001" {
+		t.Errorf("Expected error code E7001, got %s", errResult.Code)
+	}
+}
+
+func TestOSUnsetEnv(t *testing.T) {
+	fn := OSBuiltins["os.unset_env"]
+
+	// Set then unset a variable
+	os.Setenv("EZ_UNSET_TEST", "to_be_removed")
+
+	result := fn.Fn(&object.String{Value: "EZ_UNSET_TEST"})
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if retVal.Values[0] != object.TRUE {
+		t.Errorf("Expected TRUE, got %v", retVal.Values[0])
+	}
+
+	// Verify it was unset
+	if _, exists := os.LookupEnv("EZ_UNSET_TEST"); exists {
+		t.Errorf("Environment variable should have been unset")
+	}
+}
+
+func TestOSEnv(t *testing.T) {
+	fn := OSBuiltins["os.env"]
+
+	// Set a known test variable
+	os.Setenv("EZ_ENV_TEST", "test123")
+	defer os.Unsetenv("EZ_ENV_TEST")
+
+	result := fn.Fn()
+	mapResult, ok := result.(*object.Map)
+	if !ok {
+		t.Fatalf("Expected Map, got %T", result)
+	}
+
+	// Check that it contains our test variable
+	key := &object.String{Value: "EZ_ENV_TEST"}
+	val, _ := mapResult.Get(key)
+	strVal, ok := val.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String value for EZ_ENV_TEST, got %T", val)
+	}
+	if strVal.Value != "test123" {
+		t.Errorf("Expected 'test123', got '%s'", strVal.Value)
+	}
+
+	// Check that the map is immutable
+	if mapResult.Mutable {
+		t.Errorf("Environment map should be immutable")
+	}
+}
+
+func TestOSArgs(t *testing.T) {
+	fn := OSBuiltins["os.args"]
+
+	// Set CommandLineArgs for testing
+	originalArgs := CommandLineArgs
+	CommandLineArgs = []string{"program", "arg1", "arg2"}
+	defer func() { CommandLineArgs = originalArgs }()
+
+	result := fn.Fn()
+	arrResult, ok := result.(*object.Array)
+	if !ok {
+		t.Fatalf("Expected Array, got %T", result)
+	}
+
+	if len(arrResult.Elements) != 3 {
+		t.Fatalf("Expected 3 elements, got %d", len(arrResult.Elements))
+	}
+
+	expectedArgs := []string{"program", "arg1", "arg2"}
+	for i, expected := range expectedArgs {
+		strElem, ok := arrResult.Elements[i].(*object.String)
+		if !ok {
+			t.Fatalf("Expected String at index %d, got %T", i, arrResult.Elements[i])
+		}
+		if strElem.Value != expected {
+			t.Errorf("At index %d: expected '%s', got '%s'", i, expected, strElem.Value)
+		}
+	}
+
+	// Check that the array is immutable
+	if arrResult.Mutable {
+		t.Errorf("Args array should be immutable")
+	}
+}
+
+// ============================================================================
+// Process / System Tests
+// ============================================================================
+
+func TestOSCwd(t *testing.T) {
+	fn := OSBuiltins["os.cwd"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	// Get actual cwd
+	expectedCwd, _ := os.Getwd()
+	if strResult.Value != expectedCwd {
+		t.Errorf("Expected '%s', got '%s'", expectedCwd, strResult.Value)
+	}
+
+	// Error should be nil
+	if retVal.Values[1] != object.NIL {
+		t.Errorf("Expected NIL error, got %v", retVal.Values[1])
+	}
+}
+
+func TestOSChdir(t *testing.T) {
+	fn := OSBuiltins["os.chdir"]
+
+	// Save current directory
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	// Change to temp dir
+	tempDir := os.TempDir()
+	result := fn.Fn(&object.String{Value: tempDir})
+
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	if retVal.Values[0] != object.TRUE {
+		t.Errorf("Expected TRUE, got %v", retVal.Values[0])
+	}
+
+	// Test changing to non-existent directory
+	result = fn.Fn(&object.String{Value: "/nonexistent/path/12345"})
+	retVal, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	if retVal.Values[0] != object.FALSE {
+		t.Errorf("Expected FALSE for invalid path, got %v", retVal.Values[0])
+	}
+
+	// Test wrong argument count
+	result = fn.Fn()
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error, got %T", result)
+	}
+	if errResult.Code != "E7001" {
+		t.Errorf("Expected error code E7001, got %s", errResult.Code)
+	}
+}
+
+func TestOSHostname(t *testing.T) {
+	fn := OSBuiltins["os.hostname"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	expectedHostname, _ := os.Hostname()
+	if strResult.Value != expectedHostname {
+		t.Errorf("Expected '%s', got '%s'", expectedHostname, strResult.Value)
+	}
+}
+
+func TestOSUsername(t *testing.T) {
+	fn := OSBuiltins["os.username"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	currentUser, _ := user.Current()
+	if strResult.Value != currentUser.Username {
+		t.Errorf("Expected '%s', got '%s'", currentUser.Username, strResult.Value)
+	}
+}
+
+func TestOSHomeDir(t *testing.T) {
+	fn := OSBuiltins["os.home_dir"]
+
+	result := fn.Fn()
+	retVal, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", retVal.Values[0])
+	}
+
+	expectedHome, _ := os.UserHomeDir()
+	if strResult.Value != expectedHome {
+		t.Errorf("Expected '%s', got '%s'", expectedHome, strResult.Value)
+	}
+}
+
+func TestOSTempDir(t *testing.T) {
+	fn := OSBuiltins["os.temp_dir"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	if strResult.Value != os.TempDir() {
+		t.Errorf("Expected '%s', got '%s'", os.TempDir(), strResult.Value)
+	}
+}
+
+func TestOSPid(t *testing.T) {
+	fn := OSBuiltins["os.pid"]
+
+	result := fn.Fn()
+	intResult, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("Expected Integer, got %T", result)
+	}
+
+	if intResult.Value != int64(os.Getpid()) {
+		t.Errorf("Expected %d, got %d", os.Getpid(), intResult.Value)
+	}
+}
+
+func TestOSPpid(t *testing.T) {
+	fn := OSBuiltins["os.ppid"]
+
+	result := fn.Fn()
+	intResult, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("Expected Integer, got %T", result)
+	}
+
+	if intResult.Value != int64(os.Getppid()) {
+		t.Errorf("Expected %d, got %d", os.Getppid(), intResult.Value)
+	}
+}
+
+// ============================================================================
+// Platform Detection Tests
+// ============================================================================
+
+func TestOSConstants(t *testing.T) {
+	macOS := OSBuiltins["os.MAC_OS"]
+	linux := OSBuiltins["os.LINUX"]
+	windows := OSBuiltins["os.WINDOWS"]
+	currentOS := OSBuiltins["os.CURRENT_OS"]
+
+	// Check constants have expected values
+	macResult := macOS.Fn().(*object.Integer)
+	linuxResult := linux.Fn().(*object.Integer)
+	windowsResult := windows.Fn().(*object.Integer)
+
+	if macResult.Value != 0 {
+		t.Errorf("Expected MAC_OS = 0, got %d", macResult.Value)
+	}
+	if linuxResult.Value != 1 {
+		t.Errorf("Expected LINUX = 1, got %d", linuxResult.Value)
+	}
+	if windowsResult.Value != 2 {
+		t.Errorf("Expected WINDOWS = 2, got %d", windowsResult.Value)
+	}
+
+	// Check CURRENT_OS matches expected constant for this platform
+	currentResult := currentOS.Fn().(*object.Integer)
+	switch runtime.GOOS {
+	case "darwin":
+		if currentResult.Value != 0 {
+			t.Errorf("Expected CURRENT_OS = MAC_OS (0) on darwin, got %d", currentResult.Value)
+		}
+	case "linux":
+		if currentResult.Value != 1 {
+			t.Errorf("Expected CURRENT_OS = LINUX (1) on linux, got %d", currentResult.Value)
+		}
+	case "windows":
+		if currentResult.Value != 2 {
+			t.Errorf("Expected CURRENT_OS = WINDOWS (2) on windows, got %d", currentResult.Value)
+		}
+	}
+}
+
+func TestOSPlatform(t *testing.T) {
+	fn := OSBuiltins["os.platform"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	if strResult.Value != runtime.GOOS {
+		t.Errorf("Expected '%s', got '%s'", runtime.GOOS, strResult.Value)
+	}
+}
+
+func TestOSArch(t *testing.T) {
+	fn := OSBuiltins["os.arch"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	if strResult.Value != runtime.GOARCH {
+		t.Errorf("Expected '%s', got '%s'", runtime.GOARCH, strResult.Value)
+	}
+}
+
+func TestOSIsWindows(t *testing.T) {
+	fn := OSBuiltins["os.is_windows"]
+
+	result := fn.Fn()
+	boolResult, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("Expected Boolean, got %T", result)
+	}
+
+	expected := runtime.GOOS == "windows"
+	if boolResult.Value != expected {
+		t.Errorf("Expected %v, got %v", expected, boolResult.Value)
+	}
+}
+
+func TestOSIsLinux(t *testing.T) {
+	fn := OSBuiltins["os.is_linux"]
+
+	result := fn.Fn()
+	boolResult, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("Expected Boolean, got %T", result)
+	}
+
+	expected := runtime.GOOS == "linux"
+	if boolResult.Value != expected {
+		t.Errorf("Expected %v, got %v", expected, boolResult.Value)
+	}
+}
+
+func TestOSIsMacos(t *testing.T) {
+	fn := OSBuiltins["os.is_macos"]
+
+	result := fn.Fn()
+	boolResult, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("Expected Boolean, got %T", result)
+	}
+
+	expected := runtime.GOOS == "darwin"
+	if boolResult.Value != expected {
+		t.Errorf("Expected %v, got %v", expected, boolResult.Value)
+	}
+}
+
+func TestOSNumCpu(t *testing.T) {
+	fn := OSBuiltins["os.num_cpu"]
+
+	result := fn.Fn()
+	intResult, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("Expected Integer, got %T", result)
+	}
+
+	if intResult.Value != int64(runtime.NumCPU()) {
+		t.Errorf("Expected %d, got %d", runtime.NumCPU(), intResult.Value)
+	}
+}
+
+// ============================================================================
+// Platform Constants Tests
+// ============================================================================
+
+func TestOSLineSeparator(t *testing.T) {
+	fn := OSBuiltins["os.line_separator"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	var expected string
+	if runtime.GOOS == "windows" {
+		expected = "\r\n"
+	} else {
+		expected = "\n"
+	}
+
+	if strResult.Value != expected {
+		t.Errorf("Expected '%q', got '%q'", expected, strResult.Value)
+	}
+}
+
+func TestOSDevNull(t *testing.T) {
+	fn := OSBuiltins["os.dev_null"]
+
+	result := fn.Fn()
+	strResult, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("Expected String, got %T", result)
+	}
+
+	var expected string
+	if runtime.GOOS == "windows" {
+		expected = "NUL"
+	} else {
+		expected = "/dev/null"
+	}
+
+	if strResult.Value != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, strResult.Value)
+	}
+}
+
+// ============================================================================
+// Exit function test (cannot test os.Exit directly, just verify function exists)
+// ============================================================================
+
+func TestOSExitExists(t *testing.T) {
+	fn := OSBuiltins["os.exit"]
+	if fn == nil {
+		t.Error("os.exit function should exist")
+	}
+
+	// Test wrong argument type (we can test error handling but not actual exit)
+	result := fn.Fn(&object.String{Value: "not a number"})
+	errResult, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("Expected Error for wrong type, got %T", result)
+	}
+	if errResult.Code != "E7003" {
+		t.Errorf("Expected error code E7003, got %s", errResult.Code)
+	}
+}
+
+// ============================================================================
+// Helper function tests
+// ============================================================================
+
+func TestCreateOSError(t *testing.T) {
+	err := createOSError("E9999", "test error message")
+
+	if err.TypeName != "Error" {
+		t.Errorf("Expected TypeName 'Error', got '%s'", err.TypeName)
+	}
+
+	msgField, ok := err.Fields["message"].(*object.String)
+	if !ok {
+		t.Fatalf("Expected message field to be String, got %T", err.Fields["message"])
+	}
+	if msgField.Value != "test error message" {
+		t.Errorf("Expected message 'test error message', got '%s'", msgField.Value)
+	}
+
+	codeField, ok := err.Fields["code"].(*object.String)
+	if !ok {
+		t.Fatalf("Expected code field to be String, got %T", err.Fields["code"])
+	}
+	if codeField.Value != "E9999" {
+		t.Errorf("Expected code 'E9999', got '%s'", codeField.Value)
+	}
+}

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -34,6 +34,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range MapsBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range IOBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -40,6 +40,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range OSBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range BytesBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -37,6 +37,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range IOBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range OSBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -172,7 +172,7 @@ func (tc *TypeChecker) registerBuiltinTypes() {
 		// Floats
 		"f32", "f64", "float",
 		// Other primitives
-		"bool", "char", "string",
+		"bool", "char", "string", "byte",
 		// Special
 		"void", "nil",
 	}
@@ -2026,7 +2026,7 @@ func (tc *TypeChecker) isNumericType(typeName string) bool {
 	switch typeName {
 	case "int", "i8", "i16", "i32", "i64", "i128", "i256",
 		"uint", "u8", "u16", "u32", "u64", "u128", "u256",
-		"float", "f32", "f64":
+		"float", "f32", "f64", "byte":
 		return true
 	default:
 		return false
@@ -2155,6 +2155,17 @@ func (tc *TypeChecker) typesCompatible(declared, actual string) bool {
 	// For now, we allow int to unsigned assignment and let runtime catch negative values
 	if tc.isUnsignedIntegerType(declared) && tc.isSignedIntegerType(actual) {
 		// We'll be permissive here - the runtime already catches negative values
+		return true
+	}
+
+	// Byte type compatibility - bytes are like unsigned 8-bit integers
+	// Allow int to byte assignment (runtime validates 0-255 range)
+	if declared == "byte" && (tc.isSignedIntegerType(actual) || tc.isUnsignedIntegerType(actual)) {
+		return true
+	}
+
+	// Allow byte to integer/unsigned types
+	if (tc.isSignedIntegerType(declared) || tc.isUnsignedIntegerType(declared)) && actual == "byte" {
 		return true
 	}
 

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -17,7 +17,7 @@
 // IMPORTS
 // ==================================================
 
-import @std, @math, @arrays, @strings, @maps, @time
+import @std, @math, @arrays, @strings, @maps, @time, @io
 
 using std
 
@@ -145,6 +145,10 @@ do main() {
     total_failed += result.failed
 
     result = test_stdlib_time()
+    total_passed += result.passed
+    total_failed += result.failed
+
+    result = test_stdlib_io()
     total_passed += result.passed
     total_failed += result.failed
 
@@ -1041,6 +1045,228 @@ do test_printf_and_escapes() -> TestResult {
     temp quote_str string = "She said \"Hello\""
     println("  Escaped quotes: ${quote_str}")
     passed += 1
+
+    println("  PASSED: ${passed}, FAILED: ${failed}")
+    return TestResult{passed: passed, failed: failed}
+}
+
+// ==================================================
+// STDLIB: @io
+// ==================================================
+
+do test_stdlib_io() -> TestResult {
+    print_section("Standard Library: @io")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Create a test directory for our IO tests
+    temp test_dir string = io.path_join(".", "ez_io_test_temp")
+
+    // Test mkdir (use multi-return without type annotations)
+    temp mkdir_ok, mkdir_err = io.mkdir(test_dir)
+    if mkdir_err == nil {
+        println("  io.mkdir('${test_dir}') = success")
+        passed += 1
+    } otherwise {
+        println("  io.mkdir failed (may already exist)")
+        passed += 1
+    }
+
+    // Test exists
+    temp dir_exists bool = io.exists(test_dir)
+    println("  io.exists('${test_dir}') = ${dir_exists}")
+    passed += 1
+
+    // Test is_dir
+    temp is_directory bool = io.is_dir(test_dir)
+    println("  io.is_dir('${test_dir}') = ${is_directory}")
+    passed += 1
+
+    // Test write_file
+    temp test_file string = io.path_join(test_dir, "test.txt")
+    temp content string = "Hello from EZ IO test!\nThis is line 2."
+    temp write_ok, write_err = io.write_file(test_file, content)
+    if write_err == nil {
+        println("  io.write_file() = success")
+        passed += 1
+    } otherwise {
+        println("  io.write_file() = FAILED")
+        failed += 1
+    }
+
+    // Test is_file
+    temp is_regular_file bool = io.is_file(test_file)
+    println("  io.is_file('${test_file}') = ${is_regular_file}")
+    passed += 1
+
+    // Test read_file
+    temp read_content, read_err = io.read_file(test_file)
+    if read_err == nil {
+        println("  io.read_file() = success (${len(read_content)} bytes)")
+        passed += 1
+    } otherwise {
+        println("  io.read_file() = FAILED")
+        failed += 1
+    }
+
+    // Test append_file
+    temp append_ok, append_err = io.append_file(test_file, "\nAppended line.")
+    if append_err == nil {
+        println("  io.append_file() = success")
+        passed += 1
+    } otherwise {
+        println("  io.append_file() = FAILED")
+        failed += 1
+    }
+
+    // Verify append worked
+    temp updated_content, @ignore = io.read_file(test_file)
+    temp has_append bool = strings.contains(updated_content, "Appended line")
+    println("  Append verification: ${has_append}")
+    passed += 1
+
+    // Test file_size
+    temp size, size_err = io.file_size(test_file)
+    if size_err == nil {
+        println("  io.file_size('${test_file}') = ${size} bytes")
+        passed += 1
+    } otherwise {
+        println("  io.file_size() = FAILED")
+        failed += 1
+    }
+
+    // Test file_mod_time
+    temp mod_time, mod_err = io.file_mod_time(test_file)
+    if mod_err == nil {
+        println("  io.file_mod_time() = ${mod_time} (Unix timestamp)")
+        passed += 1
+    } otherwise {
+        println("  io.file_mod_time() = FAILED")
+        failed += 1
+    }
+
+    // Test copy
+    temp copy_dest string = io.path_join(test_dir, "copy.txt")
+    temp copy_ok, copy_err = io.copy(test_file, copy_dest)
+    if copy_err == nil {
+        println("  io.copy() = success")
+        passed += 1
+    } otherwise {
+        println("  io.copy() = FAILED")
+        failed += 1
+    }
+
+    // Test rename
+    temp rename_dest string = io.path_join(test_dir, "renamed.txt")
+    temp rename_ok, rename_err = io.rename(copy_dest, rename_dest)
+    if rename_err == nil {
+        println("  io.rename() = success")
+        passed += 1
+    } otherwise {
+        println("  io.rename() = FAILED")
+        failed += 1
+    }
+
+    // Test mkdir_all (nested directories)
+    temp nested_dir string = io.path_join(test_dir, "a", "b", "c")
+    temp mkdirall_ok, mkdirall_err = io.mkdir_all(nested_dir)
+    if mkdirall_err == nil {
+        println("  io.mkdir_all('${nested_dir}') = success")
+        passed += 1
+    } otherwise {
+        println("  io.mkdir_all() = FAILED")
+        failed += 1
+    }
+
+    // Test read_dir
+    temp entries, readdir_err = io.read_dir(test_dir)
+    if readdir_err == nil {
+        println("  io.read_dir() returned ${len(entries)} entries:")
+        for_each entry in entries {
+            println("    - ${entry}")
+        }
+        passed += 1
+    } otherwise {
+        println("  io.read_dir() = FAILED")
+        failed += 1
+    }
+
+    // Test path utilities
+    println("")
+    println("  Path Utilities:")
+    temp sample_path string = io.path_join("home", "user", "docs", "file.txt")
+    println("  io.path_join('home', 'user', 'docs', 'file.txt') = '${sample_path}'")
+    passed += 1
+
+    temp base string = io.path_base(sample_path)
+    println("  io.path_base('${sample_path}') = '${base}'")
+    passed += 1
+
+    temp dir string = io.path_dir(sample_path)
+    println("  io.path_dir('${sample_path}') = '${dir}'")
+    passed += 1
+
+    temp ext string = io.path_ext(sample_path)
+    println("  io.path_ext('${sample_path}') = '${ext}'")
+    passed += 1
+
+    temp separator string = io.path_separator()
+    println("  io.path_separator() = '${separator}'")
+    passed += 1
+
+    temp clean_path string = io.path_clean("./foo/../bar//baz")
+    println("  io.path_clean('./foo/../bar//baz') = '${clean_path}'")
+    passed += 1
+
+    temp abs_path, abs_err = io.path_abs(".")
+    if abs_err == nil {
+        println("  io.path_abs('.') = '${abs_path}'")
+        passed += 1
+    } otherwise {
+        println("  io.path_abs() = FAILED")
+        failed += 1
+    }
+
+    // Test error handling - non-existent file
+    println("")
+    println("  Error Handling:")
+    temp not_found_content, not_found_err = io.read_file("nonexistent_file_12345.txt")
+    if not_found_err != nil {
+        println("  io.read_file(nonexistent) correctly returned error")
+        passed += 1
+    } otherwise {
+        println("  Expected error but got nil")
+        failed += 1
+    }
+
+    // Cleanup - remove test files and directories
+    println("")
+    println("  Cleanup:")
+
+    // Remove files first
+    temp rm1_ok, rm1_err = io.remove(test_file)
+    temp rm2_ok, rm2_err = io.remove(rename_dest)
+    println("  Removed test files")
+
+    // Remove nested directory recursively
+    temp rmall_ok, rmall_err = io.remove_all(test_dir)
+    if rmall_err == nil {
+        println("  io.remove_all('${test_dir}') = success")
+        passed += 1
+    } otherwise {
+        println("  io.remove_all() = FAILED")
+        failed += 1
+    }
+
+    // Verify cleanup
+    temp still_exists bool = io.exists(test_dir)
+    if !still_exists {
+        println("  Cleanup verified - directory removed")
+        passed += 1
+    } otherwise {
+        println("  Cleanup incomplete")
+        failed += 1
+    }
 
     println("  PASSED: ${passed}, FAILED: ${failed}")
     return TestResult{passed: passed, failed: failed}

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -17,7 +17,7 @@
 // IMPORTS
 // ==================================================
 
-import @std, @math, @arrays, @strings, @maps, @time, @io
+import @std, @math, @arrays, @strings, @maps, @time, @io, @os
 
 using std
 
@@ -149,6 +149,10 @@ do main() {
     total_failed += result.failed
 
     result = test_stdlib_io()
+    total_passed += result.passed
+    total_failed += result.failed
+
+    result = test_stdlib_os()
     total_passed += result.passed
     total_failed += result.failed
 
@@ -1265,6 +1269,315 @@ do test_stdlib_io() -> TestResult {
         passed += 1
     } otherwise {
         println("  Cleanup incomplete")
+        failed += 1
+    }
+
+    println("  PASSED: ${passed}, FAILED: ${failed}")
+    return TestResult{passed: passed, failed: failed}
+}
+
+do test_stdlib_os() -> TestResult {
+    print_section("Standard Library: @os")
+    temp passed int = 0
+    temp failed int = 0
+
+    // ============================================================================
+    // Environment Variables
+    // ============================================================================
+    println("  Environment Variables:")
+
+    // Test os.get_env - this should work on any system
+    temp path_value = os.get_env("PATH")
+    if path_value != nil {
+        println("  os.get_env('PATH') = [value present, ${len(path_value)} chars]")
+        passed += 1
+    } otherwise {
+        println("  os.get_env('PATH') = nil (unexpected)")
+        failed += 1
+    }
+
+    // Test os.get_env for non-existent variable
+    temp nonexistent = os.get_env("EZ_NONEXISTENT_VAR_12345")
+    if nonexistent == nil {
+        println("  os.get_env('EZ_NONEXISTENT_VAR_12345') = nil (correct)")
+        passed += 1
+    } otherwise {
+        println("  os.get_env('EZ_NONEXISTENT_VAR_12345') should be nil")
+        failed += 1
+    }
+
+    // Test os.set_env
+    temp set_ok, set_err = os.set_env("EZ_TEST_VAR", "test_value_123")
+    if set_err == nil {
+        println("  os.set_env('EZ_TEST_VAR', 'test_value_123') = success")
+        passed += 1
+
+        // Verify it was set
+        temp verify_value = os.get_env("EZ_TEST_VAR")
+        if verify_value == "test_value_123" {
+            println("  os.get_env('EZ_TEST_VAR') = '${verify_value}' (verified)")
+            passed += 1
+        } otherwise {
+            println("  Verification failed")
+            failed += 1
+        }
+    } otherwise {
+        println("  os.set_env() = FAILED")
+        failed += 1
+    }
+
+    // Test os.unset_env
+    temp unset_ok, unset_err = os.unset_env("EZ_TEST_VAR")
+    if unset_err == nil {
+        println("  os.unset_env('EZ_TEST_VAR') = success")
+        passed += 1
+
+        // Verify it was unset
+        temp after_unset = os.get_env("EZ_TEST_VAR")
+        if after_unset == nil {
+            println("  Variable correctly unset (verified)")
+            passed += 1
+        } otherwise {
+            println("  Variable should have been unset")
+            failed += 1
+        }
+    } otherwise {
+        println("  os.unset_env() = FAILED")
+        failed += 1
+    }
+
+    // Test os.env - get all environment variables
+    temp all_env = os.env()
+    temp env_count int = len(all_env)
+    if env_count > 0 {
+        println("  os.env() = [map with ${env_count} entries]")
+        passed += 1
+    } otherwise {
+        println("  os.env() returned empty map (unexpected)")
+        failed += 1
+    }
+
+    // Test os.args
+    temp args = os.args()
+    println("  os.args() = [array with ${len(args)} entries]")
+    passed += 1
+
+    // ============================================================================
+    // Process / System
+    // ============================================================================
+    println("")
+    println("  Process / System:")
+
+    // Test os.cwd
+    temp cwd, cwd_err = os.cwd()
+    if cwd_err == nil {
+        println("  os.cwd() = '${cwd}'")
+        passed += 1
+    } otherwise {
+        println("  os.cwd() = FAILED")
+        failed += 1
+    }
+
+    // Test os.hostname
+    temp hostname, host_err = os.hostname()
+    if host_err == nil {
+        println("  os.hostname() = '${hostname}'")
+        passed += 1
+    } otherwise {
+        println("  os.hostname() = FAILED")
+        failed += 1
+    }
+
+    // Test os.username
+    temp username, user_err = os.username()
+    if user_err == nil {
+        println("  os.username() = '${username}'")
+        passed += 1
+    } otherwise {
+        println("  os.username() = FAILED")
+        failed += 1
+    }
+
+    // Test os.home_dir
+    temp home, home_err = os.home_dir()
+    if home_err == nil {
+        println("  os.home_dir() = '${home}'")
+        passed += 1
+    } otherwise {
+        println("  os.home_dir() = FAILED")
+        failed += 1
+    }
+
+    // Test os.temp_dir
+    temp temp_dir string = os.temp_dir()
+    println("  os.temp_dir() = '${temp_dir}'")
+    passed += 1
+
+    // Test os.pid
+    temp pid int = os.pid()
+    println("  os.pid() = ${pid}")
+    passed += 1
+
+    // Test os.ppid
+    temp ppid int = os.ppid()
+    println("  os.ppid() = ${ppid}")
+    passed += 1
+
+    // ============================================================================
+    // OS Constants
+    // ============================================================================
+    println("")
+    println("  OS Constants:")
+
+    // Test that constants have expected values
+    println("  os.MAC_OS = ${os.MAC_OS}")
+    println("  os.LINUX = ${os.LINUX}")
+    println("  os.WINDOWS = ${os.WINDOWS}")
+    println("  os.CURRENT_OS = ${os.CURRENT_OS}")
+    passed += 1
+
+    // Test CURRENT_OS matches one of the constants
+    if os.CURRENT_OS == os.MAC_OS {
+        println("  os.CURRENT_OS == os.MAC_OS (correct for macOS)")
+        passed += 1
+    }
+    if os.CURRENT_OS == os.LINUX {
+        println("  os.CURRENT_OS == os.LINUX (correct for Linux)")
+        passed += 1
+    }
+    if os.CURRENT_OS == os.WINDOWS {
+        println("  os.CURRENT_OS == os.WINDOWS (correct for Windows)")
+        passed += 1
+    }
+
+    // ============================================================================
+    // Platform Detection
+    // ============================================================================
+    println("")
+    println("  Platform Detection:")
+
+    // Test os.platform
+    temp platform string = os.platform()
+    println("  os.platform() = '${platform}'")
+    passed += 1
+
+    // Test os.arch
+    temp arch string = os.arch()
+    println("  os.arch() = '${arch}'")
+    passed += 1
+
+    // Test os.is_windows
+    temp is_win bool = os.is_windows()
+    println("  os.is_windows() = ${is_win}")
+    passed += 1
+
+    // Test os.is_linux
+    temp is_lin bool = os.is_linux()
+    println("  os.is_linux() = ${is_lin}")
+    passed += 1
+
+    // Test os.is_macos
+    temp is_mac bool = os.is_macos()
+    println("  os.is_macos() = ${is_mac}")
+    passed += 1
+
+    // Verify platform consistency
+    temp platform_verified bool = false
+    if platform == "darwin" && is_mac {
+        println("  Platform consistency: darwin == is_macos (verified)")
+        platform_verified = true
+    }
+    if platform == "linux" && is_lin {
+        println("  Platform consistency: linux == is_linux (verified)")
+        platform_verified = true
+    }
+    if platform == "windows" && is_win {
+        println("  Platform consistency: windows == is_windows (verified)")
+        platform_verified = true
+    }
+    if !platform_verified {
+        println("  Platform consistency check: passed")
+    }
+    passed += 1
+
+    // Test os.num_cpu
+    temp num_cpus int = os.num_cpu()
+    if num_cpus > 0 {
+        println("  os.num_cpu() = ${num_cpus}")
+        passed += 1
+    } otherwise {
+        println("  os.num_cpu() should be > 0")
+        failed += 1
+    }
+
+    // ============================================================================
+    // Platform Constants
+    // ============================================================================
+    println("")
+    println("  Platform Constants:")
+
+    // Test os.line_separator - just check that it returns a non-empty string
+    temp line_sep string = os.line_separator()
+    temp line_sep_len int = len(line_sep)
+    if line_sep_len > 0 && line_sep_len <= 2 {
+        println("  os.line_separator() = [${line_sep_len} char(s)]")
+        passed += 1
+    } otherwise {
+        println("  os.line_separator() unexpected length: ${line_sep_len}")
+        failed += 1
+    }
+
+    // Test os.dev_null
+    temp dev_null string = os.dev_null()
+    temp dev_null_ok bool = false
+    if is_win && dev_null == "NUL" {
+        println("  os.dev_null() = '${dev_null}' (Windows)")
+        dev_null_ok = true
+    }
+    if !is_win && dev_null == "/dev/null" {
+        println("  os.dev_null() = '${dev_null}' (Unix)")
+        dev_null_ok = true
+    }
+    if dev_null_ok {
+        passed += 1
+    } otherwise {
+        println("  os.dev_null() = '${dev_null}' (unexpected value for platform)")
+        failed += 1
+    }
+
+    // ============================================================================
+    // Test os.chdir (carefully - restore original directory)
+    // ============================================================================
+    println("")
+    println("  Directory Operations:")
+
+    temp original_dir, @ignore = os.cwd()
+    temp target_dir string = os.temp_dir()
+
+    temp chdir_ok, chdir_err = os.chdir(target_dir)
+    if chdir_err == nil {
+        temp new_cwd, new_cwd_err = os.cwd()
+        println("  os.chdir('${target_dir}') = success")
+        println("  Current dir after chdir: '${new_cwd}'")
+        passed += 1
+
+        // Restore original directory
+        temp restore_ok, restore_err = os.chdir(original_dir)
+        temp restored_cwd, restored_err = os.cwd()
+        println("  Restored to: '${restored_cwd}'")
+        passed += 1
+    } otherwise {
+        println("  os.chdir() = FAILED")
+        failed += 1
+    }
+
+    // Test chdir to invalid directory
+    temp bad_chdir_ok, bad_chdir_err = os.chdir("/nonexistent/path/12345")
+    if bad_chdir_err != nil {
+        println("  os.chdir(invalid) correctly returned error")
+        passed += 1
+    } otherwise {
+        println("  os.chdir(invalid) should have returned error")
         failed += 1
     }
 


### PR DESCRIPTION
## Summary

This release brings major additions to the EZ standard library and language features:

### @io Module (#245)
File system operations including:
- File read/write (`io.read_file`, `io.write_file`, `io.append_file`)
- File/directory checks (`io.exists`, `io.is_file`, `io.is_dir`)
- File operations (`io.remove`, `io.rename`, `io.copy`)
- Directory operations (`io.mkdir`, `io.mkdir_all`, `io.read_dir`, `io.remove_dir`, `io.remove_all`)
- Path utilities (`io.path_join`, `io.path_base`, `io.path_dir`, `io.path_ext`, `io.path_abs`, `io.path_clean`)
- File metadata (`io.file_size`, `io.file_mod_time`)

### @os Module (#246)
Operating system operations including:
- Environment variables (`os.get_env`, `os.set_env`, `os.unset_env`, `os.env`)
- Process info (`os.args`, `os.exit`, `os.pid`, `os.ppid`)
- Directory operations (`os.cwd`, `os.chdir`)
- System info (`os.hostname`, `os.username`, `os.home_dir`, `os.temp_dir`)
- Platform detection (`os.platform`, `os.arch`, `os.is_windows`, `os.is_linux`, `os.is_macos`)
- System constants (`os.CURRENT_OS`, `os.MAC_OS`, `os.LINUX`, `os.WINDOWS`, `os.num_cpu`, `os.line_separator`, `os.dev_null`)

### Byte Data Types (#248, #249)
- Native `byte` type (unsigned 8-bit, 0-255)
- `[byte]` byte array type
- Hex literals (`0xFF`, `0xDEAD_BEEF`)
- Binary literals (`0b1010`, `0b1111_0000`)
- Compile-time validation (E3021, E3022)
- Warnings for byte overflow (W2006) and implicit promotion (W2004)

### @bytes Module (#250, #251)
36 functions for binary data manipulation:
- Creation: `from_array`, `from_string`, `from_hex`, `from_base64`
- Conversion: `to_string`, `to_array`, `to_hex`, `to_hex_upper`, `to_base64`
- Operations: `slice`, `concat`, `join`, `split`, `contains`, `index`, `last_index`, `count`, `compare`, `equals`
- Inspection: `is_empty`, `starts_with`, `ends_with`
- Manipulation: `reverse`, `repeat`, `replace`, `replace_n`, `trim`, `trim_left`, `trim_right`, `pad_left`, `pad_right`
- Bitwise: `and`, `or`, `xor`, `not`
- Utility: `fill`, `copy`, `zero`

## Test Plan

- [x] All Go unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Closes

Closes #243
Closes #244
Closes #248
Closes #250