### PR TITLE
feat(io): byte operations, file handles & enhancements

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -180,6 +180,35 @@ var (
 
 	// Legacy codes for backward compatibility with builtins
 	E7015 = ErrorCode{"E7015", "len-unsupported-type", "len not supported for type"}
+
+	// I/O errors
+	E7016 = ErrorCode{"E7016", "file-not-found", "file or directory not found"}
+	E7017 = ErrorCode{"E7017", "permission-denied", "permission denied"}
+	E7018 = ErrorCode{"E7018", "cannot-remove-directory", "io.remove() cannot remove directories"}
+	E7019 = ErrorCode{"E7019", "cannot-remove-file", "io.remove_dir() can only remove directories"}
+	E7020 = ErrorCode{"E7020", "safety-check-failed", "cannot remove root or home directory"}
+	E7021 = ErrorCode{"E7021", "cannot-copy-directory", "io.copy() cannot copy directories"}
+	E7022 = ErrorCode{"E7022", "file-already-exists", "file or directory already exists"}
+	E7023 = ErrorCode{"E7023", "directory-not-empty", "directory not empty"}
+
+	// OS module errors
+	E7024 = ErrorCode{"E7024", "env-var-operation-failed", "environment variable operation failed"}
+	E7025 = ErrorCode{"E7025", "get-cwd-failed", "failed to get current directory"}
+	E7026 = ErrorCode{"E7026", "chdir-failed", "failed to change directory"}
+	E7027 = ErrorCode{"E7027", "get-hostname-failed", "failed to get hostname"}
+	E7028 = ErrorCode{"E7028", "get-username-failed", "failed to get username"}
+	E7029 = ErrorCode{"E7029", "get-homedir-failed", "failed to get home directory"}
+
+	// Path validation errors
+	E7040 = ErrorCode{"E7040", "empty-path", "path cannot be empty"}
+	E7041 = ErrorCode{"E7041", "path-null-byte", "path contains null byte"}
+	E7042 = ErrorCode{"E7042", "read-directory-as-file", "cannot read directory as file"}
+
+	// File handle errors
+	E7050 = ErrorCode{"E7050", "file-handle-closed", "file handle is closed"}
+
+	// General I/O error (catch-all)
+	E7099 = ErrorCode{"E7099", "io-error", "general I/O error"}
 )
 
 // =============================================================================

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -5,6 +5,7 @@ package object
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/marshallburns/ez/pkg/ast"
@@ -32,6 +33,7 @@ const (
 	ENUM_OBJ         ObjectType = "ENUM"
 	ENUM_VALUE_OBJ   ObjectType = "ENUM_VALUE"
 	MODULE_OBJ       ObjectType = "MODULE"
+	FILE_HANDLE_OBJ  ObjectType = "FILE_HANDLE"
 )
 
 type Object interface {
@@ -94,6 +96,22 @@ type Byte struct {
 
 func (b *Byte) Type() ObjectType { return BYTE_OBJ }
 func (b *Byte) Inspect() string  { return fmt.Sprintf("%d", b.Value) }
+
+// FileHandle wraps an open file handle for streaming I/O
+type FileHandle struct {
+	File     *os.File
+	Path     string // Original path used to open the file
+	Mode     int    // Open mode flags
+	IsClosed bool   // Track if handle has been closed
+}
+
+func (fh *FileHandle) Type() ObjectType { return FILE_HANDLE_OBJ }
+func (fh *FileHandle) Inspect() string {
+	if fh.IsClosed {
+		return fmt.Sprintf("<FileHandle(closed) %s>", fh.Path)
+	}
+	return fmt.Sprintf("<FileHandle %s>", fh.Path)
+}
 
 // Boolean wraps bool
 type Boolean struct {

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -320,7 +320,7 @@ var IOBuiltins = map[string]*object.Builtin{
 
 			_, err = f.WriteString(content.Value)
 			if err != nil {
-				f.Close()
+				_ = f.Close()
 				return createIOErrorResult(err, "append")
 			}
 
@@ -432,7 +432,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			// Write line with newline
 			_, err = f.WriteString(line.Value + "\n")
 			if err != nil {
-				f.Close()
+				_ = f.Close()
 				return createIOErrorResult(err, "append line")
 			}
 


### PR DESCRIPTION
## Summary

Implements issue #255 - @io module expansion with byte operations, file handles, and enhancements.

### Phase 4: Byte I/O & Atomic Writes
- `io.read_bytes(path)` - read file as byte array
- `io.write_bytes(path, data, [perms])` - write byte array atomically
- Made `io.write_file()` atomic using temp file + rename

### Phase 5: File Handles & Streaming I/O
- Added `FileHandle` type for streaming I/O operations
- I/O mode constants: `READ_ONLY`, `WRITE_ONLY`, `READ_WRITE`, `APPEND`, `CREATE`, `TRUNCATE`, `EXCLUSIVE`
- Seek constants: `SEEK_START`, `SEEK_CURRENT`, `SEEK_END`
- File handle functions: `open`, `read`, `read_all`, `read_string`, `write`, `seek`, `tell`, `flush`, `close`
- New error code E7050 for closed file handle operations

### Phase 6: Permissions & Convenience Functions
- Optional permissions parameter for: `write_file`, `append_file`, `mkdir`, `mkdir_all`, `copy`
- Convenience functions: `read_lines`, `append_line`, `expand_path`

## Test plan
- [x] All unit tests pass for new functions
- [x] All existing io tests continue to pass
- [x] Full test suite passes

Closes #255