### PR TITLE
fix: remove deprecated lowercase math constants

### DIFF
--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -605,7 +605,7 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Constants (UPPERCASE is the standard, lowercase is deprecated)
+	// Constants
 	"math.PI": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Pi}
@@ -666,44 +666,6 @@ var MathBuiltins = map[string]*object.Builtin{
 				return object.TRUE
 			}
 			return object.FALSE
-		},
-	},
-
-	// Deprecated lowercase constants (use uppercase versions instead)
-	"math.pi": {
-		Fn: func(args ...object.Object) object.Object {
-			fmt.Println("warning: math.pi is deprecated, use math.PI instead")
-			return &object.Float{Value: math.Pi}
-		},
-	},
-	"math.e": {
-		Fn: func(args ...object.Object) object.Object {
-			fmt.Println("warning: math.e is deprecated, use math.E instead")
-			return &object.Float{Value: math.E}
-		},
-	},
-	"math.phi": {
-		Fn: func(args ...object.Object) object.Object {
-			fmt.Println("warning: math.phi is deprecated, use math.PHI instead")
-			return &object.Float{Value: math.Phi}
-		},
-	},
-	"math.sqrt2": {
-		Fn: func(args ...object.Object) object.Object {
-			fmt.Println("warning: math.sqrt2 is deprecated, use math.SQRT2 instead")
-			return &object.Float{Value: math.Sqrt2}
-		},
-	},
-	"math.ln2": {
-		Fn: func(args ...object.Object) object.Object {
-			fmt.Println("warning: math.ln2 is deprecated, use math.LN2 instead")
-			return &object.Float{Value: math.Ln2}
-		},
-	},
-	"math.ln10": {
-		Fn: func(args ...object.Object) object.Object {
-			fmt.Println("warning: math.ln10 is deprecated, use math.LN10 instead")
-			return &object.Float{Value: math.Ln10}
 		},
 	},
 


### PR DESCRIPTION
## Summary

Remove all deprecated lowercase constant aliases from the math module:

- `math.pi` → removed (use `math.PI`)
- `math.e` → removed (use `math.E`)
- `math.phi` → removed (use `math.PHI`)
- `math.sqrt2` → removed (use `math.SQRT2`)
- `math.ln2` → removed (use `math.LN2`)
- `math.ln10` → removed (use `math.LN10`)

## Test plan

- [x] All 180 integration tests pass
- [x] Math constants (uppercase) still work correctly

Closes #260