### PR TITLE
fix: fixed-size array indexing returns correct element type

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2179,8 +2179,13 @@ func (tc *TypeChecker) inferIndexType(index *ast.IndexExpression) (string, bool)
 
 	// Indexing into an array returns element type
 	if len(leftType) > 2 && leftType[0] == '[' {
-		// Extract element type from [type]
-		return leftType[1 : len(leftType)-1], true
+		// Extract element type from [type] or [type,size]
+		inner := leftType[1 : len(leftType)-1]
+		// Handle fixed-size arrays: [int,3] -> int
+		if commaIdx := strings.Index(inner, ","); commaIdx != -1 {
+			return inner[:commaIdx], true
+		}
+		return inner, true
 	}
 
 	// Indexing into a map returns value type

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1214,3 +1214,17 @@ do main() {
 	tc := typecheck(t, input)
 	assertHasError(t, tc, errors.E3023)
 }
+
+func TestFixedSizeArrayIndexType(t *testing.T) {
+	// Test: indexing fixed-size array returns element type, not "type,size"
+	// This was bug #267 - [int,3][0] was returning type "int,3" instead of "int"
+	input := `
+do main() {
+	temp arr [int, 3] = {1, 2, 3}
+	temp x int = arr[0]
+	temp y int = arr[1] + arr[2]
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -457,6 +457,18 @@ do test_arrays() -> TestResult {
     println("  fixed size array: ${fixed}")
     passed += 1
 
+    // Fixed size array indexing returns correct element type (bug #267 fix)
+    temp fixed_mutable [int, 3] = {10, 20, 30}
+    temp elem int = fixed_mutable[0]
+    temp sum int = fixed_mutable[0] + fixed_mutable[1] + fixed_mutable[2]
+    if elem == 10 && sum == 60 {
+        println("  fixed size array indexing: elem=${elem}, sum=${sum}")
+        passed += 1
+    } otherwise {
+        println("  FAILED: fixed size array indexing")
+        failed += 1
+    }
+
     println("  PASSED: ${passed}, FAILED: ${failed}")
     return TestResult{passed: passed, failed: failed}
 }


### PR DESCRIPTION
## Summary

Fix type inference for fixed-size array indexing. The typechecker was returning the full type (e.g., `int,3`) instead of the element type (`int`).

## Before

```
error[E3001]: type mismatch: cannot assign int to int,3
  --> foo.ez:3:8
   |
3 |     arr[0] = 100
   |        ^ types do not match
```

## After

```
error[E5016]: cannot modify immutable variable 'arr' (declared as const)
```

## Changes

- Fix `inferIndexType` to handle fixed-size array format `[type,size]`
- Add unit test for fixed-size array indexing
- Add integration test in comprehensive.ez

## Test plan

- [x] Unit test: `TestFixedSizeArrayIndexType`
- [x] Integration test: fixed-size array indexing in comprehensive.ez
- [x] All 181 tests pass

Closes #267