### PR TITLE
remove arrays.copy() and maps.copy() in favor of copy() builtin

### DIFF
--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -897,21 +897,6 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.copy": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("arrays.copy() takes exactly 1 argument")
-			}
-			arr, ok := args[0].(*object.Array)
-			if !ok {
-				return &object.Error{Code: "E7002", Message: "arrays.copy() requires an array"}
-			}
-			newElements := make([]object.Object, len(arr.Elements))
-			copy(newElements, arr.Elements)
-			return &object.Array{Elements: newElements}
-		},
-	},
-
 	"arrays.join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -179,24 +179,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.copy": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("maps.copy() takes exactly 1 argument")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.copy() requires a map"}
-			}
-			// Create a shallow copy of the map
-			newMap := object.NewMap()
-			for _, pair := range m.Pairs {
-				newMap.Set(pair.Key, pair.Value)
-			}
-			return newMap
-		},
-	},
-
 	"maps.merge": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2653,7 +2653,6 @@ func (tc *TypeChecker) checkArraysModuleCall(funcName string, call *ast.CallExpr
 		"pop":        {1, 1, []string{"array"}, "any"},
 		"shift":      {1, 1, []string{"array"}, "any"},
 		"clear":      {1, 1, []string{"array"}, "array"},
-		"copy":       {1, 1, []string{"array"}, "array"},
 		"reverse":    {1, 1, []string{"array"}, "array"},
 		"sort":       {1, 1, []string{"array"}, "array"},
 		"sort_desc":  {1, 1, []string{"array"}, "array"},
@@ -2721,7 +2720,6 @@ func (tc *TypeChecker) checkMapsModuleCall(funcName string, call *ast.CallExpres
 		"keys":     {1, 1, []string{"map"}, "array"},
 		"values":   {1, 1, []string{"map"}, "array"},
 		"clear":    {1, 1, []string{"map"}, "void"},
-		"copy":     {1, 1, []string{"map"}, "map"},
 		"to_array": {1, 1, []string{"map"}, "array"},
 		"invert":   {1, 1, []string{"map"}, "map"},
 


### PR DESCRIPTION
## Summary

Closes #269

Removes `arrays.copy()` and `maps.copy()` now that the `copy()` builtin exists (#265).

The `copy()` builtin handles all types uniformly:
```
copy(myArray)   // works
copy(myMap)     // works
copy(myStruct)  // works
```

## Test plan

- [x] All 189 integration tests pass
- [x] All Go unit tests pass
- [x] No tests used arrays.copy() or maps.copy()