### PR TITLE
fix: struct mutability now respects temp/const declaration

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -748,6 +748,13 @@ func evalVariableDeclaration(node *ast.VariableDeclaration, env *Environment) Ob
 		}
 	}
 
+	// Set struct mutability based on temp vs const (for type inference case where TypeName == "")
+	// This handles cases like: temp p = new(Person) or temp p = Person{name: "test"}
+	// where no explicit type annotation is provided
+	if structObj, ok := val.(*Struct); ok {
+		structObj.Mutable = node.Mutable
+	}
+
 	// Handle multiple assignment: temp result, err = function()
 	vis := convertVisibility(node.Visibility)
 	if len(node.Names) > 1 {

--- a/tests/errors/comprehensive/E5017_immutable_struct_literal.ez
+++ b/tests/errors/comprehensive/E5017_immutable_struct_literal.ez
@@ -1,0 +1,17 @@
+/*
+ * E5017: Cannot modify field of immutable struct created with literal
+ * Expected: "cannot modify field of const struct"
+ *
+ * This tests that const structs created via struct literal are immutable.
+ * Fix for issue #298: struct mutability now respects temp/const.
+ */
+
+const Person struct {
+    name string
+    age int
+}
+
+do main() {
+    const p Person = Person{name: "Bob", age: 25}
+    p.age = 30  // ERROR: cannot modify field of const struct
+}

--- a/tests/errors/comprehensive/E5017_immutable_struct_new.ez
+++ b/tests/errors/comprehensive/E5017_immutable_struct_new.ez
@@ -1,0 +1,17 @@
+/*
+ * E5017: Cannot modify field of immutable struct created with new()
+ * Expected: "cannot modify field of const struct"
+ *
+ * This tests that const structs created via new() are immutable.
+ * Fix for issue #298: struct mutability now respects temp/const.
+ */
+
+const Person struct {
+    name string
+    age int
+}
+
+do main() {
+    const p Person = new(Person)
+    p.name = "Alice"  // ERROR: cannot modify field of const struct
+}


### PR DESCRIPTION
## Summary

- Fixes struct mutability to respect `temp`/`const` declaration
- Adds error tests for immutable struct scenarios

## Problem

Structs created with `new()` or struct literals were always immutable regardless of whether declared with `temp` or `const`. This was inconsistent with primitives, arrays, and maps.

```ez
temp p = new(Person)
p.name = "Alice"  // ERROR: was incorrectly immutable
```

## Root Cause

In `evalVariableDeclaration()`, struct mutability was only set inside `if node.TypeName != ""` block, so type-inferred declarations like `temp p = new(Person)` never had their `Mutable` flag set.

## Fix

Added a check after type-specific handling to always set struct mutability based on the variable declaration keyword (line ~751 in evaluator.go).

## Test plan

- [x] All 215 comprehensive tests pass
- [x] All 70 error tests pass
- [x] New error tests added:
  - `E5017_immutable_struct_new.ez` - verifies `const` + `new()` is immutable
  - `E5017_immutable_struct_literal.ez` - verifies `const` + literal is immutable
- [x] `tests.ez` mutability tests pass

Closes #298