### PR TITLE
feat: allow type inference for const declarations

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -633,6 +633,15 @@ func (p *Parser) parseVarableDeclarationOrStruct() Statement {
 		stmt.Names = append(stmt.Names, &Label{Token: nameToken, Value: nameToken.Literal})
 		stmt.Name = stmt.Names[0]
 
+		// Check if this is a type-inferred assignment (const x = value)
+		// This allows: const p = new(Person) or const p = Person{...}
+		if p.peekTokenMatches(ASSIGN) {
+			p.nextToken() // consume =
+			p.nextToken() // move to value
+			stmt.Value = p.parseExpression(LOWEST)
+			return stmt
+		}
+
 		// Parse type using parseTypeName which handles qualified names (module.Type),
 		// arrays ([type], [type,size]), and maps (map[key:value])
 		p.nextToken()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -494,6 +494,7 @@ func TestVariableDeclarations(t *testing.T) {
 		{"temp with type", "temp x int = 5", "x", true, "int"},
 		{"temp inferred", "temp x = 5", "x", true, ""},
 		{"const with type", "const x int = 5", "x", false, "int"},
+		{"const inferred", "const x = 5", "x", false, ""},
 		{"temp float", "temp f float = 3.14", "f", true, "float"},
 		{"temp string", "temp s string = \"hello\"", "s", true, "string"},
 		{"temp bool", "temp b bool = true", "b", true, "bool"},

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -948,6 +948,24 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
+func TestConstTypeInference(t *testing.T) {
+	input := `
+const Person struct {
+	name string
+	age int
+}
+
+do main() {
+	const p1 = new(Person)
+	const p2 = Person{name: "Alice", age: 30}
+	const x = 42
+	const s = "hello"
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
 func TestMapDeclaration(t *testing.T) {
 	input := `
 do main() {

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -942,6 +942,36 @@ do test_structs() -> TestResult {
     println("  Array of Points: ${points}")
     passed += 1
 
+    // const type inference with new() (issue #302)
+    const p1 = new(Person)
+    if p1.name == "" && p1.age == 0 {
+        println("  const p1 = new(Person) - type inferred correctly")
+        passed += 1
+    } otherwise {
+        println("  FAILED: const type inference with new()")
+        failed += 1
+    }
+
+    // const type inference with struct literal (issue #302)
+    const p2 = Person{name: "Bob", age: 25, active: true}
+    if p2.name == "Bob" && p2.age == 25 {
+        println("  const p2 = Person{...} - type inferred correctly")
+        passed += 1
+    } otherwise {
+        println("  FAILED: const type inference with struct literal")
+        failed += 1
+    }
+
+    // const type inference with copy()
+    const p3 = copy(person)
+    if p3.name == "Alice" && p3.age == 30 {
+        println("  const p3 = copy(person) - type inferred correctly")
+        passed += 1
+    } otherwise {
+        println("  FAILED: const type inference with copy()")
+        failed += 1
+    }
+
     println("  PASSED: ${passed}, FAILED: ${failed}")
     return TestResult{passed: passed, failed: failed}
 }


### PR DESCRIPTION
## Summary

- Allows `const` declarations to infer type from RHS, matching `temp` behavior
- Eliminates redundant type annotations

## Before/After

```ez
// Before (required redundant type)
const p Person = new(Person)
const p Person = Person{name: "Alice"}

// After (type inferred)
const p = new(Person)
const p = Person{name: "Alice"}
const p = copy(original)
```

## Changes

- `pkg/parser/parser.go`: Check for `=` before type in const declarations
- `pkg/parser/parser_test.go`: Add "const inferred" test case
- `pkg/typechecker/typechecker_test.go`: Add `TestConstTypeInference`
- `tests/comprehensive.ez`: Add 3 const type inference tests (total now 218)

## Test plan

- [x] All Go unit tests pass
- [x] All 218 comprehensive tests pass (was 215, added 3)
- [x] All 70 error tests pass
- [x] `const x int` without value still errors (E2011)
- [x] Immutability still enforced for inferred const structs

Closes #302