### PR TITLE
feat: add error() constructor for user-defined errors

### DIFF
--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -457,4 +457,27 @@ var StdBuiltins = map[string]*object.Builtin{
 			return deepCopy(args[0])
 		},
 	},
+
+	// Creates a user-defined error with the given message
+	// Returns an Error struct with .message set to the argument and .code set to empty string
+	// This is different from object.Error which is a runtime error that halts execution
+	"error": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: fmt.Sprintf("error() takes exactly 1 argument, got %d", len(args))}
+			}
+			str, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: fmt.Sprintf("error() argument must be a string, got %s", getEZTypeName(args[0]))}
+			}
+			// Return an Error struct (not object.Error which is a runtime error)
+			return &object.Struct{
+				TypeName: "Error",
+				Fields: map[string]object.Object{
+					"message": &object.String{Value: str.Value},
+					"code":    &object.String{Value: ""},
+				},
+			}
+		},
+	},
 }

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -211,7 +211,7 @@ func (tc *TypeChecker) registerBuiltinTypes() {
 		Kind: StructType,
 		Fields: map[string]*Type{
 			"message": {Name: "string", Kind: PrimitiveType},
-			"code":    {Name: "int", Kind: PrimitiveType},
+			"code":    {Name: "string", Kind: PrimitiveType},
 		},
 	}
 }

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -181,6 +181,10 @@ do main() {
     total_passed += result.passed
     total_failed += result.failed
 
+    result = test_error_constructor()
+    total_passed += result.passed
+    total_failed += result.failed
+
     temp total int = total_passed + total_failed
 
     println("")
@@ -1948,6 +1952,84 @@ do test_printf_and_escapes() -> TestResult {
     temp quote_str string = "She said \"Hello\""
     println("  Escaped quotes: ${quote_str}")
     passed += 1
+
+    println("  PASSED: ${passed}, FAILED: ${failed}")
+    return TestResult{passed: passed, failed: failed}
+}
+
+// ==================================================
+// ERROR CONSTRUCTOR
+// ==================================================
+
+// Helper function that validates a name and returns Error on failure
+do validate_name(name string) -> Error {
+    if len(name) == 0 {
+        return error("name cannot be empty")
+    }
+    return nil
+}
+
+// Helper function that divides and returns Error on division by zero
+do safe_divide(a int, b int) -> (int, Error) {
+    if b == 0 {
+        return 0, error("division by zero")
+    }
+    return a / b, nil
+}
+
+do test_error_constructor() -> TestResult {
+    print_section("Error Constructor")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: error() creates Error struct with message
+    temp err1 = validate_name("")
+    if err1 != nil && err1.message == "name cannot be empty" {
+        println("  error() with message: PASS")
+        passed += 1
+    } otherwise {
+        println("  error() with message: FAIL")
+        failed += 1
+    }
+
+    // Test 2: error().code is empty string for user errors
+    if err1 != nil && err1.code == "" {
+        println("  error().code is empty: PASS")
+        passed += 1
+    } otherwise {
+        println("  error().code is empty: FAIL")
+        failed += 1
+    }
+
+    // Test 3: returning nil for no error
+    temp err2 = validate_name("Alice")
+    if err2 == nil {
+        println("  return nil for no error: PASS")
+        passed += 1
+    } otherwise {
+        println("  return nil for no error: FAIL")
+        failed += 1
+    }
+
+    // Test 4: error in tuple return
+    temp result, err3 = safe_divide(10, 0)
+    if err3 != nil && err3.message == "division by zero" {
+        println("  error in tuple return: PASS")
+        passed += 1
+    } otherwise {
+        println("  error in tuple return: FAIL")
+        failed += 1
+    }
+
+    // Test 5: nil error in tuple return
+    temp result2, err4 = safe_divide(10, 2)
+    if err4 == nil && result2 == 5 {
+        println("  nil error in tuple return: PASS")
+        passed += 1
+    } otherwise {
+        println("  nil error in tuple return: FAIL")
+        failed += 1
+    }
 
     println("  PASSED: ${passed}, FAILED: ${failed}")
     return TestResult{passed: passed, failed: failed}

--- a/tests/errors/comprehensive/E7003_error_requires_string.ez
+++ b/tests/errors/comprehensive/E7003_error_requires_string.ez
@@ -1,0 +1,14 @@
+/*
+ * E7003: error() requires string argument
+ * Expected: "error() argument must be a string"
+ *
+ * The error() constructor only accepts a string message.
+ * Passing other types should produce this error.
+ */
+
+import & use @std
+
+do main() {
+    temp err = error(42)  // ERROR: must be a string
+    println(err.message)
+}


### PR DESCRIPTION
## Summary

Adds an `error()` builtin function that creates user-defined Error values.

## Syntax

```ez
error("message") -> Error
```

## Usage

```ez
do validate(name string) -> Error {
    if len(name) == 0 {
        return error("name cannot be empty")
    }
    return nil
}

do divide(a int, b int) -> (int, Error) {
    if b == 0 {
        return 0, error("division by zero")
    }
    return a / b, nil
}

do main() {
    temp err = validate("")
    if err != nil {
        println("Error: ${err.message}")  // "name cannot be empty"
        println("Code: ${err.code}")      // "" (empty for user errors)
    }
}
```

## Design Decisions

1. **Type distinction**: `Error` is the type, `error()` is the constructor
2. **Returns Error struct** (not `object.Error` which halts execution)
3. **Simple API**: `error("message")` - single string argument only
4. **Empty code**: `err.code` is `""` for user errors (stdlib errors have E-codes)
5. **Same type as stdlib errors**: Works with `err != nil`, `err.message`, `err.code`

## Changes

- `pkg/stdlib/builtins.go`: Add `error()` builtin
- `pkg/stdlib/stdlib_test.go`: Add unit tests
- `pkg/typechecker/typechecker.go`: Fix `Error.code` type to string (was int)
- `tests/comprehensive.ez`: Add 5 integration tests (total now 223)
- `tests/errors/comprehensive/E7003_error_requires_string.ez`: Error test

## Test Plan

- [x] All Go unit tests pass
- [x] All 223 comprehensive tests pass (was 218, added 5)
- [x] All 71 error tests pass (was 70, added 1)
- [x] `error()` with non-string argument produces E7003 error
- [x] `error()` with wrong arg count produces E7001 error

Closes #292