### PR TITLE
Bug fixes - December 4, 2025

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -70,6 +70,7 @@ var (
 	E2032 = ErrorCode{"E2032", "const-array-requires-size", "const array must have fixed size"}
 	E2033 = ErrorCode{"E2033", "reserved-param-name", "parameter name is reserved"}
 	E2034 = ErrorCode{"E2034", "invalid-struct-field", "invalid struct field name"}
+	E2035 = ErrorCode{"E2035", "invalid-enum-value", "invalid enum value name"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -71,6 +71,7 @@ var (
 	E2033 = ErrorCode{"E2033", "reserved-param-name", "parameter name is reserved"}
 	E2034 = ErrorCode{"E2034", "invalid-struct-field", "invalid struct field name"}
 	E2035 = ErrorCode{"E2035", "invalid-enum-value", "invalid enum value name"}
+	E2036 = ErrorCode{"E2036", "import-inside-block", "import must be at file level"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -144,6 +144,7 @@ var (
 	E5015 = ErrorCode{"E5015", "postfix-requires-identifier", "postfix operator needs variable"}
 	E5016 = ErrorCode{"E5016", "immutable-parameter", "cannot modify read-only parameter"}
 	E5017 = ErrorCode{"E5017", "immutable-struct", "cannot modify field of const struct"}
+	E5018 = ErrorCode{"E5018", "max-recursion-depth", "maximum recursion depth exceeded"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -68,6 +68,7 @@ var (
 	E2030 = ErrorCode{"E2030", "expected-block", "expected block statement"}
 	E2031 = ErrorCode{"E2031", "string-enum-requires-values", "string enum needs explicit values"}
 	E2032 = ErrorCode{"E2032", "const-array-requires-size", "const array must have fixed size"}
+	E2033 = ErrorCode{"E2033", "reserved-param-name", "parameter name is reserved"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -97,6 +97,7 @@ var (
 	E3021 = ErrorCode{"E3021", "byte-value-out-of-range", "byte value must be between 0 and 255"}
 	E3022 = ErrorCode{"E3022", "byte-array-element-out-of-range", "byte array element must be between 0 and 255"}
 	E3023 = ErrorCode{"E3023", "const-to-mutable-param", "cannot pass immutable variable to mutable parameter"}
+	E3024 = ErrorCode{"E3024", "missing-return-statement", "function must return a value"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -72,6 +72,8 @@ var (
 	E2034 = ErrorCode{"E2034", "invalid-struct-field", "invalid struct field name"}
 	E2035 = ErrorCode{"E2035", "invalid-enum-value", "invalid enum value name"}
 	E2036 = ErrorCode{"E2036", "import-inside-block", "import must be at file level"}
+	E2037 = ErrorCode{"E2037", "reserved-struct-name", "struct name is reserved"}
+	E2038 = ErrorCode{"E2038", "reserved-enum-name", "enum name is reserved"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -69,6 +69,7 @@ var (
 	E2031 = ErrorCode{"E2031", "string-enum-requires-values", "string enum needs explicit values"}
 	E2032 = ErrorCode{"E2032", "const-array-requires-size", "const array must have fixed size"}
 	E2033 = ErrorCode{"E2033", "reserved-param-name", "parameter name is reserved"}
+	E2034 = ErrorCode{"E2034", "invalid-struct-field", "invalid struct field name"}
 )
 
 // =============================================================================

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -31,6 +31,15 @@ func NewLexer(input string) *Lexer {
 	return l
 }
 
+// NewLexerWithOffset creates a new Lexer with specified starting line and column
+// This is useful for parsing substrings like string interpolation expressions
+// where the offset should match the original source position
+func NewLexerWithOffset(input string, startLine, startColumn int) *Lexer {
+	l := &Lexer{input: input, line: startLine, column: startColumn, errors: []LexerError{}}
+	l.readChar()
+	return l
+}
+
 // Errors returns any lexer errors
 func (l *Lexer) Errors() []LexerError {
 	return l.errors

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -706,6 +706,13 @@ func (p *Parser) parseVarableDeclaration() *VariableDeclaration {
 	if p.peekTokenMatches(IGNORE) {
 		p.nextToken()
 		stmt.Names = append(stmt.Names, &Label{Token: p.currentToken, Value: "@ignore"})
+	} else if IsKeyword(p.peekToken.Type) {
+		// If user tries to use a keyword as variable name, give helpful error
+		keyword := KeywordLiteral(p.peekToken.Type)
+		msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a variable name", keyword)
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E2020, msg, p.peekToken)
+		return nil
 	} else if !p.expectPeek(IDENT) {
 		return nil
 	} else {
@@ -734,6 +741,13 @@ func (p *Parser) parseVarableDeclaration() *VariableDeclaration {
 
 		if p.currentTokenMatches(IGNORE) {
 			stmt.Names = append(stmt.Names, &Label{Token: p.currentToken, Value: "@ignore"})
+		} else if IsKeyword(p.currentToken.Type) {
+			// If user tries to use a keyword as variable name, give helpful error
+			keyword := KeywordLiteral(p.currentToken.Type)
+			msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a variable name", keyword)
+			p.errors = append(p.errors, msg)
+			p.addEZError(errors.E2020, msg, p.currentToken)
+			return nil
 		} else if p.currentTokenMatches(IDENT) {
 			name := p.currentToken.Literal
 			// Check for reserved names
@@ -1051,6 +1065,14 @@ func (p *Parser) parseForStatement() *ForStatement {
 		p.nextToken() // consume '('
 	}
 
+	if IsKeyword(p.peekToken.Type) {
+		// If user tries to use a keyword as loop variable, give helpful error
+		keyword := KeywordLiteral(p.peekToken.Type)
+		msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a variable name", keyword)
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E2020, msg, p.peekToken)
+		return nil
+	}
 	if !p.expectPeek(IDENT) {
 		return nil
 	}
@@ -1095,6 +1117,14 @@ func (p *Parser) parseForEachStatement() *ForEachStatement {
 		p.nextToken() // consume '('
 	}
 
+	if IsKeyword(p.peekToken.Type) {
+		// If user tries to use a keyword as loop variable, give helpful error
+		keyword := KeywordLiteral(p.peekToken.Type)
+		msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a variable name", keyword)
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E2020, msg, p.peekToken)
+		return nil
+	}
 	if !p.expectPeek(IDENT) {
 		return nil
 	}
@@ -1169,6 +1199,14 @@ func (p *Parser) parseFunctionDeclarationWithAttrs(attrs []*Attribute) *Function
 		return nil
 	}
 
+	if IsKeyword(p.peekToken.Type) {
+		// If user tries to use a keyword as function name, give helpful error
+		keyword := KeywordLiteral(p.peekToken.Type)
+		msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a function name", keyword)
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E2021, msg, p.peekToken)
+		return nil
+	}
 	if !p.expectPeek(IDENT) {
 		return nil
 	}
@@ -1284,6 +1322,14 @@ func (p *Parser) parseFunctionParameters() []*Parameter {
 		}
 
 		// Read first parameter name
+		if IsKeyword(p.currentToken.Type) {
+			// If user tries to use a keyword as parameter name, give helpful error
+			keyword := KeywordLiteral(p.currentToken.Type)
+			msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a parameter name", keyword)
+			p.errors = append(p.errors, msg)
+			p.addEZError(errors.E2033, msg, p.currentToken)
+			return nil
+		}
 		if !p.currentTokenMatches(IDENT) {
 			msg := fmt.Sprintf("expected parameter name, got %s", p.currentToken.Type)
 			p.addEZError(errors.E2002, msg, p.currentToken)
@@ -1294,6 +1340,14 @@ func (p *Parser) parseFunctionParameters() []*Parameter {
 		// Strategy: collect IDENT tokens while they're followed by COMMA
 		// The last IDENT (not followed by COMMA) is the type
 		for {
+			if IsKeyword(p.currentToken.Type) {
+				// If user tries to use a keyword as parameter name, give helpful error
+				keyword := KeywordLiteral(p.currentToken.Type)
+				msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a parameter name", keyword)
+				p.errors = append(p.errors, msg)
+				p.addEZError(errors.E2033, msg, p.currentToken)
+				return nil
+			}
 			if !p.currentTokenMatches(IDENT) {
 				msg := fmt.Sprintf("expected parameter name, got %s", p.currentToken.Type)
 				p.addEZError(errors.E2002, msg, p.currentToken)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2250,8 +2250,9 @@ func processEscapeSequences(s string) string {
 
 // parseInterpolatedExpression parses an expression from within ${}
 func (p *Parser) parseInterpolatedExpression(exprStr string, origToken Token) Expression {
-	// Create a new lexer for the expression
-	lexer := NewLexer(exprStr)
+	// Create a new lexer for the expression with the original token's line/column
+	// This ensures error messages point to the correct location in the source
+	lexer := NewLexerWithOffset(exprStr, origToken.Line, origToken.Column)
 
 	// Create a temporary parser
 	tempParser := &Parser{

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -25,11 +25,21 @@ var reservedKeywords = map[string]bool{
 	"module": true, "private": true, "from": true, "use": true,
 }
 
-// Builtin function names that cannot be redefined
+// Builtin function and type names that cannot be redefined
 var builtinNames = map[string]bool{
+	// Builtin functions
 	"len": true, "typeof": true, "input": true,
-	"int": true, "float": true, "string": true, "bool": true, "char": true, "byte": true,
 	"println": true, "print": true, "read_int": true,
+	"copy": true, "append": true, "error": true,
+	// Primitive type names
+	"int": true, "float": true, "string": true, "bool": true, "char": true, "byte": true,
+	// Sized integers
+	"i8": true, "i16": true, "i32": true, "i64": true, "i128": true, "i256": true,
+	"u8": true, "u16": true, "u32": true, "u64": true, "u128": true, "u256": true, "uint": true,
+	// Sized floats
+	"f32": true, "f64": true,
+	// Collection types
+	"map": true,
 }
 
 // isReservedName checks if a name is a reserved keyword or builtin
@@ -1280,6 +1290,13 @@ func (p *Parser) parseFunctionParameters() []*Parameter {
 			// Look ahead to see what follows this IDENT
 			if p.peekTokenMatches(COMMA) {
 				// This IDENT is a parameter name (more names or params follow)
+				// Check for reserved names
+				if isReservedName(currentIdent.Value) {
+					msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a parameter name", currentIdent.Value)
+					p.errors = append(p.errors, msg)
+					p.addEZError(errors.E2033, msg, currentIdent.Token)
+					return nil
+				}
 				// Check for duplicate
 				if prevToken, exists := paramNames[currentIdent.Value]; exists {
 					msg := fmt.Sprintf("duplicate parameter name '%s'", currentIdent.Value)
@@ -1302,6 +1319,13 @@ func (p *Parser) parseFunctionParameters() []*Parameter {
 				continue
 			} else if p.peekTokenMatches(IDENT) || p.peekTokenMatches(LBRACKET) {
 				// This IDENT is a parameter name, and the next token is the type
+				// Check for reserved names
+				if isReservedName(currentIdent.Value) {
+					msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a parameter name", currentIdent.Value)
+					p.errors = append(p.errors, msg)
+					p.addEZError(errors.E2033, msg, currentIdent.Token)
+					return nil
+				}
 				// Check for duplicate
 				if prevToken, exists := paramNames[currentIdent.Value]; exists {
 					msg := fmt.Sprintf("duplicate parameter name '%s'", currentIdent.Value)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1694,6 +1694,14 @@ func (p *Parser) parseEnumDeclaration() *EnumDeclaration {
 		enumValue := &EnumValue{}
 		enumValue.Name = &Label{Token: p.currentToken, Value: p.currentToken.Literal}
 
+		// Check for reserved names
+		if isReservedName(enumValue.Name.Value) {
+			msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as an enum value name", enumValue.Name.Value)
+			p.errors = append(p.errors, msg)
+			p.addEZError(errors.E2035, msg, enumValue.Name.Token)
+			return nil
+		}
+
 		// Check for duplicate value names
 		if prevToken, exists := valueNames[enumValue.Name.Value]; exists {
 			msg := fmt.Sprintf("duplicate value name '%s' in enum '%s'", enumValue.Name.Value, stmt.Name.Value)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -676,7 +676,11 @@ func (p *Parser) parseVarableDeclarationOrStruct() Statement {
 	}
 
 	// Not the special "const Name struct" case, use regular variable declaration
-	return p.parseVarableDeclaration()
+	result := p.parseVarableDeclaration()
+	if result == nil {
+		return nil // Return untyped nil to avoid typed nil interface issue
+	}
+	return result
 }
 
 func (p *Parser) parseVarableDeclaration() *VariableDeclaration {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1650,7 +1650,7 @@ func (p *Parser) parseEnumDeclaration() *EnumDeclaration {
 	if isReservedName(p.currentToken.Literal) {
 		msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as an enum name", p.currentToken.Literal)
 		p.errors = append(p.errors, msg)
-		p.addEZError(errors.E2022, msg, p.currentToken)
+		p.addEZError(errors.E2038, msg, p.currentToken)
 		return nil
 	}
 
@@ -1885,7 +1885,7 @@ func (p *Parser) parseStructDeclaration() *StructDeclaration {
 	if isReservedName(p.currentToken.Literal) {
 		msg := fmt.Sprintf("'%s' is a reserved keyword and cannot be used as a struct name", p.currentToken.Literal)
 		p.errors = append(p.errors, msg)
-		p.addEZError(errors.E2022, msg, p.currentToken)
+		p.addEZError(errors.E2037, msg, p.currentToken)
 		return nil
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1355,13 +1355,141 @@ func TestGroupedExpressions(t *testing.T) {
 // ============================================================================
 
 func TestReservedKeywordAsVariable(t *testing.T) {
-	input := "temp if int = 5"
-	l := NewLexer(input)
-	p := NewWithSource(l, input, "test.ez")
-	p.ParseProgram()
+	tests := []struct {
+		name          string
+		input         string
+		expectedCode  string
+		expectedIdent string
+	}{
+		{
+			name:          "if as variable",
+			input:         "temp if int = 5",
+			expectedCode:  "E2020",
+			expectedIdent: "if",
+		},
+		{
+			name:          "do as variable",
+			input:         "temp do = 1",
+			expectedCode:  "E2020",
+			expectedIdent: "do",
+		},
+		{
+			name:          "for as variable",
+			input:         "temp for = 1",
+			expectedCode:  "E2020",
+			expectedIdent: "for",
+		},
+		{
+			name:          "return as variable",
+			input:         "temp return = 1",
+			expectedCode:  "E2020",
+			expectedIdent: "return",
+		},
+	}
 
-	if !p.EZErrors().HasErrors() {
-		t.Error("expected error for reserved keyword as variable name")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLexer(tt.input)
+			p := NewWithSource(l, tt.input, "test.ez")
+			p.ParseProgram()
+
+			if !p.EZErrors().HasErrors() {
+				t.Fatal("expected error for reserved keyword as variable name")
+			}
+
+			// Check that the first error has the expected code
+			firstErr := p.EZErrors().Errors[0]
+			if firstErr.ErrorCode.Code != tt.expectedCode {
+				t.Errorf("expected error code %s, got %s", tt.expectedCode, firstErr.ErrorCode.Code)
+			}
+			if !strings.Contains(firstErr.Message, tt.expectedIdent) {
+				t.Errorf("expected error message to contain '%s', got '%s'", tt.expectedIdent, firstErr.Message)
+			}
+		})
+	}
+}
+
+func TestReservedKeywordAsFunctionName(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCode  string
+		expectedIdent string
+	}{
+		{
+			name:          "if as function name",
+			input:         "do if() {}",
+			expectedCode:  "E2021",
+			expectedIdent: "if",
+		},
+		{
+			name:          "return as function name",
+			input:         "do return() {}",
+			expectedCode:  "E2021",
+			expectedIdent: "return",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLexer(tt.input)
+			p := NewWithSource(l, tt.input, "test.ez")
+			p.ParseProgram()
+
+			if !p.EZErrors().HasErrors() {
+				t.Fatal("expected error for reserved keyword as function name")
+			}
+
+			firstErr := p.EZErrors().Errors[0]
+			if firstErr.ErrorCode.Code != tt.expectedCode {
+				t.Errorf("expected error code %s, got %s", tt.expectedCode, firstErr.ErrorCode.Code)
+			}
+			if !strings.Contains(firstErr.Message, tt.expectedIdent) {
+				t.Errorf("expected error message to contain '%s', got '%s'", tt.expectedIdent, firstErr.Message)
+			}
+		})
+	}
+}
+
+func TestReservedKeywordAsParameter(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCode  string
+		expectedIdent string
+	}{
+		{
+			name:          "if as parameter",
+			input:         "do test(if int) {}",
+			expectedCode:  "E2033",
+			expectedIdent: "if",
+		},
+		{
+			name:          "for as parameter",
+			input:         "do test(for int) {}",
+			expectedCode:  "E2033",
+			expectedIdent: "for",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLexer(tt.input)
+			p := NewWithSource(l, tt.input, "test.ez")
+			p.ParseProgram()
+
+			if !p.EZErrors().HasErrors() {
+				t.Fatal("expected error for reserved keyword as parameter name")
+			}
+
+			firstErr := p.EZErrors().Errors[0]
+			if firstErr.ErrorCode.Code != tt.expectedCode {
+				t.Errorf("expected error code %s, got %s", tt.expectedCode, firstErr.ErrorCode.Code)
+			}
+			if !strings.Contains(firstErr.Message, tt.expectedIdent) {
+				t.Errorf("expected error message to contain '%s', got '%s'", tt.expectedIdent, firstErr.Message)
+			}
+		})
 	}
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1873,3 +1873,75 @@ func TestMutableMapParameter(t *testing.T) {
 		t.Errorf("expected second and third parameters to be immutable")
 	}
 }
+
+// ============================================================================
+// Bug Fix Tests - December 2025
+// ============================================================================
+
+func TestImportInsideFunctionBlock(t *testing.T) {
+	// Test: import inside function block should error E2036
+	// Fixes #324
+	input := `import & use @std
+do main() {
+	import & use @math
+	println("test")
+}`
+	l := NewLexer(input)
+	p := NewWithSource(l, input, "test.ez")
+	p.ParseProgram()
+
+	if !p.EZErrors().HasErrors() {
+		t.Error("expected error for import inside function block")
+	}
+}
+
+func TestImportAfterDeclarations(t *testing.T) {
+	// Test: import after function declarations should error E2036
+	// Fixes #324
+	input := `import & use @std
+do foo() {
+	println("foo")
+}
+import & use @math
+do main() {
+	println("test")
+}`
+	l := NewLexer(input)
+	p := NewWithSource(l, input, "test.ez")
+	p.ParseProgram()
+
+	if !p.EZErrors().HasErrors() {
+		t.Error("expected error for import after declarations")
+	}
+}
+
+func TestReservedStructName(t *testing.T) {
+	// Test: using reserved keyword as struct name should error E2037
+	// Fixes #325
+	input := `const int struct {
+	x int
+}`
+	l := NewLexer(input)
+	p := NewWithSource(l, input, "test.ez")
+	p.ParseProgram()
+
+	if !p.EZErrors().HasErrors() {
+		t.Error("expected error for reserved struct name")
+	}
+}
+
+func TestReservedEnumName(t *testing.T) {
+	// Test: using reserved keyword as enum name should error E2038
+	// Fixes #326
+	input := `const int enum {
+	A
+	B
+}`
+	l := NewLexer(input)
+	p := NewWithSource(l, input, "test.ez")
+	p.ParseProgram()
+
+	if !p.EZErrors().HasErrors() {
+		t.Error("expected error for reserved enum name")
+	}
+}

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -157,3 +157,25 @@ func LookupIdentifier(ident string) TokenType {
 	}
 	return IDENT
 }
+
+// IsKeyword returns true if the token type is a keyword
+func IsKeyword(t TokenType) bool {
+	switch t {
+	case TEMP, CONST, DO, RETURN, IF, OR_KW, OTHERWISE,
+		FOR, FOR_EACH, AS_LONG_AS, LOOP, BREAK, CONTINUE,
+		IN, NOT_IN, RANGE, IMPORT, USING, STRUCT, ENUM,
+		NIL, NEW, TRUE, FALSE, IGNORE, MODULE, PRIVATE, FROM, USE:
+		return true
+	}
+	return false
+}
+
+// KeywordLiteral returns the string literal for a keyword token type
+func KeywordLiteral(t TokenType) string {
+	for literal, tokType := range keywords {
+		if tokType == t {
+			return literal
+		}
+	}
+	return string(t)
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -540,16 +540,13 @@ func (tc *TypeChecker) checkFunctionBody(node *ast.FunctionDeclaration) {
 
 	// Check if function body contains at least one return statement (for functions with return types)
 	if len(node.ReturnTypes) > 0 {
-		// Check if W2003 warning is suppressed
-		if !tc.isSuppressed("W2003", node.Attributes) {
-			if !tc.hasReturnStatement(node.Body) {
-				tc.addWarning(
-					errors.W2003,
-					fmt.Sprintf("Function '%s' declares return type(s) but has no return statement", node.Name.Value),
-					node.Name.Token.Line,
-					node.Name.Token.Column,
-				)
-			}
+		if !tc.hasReturnStatement(node.Body) {
+			tc.addError(
+				errors.E3024,
+				fmt.Sprintf("Function '%s' declares return type(s) but has no return statement", node.Name.Value),
+				node.Name.Token.Line,
+				node.Name.Token.Column,
+			)
 		}
 	}
 
@@ -577,7 +574,6 @@ func (tc *TypeChecker) isSuppressed(warningCode string, attrs []*ast.Attribute) 
 
 	// Map warning codes to their alternate names
 	alternateNames := map[string]string{
-		"W2003": "missing_return",
 		"W3003": "array_size_mismatch",
 	}
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -580,7 +580,7 @@ func (tc *TypeChecker) checkFunctionBody(node *ast.FunctionDeclaration) {
 func (tc *TypeChecker) checkMainFunction() {
 	if _, exists := tc.functions["main"]; !exists {
 		tc.addError(
-			errors.E3007,
+			errors.E4009,
 			"Program must define a main() function",
 			1,
 			1,

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -747,8 +747,14 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 		// Validate the expression itself
 		tc.checkExpression(decl.Value)
 
+		// If no declared type, infer from value and register it
 		if declaredType == "" {
-			return // No type to check against
+			inferredType, ok := tc.inferExpressionType(decl.Value)
+			if ok && inferredType != "" {
+				// Register the inferred type so future assignments are type-checked
+				tc.defineVariableWithMutability(varName, inferredType, decl.Mutable)
+			}
+			return
 		}
 
 		actualType, ok := tc.inferExpressionType(decl.Value)

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -495,8 +495,30 @@ func (tc *TypeChecker) checkFunctionDeclaration(node *ast.FunctionDeclaration) {
 		ReturnTypes: node.ReturnTypes,
 	}
 
-	// Check parameter types
+	// Check parameter types and names
 	for _, param := range node.Parameters {
+		paramName := param.Name.Value
+
+		// Check if parameter name shadows a user-defined type (struct/enum)
+		if _, exists := tc.types[paramName]; exists {
+			tc.addError(
+				errors.E2033,
+				fmt.Sprintf("'%s' is a type name and cannot be used as a parameter name", paramName),
+				param.Name.Token.Line,
+				param.Name.Token.Column,
+			)
+		}
+
+		// Check if parameter name shadows a user-defined function
+		if _, exists := tc.functions[paramName]; exists {
+			tc.addError(
+				errors.E2033,
+				fmt.Sprintf("'%s' is a function name and cannot be used as a parameter name", paramName),
+				param.Name.Token.Line,
+				param.Name.Token.Column,
+			)
+		}
+
 		if !tc.TypeExists(param.TypeName) {
 			tc.addError(
 				errors.E3010,

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -362,7 +362,7 @@ do helper() {
 }
 `
 	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3007)
+	assertHasError(t, tc, errors.E4009)
 }
 
 func TestModuleWithoutMain(t *testing.T) {

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -541,7 +541,7 @@ do main() {}
 	assertHasError(t, tc, errors.E3011)
 }
 
-func TestFunctionMissingReturnWarning(t *testing.T) {
+func TestFunctionMissingReturnError(t *testing.T) {
 	input := `
 do getValue() -> int {
 	temp x int = 5
@@ -550,7 +550,7 @@ do getValue() -> int {
 do main() {}
 `
 	tc := typecheck(t, input)
-	assertHasWarning(t, tc, errors.W2003)
+	assertHasError(t, tc, errors.E3024)
 }
 
 func TestFunctionWithReturn(t *testing.T) {

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1246,3 +1246,38 @@ do main() {
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
+
+// ============================================================================
+// Bug Fix Tests - December 2025
+// ============================================================================
+
+func TestE4011_MemberAccessOnPrimitive(t *testing.T) {
+	// Test: accessing member on primitive type should error E4011
+	// Fixes #313
+	input := `
+do main() {
+	temp s = "hello"
+	temp x = s.name
+}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E4011)
+}
+
+func TestMemberAccessOnStructValid(t *testing.T) {
+	// Test: accessing member on struct should work
+	input := `
+const Person struct {
+	name string
+	age int
+}
+
+do main() {
+	temp p = Person{name: "Alice", age: 30}
+	temp n = p.name
+	temp a = p.age
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}

--- a/tests/errors/comprehensive/E2020_keyword_as_variable.ez
+++ b/tests/errors/comprehensive/E2020_keyword_as_variable.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E2020 - reserved-variable-name
+ * Expected: "'if' is a reserved keyword and cannot be used as a variable name"
+ */
+
+do main() {
+    temp if = 5
+}

--- a/tests/errors/comprehensive/E2021_keyword_as_function.ez
+++ b/tests/errors/comprehensive/E2021_keyword_as_function.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E2021 - reserved-function-name
+ * Expected: "'if' is a reserved keyword and cannot be used as a function name"
+ */
+
+do if() {
+    return
+}
+
+do main() {}

--- a/tests/errors/comprehensive/E2033_keyword_as_param.ez
+++ b/tests/errors/comprehensive/E2033_keyword_as_param.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E2033 - reserved-param-name
+ * Expected: "'if' is a reserved keyword and cannot be used as a parameter name"
+ */
+
+do test(if int) {
+    return
+}
+
+do main() {}

--- a/tests/errors/comprehensive/E2036_import_inside_block.ez
+++ b/tests/errors/comprehensive/E2036_import_inside_block.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E2036 - import-inside-block
+ * Expected: "import"
+ */
+import & use @std
+
+do main() {
+    import & use @math  // imports not allowed inside blocks
+    println("test")
+}

--- a/tests/errors/comprehensive/E2037_reserved_struct_name.ez
+++ b/tests/errors/comprehensive/E2037_reserved_struct_name.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E2037 - reserved-struct-name
+ * Expected: "struct name is reserved"
+ */
+
+const int struct {
+    x int
+}
+
+do main() {
+    println("Should not compile!")
+}

--- a/tests/errors/comprehensive/E2038_reserved_enum_name.ez
+++ b/tests/errors/comprehensive/E2038_reserved_enum_name.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E2038 - reserved-enum-name
+ * Expected: "enum name is reserved"
+ */
+
+const int enum {
+    A
+    B
+}
+
+do main() {
+    println("Should not compile!")
+}

--- a/tests/errors/comprehensive/E4011_member_access_invalid_type.ez
+++ b/tests/errors/comprehensive/E4011_member_access_invalid_type.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E4011 - member-access-invalid-type
+ * Expected: "not a struct"
+ */
+import & use @std
+
+do main() {
+    temp s = "hello"
+    println(s.name)  // strings don't have members
+}

--- a/tests/errors/comprehensive/E5018_max_recursion_depth.ez
+++ b/tests/errors/comprehensive/E5018_max_recursion_depth.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E5018 - max-recursion-depth
+ * Expected: "maximum recursion depth exceeded"
+ */
+import & use @std
+
+do recurse(n int) {
+    recurse(n + 1)
+}
+
+do main() {
+    recurse(0)
+}


### PR DESCRIPTION
## Summary
This PR includes bug fixes for issues #313, #314, #315, #316, #317, #318, #319, #320, #321, #322, #323, #324, #325, #326, #327, #328, and #329.

## Bug Fixes

### #313 - Member access on primitives allowed
- Added validation in typechecker to block member access on non-struct types

### #314 - Wrong type to mutable (&) parameter
- Already working - typechecker correctly validates type compatibility for mutable parameters

### #315, #316, #319, #320 - Type/function/builtin names allowed as parameter names
- Added typechecker validation to block user-defined types, functions, and builtins as parameter names

### #317 - Parser crashes on `const` used as identifier
- Fixed nil pointer crash when using 'const' as identifier

### #318 - Missing return value causes interpreter crash
- Changed missing return statement from warning to error

### #321 - Struct field names have no validation
- Added validation for struct field names against reserved keywords

### #322 - Enum value names allow type names and builtins
- Added validation for enum value names against reserved keywords

### #323 - Wrong line numbers in string interpolation errors
- Added `NewLexerWithOffset()` to preserve line numbers when parsing interpolation expressions

### #324 - Import placement not validated
- Added E2036 error for imports inside blocks or after declarations

### #325 - Reserved names as struct/enum names get generic error
- Added E2037 (reserved-struct-name) and E2038 (reserved-enum-name) specific error codes

### #326 - Keywords as identifiers get generic error
- Added `IsKeyword()` and `KeywordLiteral()` helpers in tokenizer
- Parser now emits E2020/E2021/E2033 with helpful messages when keywords are used as variable/function/parameter names

### #327 - No recursion limit causes stack overflow
- Added `MAX_CALL_DEPTH` constant (10000) and E5018 error for recursion limit

### #328 - Comments-only file shows wrong error code
- Fixed to use E4009 (missing-main) instead of E3007

### #329 - Untyped variables allow reassignment to different type
- Enforced static typing for type-inferred variables

## Test plan
- [x] All unit tests pass
- [x] All 79 error integration tests pass
- [x] New tests added for each fix