### PR TITLE
fix(typechecker): handle array and map types in struct fields

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -438,7 +438,18 @@ func (tc *TypeChecker) checkStructDeclaration(node *ast.StructDeclaration) {
 		}
 
 		// Add field to struct type
-		fieldType, _ := tc.GetType(field.TypeName)
+		fieldType, ok := tc.GetType(field.TypeName)
+		if !ok {
+			// For array/map types, create a Type on-the-fly since they're not in the registry
+			if tc.isArrayType(field.TypeName) {
+				fieldType = &Type{Name: field.TypeName, Kind: ArrayType}
+			} else if tc.isMapType(field.TypeName) {
+				fieldType = &Type{Name: field.TypeName, Kind: MapType}
+			} else {
+				// This shouldn't happen since TypeExists passed, but be safe
+				continue
+			}
+		}
 		structType.Fields[field.Name.Value] = fieldType
 	}
 }

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -482,6 +482,57 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
+func TestStructWithArrayField(t *testing.T) {
+	// Regression test for issue #336: typechecker crashed when accessing
+	// struct fields with array types due to nil pointer dereference
+	input := `
+const TestResult struct {
+	passed int
+	bugs [string]
+}
+
+do main() {
+	temp r TestResult = TestResult{passed: 1, bugs: {"bug1"}}
+	temp bug_list [string] = r.bugs
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestStructWithMapField(t *testing.T) {
+	// Ensure struct fields with map types also work correctly
+	input := `
+const Config struct {
+	name string
+	settings map[string:int]
+}
+
+do main() {
+	temp c Config = Config{name: "test", settings: {"a": 1}}
+	temp s map[string:int] = c.settings
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestStructWithNestedArrayField(t *testing.T) {
+	// Test nested array types in struct fields
+	input := `
+const Matrix struct {
+	rows [[int]]
+}
+
+do main() {
+	temp m Matrix = Matrix{rows: {{1, 2}, {3, 4}}}
+	temp r [[int]] = m.rows
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
 // ============================================================================
 // Enum Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #336

The typechecker crashed with a nil pointer dereference when accessing struct fields with array or map types.

## Root Cause

1. `checkStructDeclaration` called `GetType()` for field types
2. Array/map types like `[string]` aren't registered in the type registry
3. `GetType()` returned nil, which was stored in the struct's Fields map
4. `inferMemberType` later dereferenced the nil pointer → crash

## Fix

When `GetType()` returns false, check if the field type is an array or map type and create a `Type` struct on-the-fly with the appropriate `Kind` (`ArrayType` or `MapType`).

## Tests

Added 3 unit tests:
- `TestStructWithArrayField` - struct with `[string]` field
- `TestStructWithMapField` - struct with `map[string:int]` field  
- `TestStructWithNestedArrayField` - struct with `[[int]]` field

## Test Plan

- [x] Unit tests pass
- [x] Comprehensive test passes (223/223)
- [x] Reproduction case from issue now works