### PR TITLE
fix(evaluator): isTruthy now checks Boolean.Value instead of pointer identity

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2565,11 +2565,11 @@ func nativeBoolToBooleanObject(input bool) *Boolean {
 }
 
 func isTruthy(obj Object) bool {
-	switch obj {
-	case NIL:
+	switch v := obj.(type) {
+	case *Nil:
 		return false
-	case FALSE:
-		return false
+	case *Boolean:
+		return v.Value
 	default:
 		return true
 	}


### PR DESCRIPTION
## Summary
- Fixed `isTruthy` function to check `Boolean.Value` instead of comparing pointer identity
- Root cause: Two different `FALSE` singletons existed (in `object` and `interpreter` packages)
- When stdlib functions returned `object.FALSE`, comparison against interpreter's `FALSE` failed

Fixes #342

## Test plan
- [x] 5 new unit tests for boolean truthiness in if conditions
- [x] All interpreter tests pass
- [x] All stdlib tests pass
- [x] Manual test confirms strings.contains/starts_with/ends_with work correctly