### PR TITLE
fix(parser): enum member access in if condition no longer causes parser error

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2073,3 +2073,27 @@ func TestReservedEnumName(t *testing.T) {
 		t.Error("expected error for reserved enum name")
 	}
 }
+
+func TestEnumMemberInIfCondition(t *testing.T) {
+	// Test: enum member access in if condition should parse correctly
+	// Fixes #339
+	input := `const Color enum { Red, Green, Blue }
+do main() {
+    temp c Color = Color.Red
+    if c == Color.Red {
+        println("red")
+    }
+}`
+	l := NewLexer(input)
+	p := NewWithSource(l, input, "test.ez")
+	program := p.ParseProgram()
+
+	if p.EZErrors().HasErrors() {
+		t.Errorf("unexpected parser errors: %v", p.Errors())
+	}
+
+	// Should have parsed without errors
+	if program == nil {
+		t.Fatal("program is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed parser incorrectly treating `Color.Red` followed by `{` as a struct literal
- Added check: if both object and member start with uppercase (like `Color.Red`), skip struct literal parsing
- This allows enum member access in if conditions: `if c == Color.Red {`

Fixes #339

## Test plan
- [x] New unit test for enum member in if condition
- [x] All parser tests pass
- [x] Manual test confirms enum access works in if conditions