### PR TITLE
fix(typechecker): type errors now report correct source location

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1814,6 +1814,18 @@ func (tc *TypeChecker) getExpressionPosition(expr ast.Expression) (int, int) {
 		return e.Token.Line, e.Token.Column
 	case *ast.MemberExpression:
 		return e.Token.Line, e.Token.Column
+	case *ast.NilValue:
+		return e.Token.Line, e.Token.Column
+	case *ast.MapValue:
+		return e.Token.Line, e.Token.Column
+	case *ast.StructValue:
+		return e.Token.Line, e.Token.Column
+	case *ast.NewExpression:
+		return e.Token.Line, e.Token.Column
+	case *ast.PostfixExpression:
+		return e.Token.Line, e.Token.Column
+	case *ast.RangeExpression:
+		return e.Token.Line, e.Token.Column
 	default:
 		return 1, 1
 	}


### PR DESCRIPTION
## Summary
- Added missing expression types to `getExpressionPosition`:
  - `NilValue`
  - `MapValue`
  - `StructValue`
  - `NewExpression`
  - `PostfixExpression`
  - `RangeExpression`
- These were falling through to the default case which returned `(1, 1)`

Fixes #345

## Test plan
- [x] All typechecker tests pass
- [x] Manual test confirms `if nil {}` error now points to correct line