### PR TITLE
fix(interpreter): nested mutable parameter forwarding now works correctly

### DIFF
--- a/pkg/interpreter/evaluator_test.go
+++ b/pkg/interpreter/evaluator_test.go
@@ -1099,6 +1099,49 @@ str
 	testStringObject(t, evaluated, "modified")
 }
 
+func TestNestedMutableParameterForwarding(t *testing.T) {
+	// Test that mutable parameters work when forwarded through multiple functions
+	// This tests issue #338 - nested mutable parameter forwarding breaks array indexing
+	input := `
+do outer(&arr [int]) {
+	inner(arr)
+}
+
+do inner(&arr [int]) {
+	arr[0] = 999
+}
+
+temp nums [int] = {1, 2, 3}
+outer(nums)
+nums[0]
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 999)
+}
+
+func TestDeeplyNestedMutableParameterForwarding(t *testing.T) {
+	// Test mutable parameters forwarded through multiple levels
+	input := `
+do level1(&n int) {
+	level2(n)
+}
+
+do level2(&n int) {
+	level3(n)
+}
+
+do level3(&n int) {
+	n = 42
+}
+
+temp x int = 0
+level1(x)
+x
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 42)
+}
+
 // ============================================================================
 // String Interpolation Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Fixed nested mutable (&) parameter forwarding which was causing "index operator not supported: REFERENCE" errors
- `Reference.Deref()` now recursively dereferences through chained references
- `Environment.updateRef()` now chases through references when setting values

## Test plan
- [x] Added `TestNestedMutableParameterForwarding` - tests 2-level nesting (outer -> inner)
- [x] Added `TestDeeplyNestedMutableParameterForwarding` - tests 3-level nesting (level1 -> level2 -> level3)
- [x] All existing tests pass

Fixes #338