### PR TITLE
fix: resolve multiple bugs in stdlib, lexer, and parser

### DIFF
--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -182,6 +182,38 @@ func TestFloatLiterals(t *testing.T) {
 	}
 }
 
+// TestScientificNotation tests scientific notation parsing (Bug #366 fix)
+func TestScientificNotation(t *testing.T) {
+	tests := []struct {
+		input   string
+		literal string
+	}{
+		{"1e10", "1e10"},
+		{"1E10", "1E10"},
+		{"1e+10", "1e+10"},
+		{"1e-10", "1e-10"},
+		{"1.5e10", "1.5e10"},
+		{"1.5e+10", "1.5e+10"},
+		{"1.5e-10", "1.5e-10"},
+		{"1.5E10", "1.5E10"},
+		{"2.5e308", "2.5e308"},
+		{"5e-3", "5e-3"},
+		{"3.14e2", "3.14e2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			tokens := tokenize(tt.input)
+			if tokens[0].Type != tokenizer.FLOAT {
+				t.Errorf("type = %s, want FLOAT", tokens[0].Type)
+			}
+			if tokens[0].Literal != tt.literal {
+				t.Errorf("literal = %q, want %q", tokens[0].Literal, tt.literal)
+			}
+		})
+	}
+}
+
 // TestStringLiterals tests string token parsing
 func TestStringLiterals(t *testing.T) {
 	tests := []struct {

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -5,8 +5,8 @@ package stdlib
 
 import (
 	"fmt"
+	"math/rand"
 	"sort"
-	"time"
 
 	"github.com/marshallburns/ez/pkg/object"
 )
@@ -1043,5 +1043,8 @@ func compareObjects(a, b object.Object) int {
 }
 
 func randomInt(max int64) int64 {
-	return int64(float64(max) * float64(time.Now().UnixNano()%1000) / 1000.0)
+	if max <= 0 {
+		return 0
+	}
+	return rand.Int63n(max)
 }

--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -893,6 +893,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			if err != nil {
 				return err
 			}
+			if inMax == inMin {
+				return &object.Error{Code: "E8007", Message: "math.map_range() requires in_min != in_max (division by zero)"}
+			}
 			result := (value-inMin)*(outMax-outMin)/(inMax-inMin) + outMin
 			return &object.Float{Value: result}
 		},

--- a/tests/errors/comprehensive/E8007_map_range_div_zero.ez
+++ b/tests/errors/comprehensive/E8007_map_range_div_zero.ez
@@ -1,0 +1,9 @@
+// Expected error: E8007 - math.map_range() requires in_min != in_max (division by zero)
+import @std, @math
+using std
+
+do main() {
+    // When inMin == inMax, division by zero occurs - this should error
+    temp result float = math.map_range(5.0, 0.0, 0.0, 0.0, 100.0)
+    println("${result}")
+}


### PR DESCRIPTION
## Summary
- Fix #369: `arrays.shuffle()` now properly shuffles using `math/rand`
- Fix #370: `math.map_range()` returns error on division by zero
- Fix #371: `time.add_months()` correctly clamps to end-of-month dates
- Fix #366: Scientific notation parsing now works (`1e308`, `1.5e-10`)
- Fix #364 & #365: Parser handles complex types `[map[K:V]]` and `map[K:[V]]`

## Test plan
- [x] All 223 comprehensive tests pass
- [x] All Go unit tests pass
- [x] Added unit tests for each fix
- [x] Added error test for E8007 (map_range division by zero)

Closes #364, closes #365, closes #366, closes #369, closes #370, closes #371