### PR TITLE
Replace @ignore with _ blank identifier

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -271,13 +271,13 @@ type VariableDeclaration struct {
 	Visibility Visibility   // Public (default), Private, or PrivateModule
 }
 
-// IgnoreValue represents @ignore in multiple assignment
-type IgnoreValue struct {
+// BlankIdentifier represents _ (blank identifier) in multiple assignment
+type BlankIdentifier struct {
 	Token Token
 }
 
-func (i *IgnoreValue) expressionNode()      {}
-func (i *IgnoreValue) TokenLiteral() string { return i.Token.Literal }
+func (b *BlankIdentifier) expressionNode()      {}
+func (b *BlankIdentifier) TokenLiteral() string { return b.Token.Literal }
 
 // Attribute represents @suppress(warning_name, ...)
 type Attribute struct {

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -39,7 +39,7 @@ func TestNodeInterface(t *testing.T) {
 		&MemberExpression{},
 		&NewExpression{},
 		&RangeExpression{},
-		&IgnoreValue{},
+		&BlankIdentifier{},
 		&Attribute{},
 		&VariableDeclaration{},
 		&AssignmentStatement{},
@@ -89,7 +89,7 @@ func TestExpressionInterface(t *testing.T) {
 		&MemberExpression{},
 		&NewExpression{},
 		&RangeExpression{},
-		&IgnoreValue{},
+		&BlankIdentifier{},
 		&Attribute{},
 	}
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -200,14 +200,14 @@ func Eval(node ast.Node, env *Environment) Object {
 		if call, ok := node.Expression.(*ast.CallExpression); ok {
 			if fn, ok := result.(*ReturnValue); ok && len(fn.Values) > 0 {
 				return newErrorWithLocation("E4009", call.Token.Line, call.Token.Column,
-					"return value from function not used (use @ignore to discard)")
+					"return value from function not used (use _ to discard)")
 			}
 			// Also check if the function has declared return types but result is not NIL
 			if result != NIL {
 				// Check if it's a user function with return types
 				if fnObj := getFunctionObject(call, env); fnObj != nil && len(fnObj.ReturnTypes) > 0 {
 					return newErrorWithLocation("E4009", call.Token.Line, call.Token.Column,
-						"return value from function not used (use @ignore to discard)")
+						"return value from function not used (use _ to discard)")
 				}
 			}
 		}
@@ -799,8 +799,8 @@ func evalVariableDeclaration(node *ast.VariableDeclaration, env *Environment) Ob
 		}
 
 		for i, name := range node.Names {
-			// Skip @ignore
-			if name.Value == "@ignore" {
+			// Skip blank identifier (_)
+			if name.Value == "_" {
 				continue
 			}
 			env.SetWithVisibility(name.Value, returnVal.Values[i], node.Mutable, vis)

--- a/pkg/interpreter/evaluator_test.go
+++ b/pkg/interpreter/evaluator_test.go
@@ -3409,3 +3409,59 @@ output
 	testStringObject(t, evaluated, "correct")
 }
 
+// ============================================================================
+// Blank Identifier Tests
+// ============================================================================
+
+func TestBlankIdentifierDiscardsValue(t *testing.T) {
+	input := `
+do getTwo() -> (int, int) {
+    return 1, 2
+}
+
+temp a, _ = getTwo()
+a
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 1)
+}
+
+func TestBlankIdentifierAsFirstValue(t *testing.T) {
+	input := `
+do getTwo() -> (int, int) {
+    return 1, 2
+}
+
+temp _, b = getTwo()
+b
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 2)
+}
+
+func TestMultipleBlankIdentifiersInAssignment(t *testing.T) {
+	input := `
+do getThree() -> (int, int, int) {
+    return 1, 2, 3
+}
+
+temp _, _, c = getThree()
+c
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 3)
+}
+
+func TestBlankIdentifierMiddleValue(t *testing.T) {
+	input := `
+do getThree() -> (int, int, int) {
+    return 10, 20, 30
+}
+
+temp a, _, c = getThree()
+a + c
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 40)
+}
+

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -208,16 +208,8 @@ func (l *Lexer) NextToken() tokenizer.Token {
 	case '.':
 		tok = newToken(tokenizer.DOT, l.ch, l.line, l.column)
 	case '@':
-		// Peek ahead to check for @ignore or @suppress
-		if l.peekAheadString(7) == "@ignore" {
-			// Found @ignore
-			tok = tokenizer.Token{Type: tokenizer.IGNORE, Literal: "@ignore", Line: l.line, Column: l.column}
-			// Consume the entire @ignore token
-			for i := 0; i < 7; i++ {
-				l.readChar()
-			}
-			return tok
-		} else if l.peekAheadString(9) == "@suppress" {
+		// Peek ahead to check for @suppress
+		if l.peekAheadString(9) == "@suppress" {
 			// Found @suppress
 			tok = tokenizer.Token{Type: tokenizer.SUPPRESS, Literal: "@suppress", Line: l.line, Column: l.column}
 			// Consume the entire @suppress token

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -372,16 +372,16 @@ func TestIdentifiers(t *testing.T) {
 	}
 }
 
-// TestSpecialTokens tests @ignore, @suppress, !in
+// TestSpecialTokens tests @suppress, !in, and blank identifier
 func TestSpecialTokens(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected tokenizer.TokenType
 		literal  string
 	}{
-		{"@ignore", tokenizer.IGNORE, "@ignore"},
 		{"@suppress", tokenizer.SUPPRESS, "@suppress"},
 		{"!in", tokenizer.NOT_IN, "!in"},
+		{"_", tokenizer.BLANK, "_"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -534,16 +534,71 @@ func TestMultipleVariableDeclaration(t *testing.T) {
 	}
 }
 
-func TestIgnoreInMultipleDeclaration(t *testing.T) {
-	input := "temp @ignore, b = getValues()"
+func TestBlankIdentifierInMultipleDeclaration(t *testing.T) {
+	// Test that _ (blank identifier) works in multiple assignment
+	input := "temp _, b = getValues()"
 	program := parseProgram(t, input)
 	stmt := program.Statements[0].(*VariableDeclaration)
 
 	if len(stmt.Names) != 2 {
 		t.Fatalf("expected 2 names, got %d", len(stmt.Names))
 	}
-	if stmt.Names[0].Value != "@ignore" {
-		t.Errorf("expected first name '@ignore', got %q", stmt.Names[0].Value)
+	if stmt.Names[0].Value != "_" {
+		t.Errorf("expected first name '_', got %q", stmt.Names[0].Value)
+	}
+	if stmt.Names[1].Value != "b" {
+		t.Errorf("expected second name 'b', got %q", stmt.Names[1].Value)
+	}
+}
+
+func TestBlankIdentifierAsSecondValue(t *testing.T) {
+	// Test _ as second value in multiple assignment
+	input := "temp a, _ = getValues()"
+	program := parseProgram(t, input)
+	stmt := program.Statements[0].(*VariableDeclaration)
+
+	if len(stmt.Names) != 2 {
+		t.Fatalf("expected 2 names, got %d", len(stmt.Names))
+	}
+	if stmt.Names[0].Value != "a" {
+		t.Errorf("expected first name 'a', got %q", stmt.Names[0].Value)
+	}
+	if stmt.Names[1].Value != "_" {
+		t.Errorf("expected second name '_', got %q", stmt.Names[1].Value)
+	}
+}
+
+func TestMultipleBlankIdentifiers(t *testing.T) {
+	// Test multiple _ in a single assignment
+	input := "temp _, _, c = getThreeValues()"
+	program := parseProgram(t, input)
+	stmt := program.Statements[0].(*VariableDeclaration)
+
+	if len(stmt.Names) != 3 {
+		t.Fatalf("expected 3 names, got %d", len(stmt.Names))
+	}
+	if stmt.Names[0].Value != "_" {
+		t.Errorf("expected first name '_', got %q", stmt.Names[0].Value)
+	}
+	if stmt.Names[1].Value != "_" {
+		t.Errorf("expected second name '_', got %q", stmt.Names[1].Value)
+	}
+	if stmt.Names[2].Value != "c" {
+		t.Errorf("expected third name 'c', got %q", stmt.Names[2].Value)
+	}
+}
+
+func TestBlankIdentifierOnly(t *testing.T) {
+	// Test _ as the only variable (discarding a single return value)
+	input := "temp _ = getSingleValue()"
+	program := parseProgram(t, input)
+	stmt := program.Statements[0].(*VariableDeclaration)
+
+	if len(stmt.Names) != 1 {
+		t.Fatalf("expected 1 name, got %d", len(stmt.Names))
+	}
+	if stmt.Names[0].Value != "_" {
+		t.Errorf("expected name '_', got %q", stmt.Names[0].Value)
 	}
 }
 

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -75,7 +75,7 @@ const (
 	// Dot
 	DOT TokenType = "."
 
-	// At sign (for attributes and @ignore)
+	// At sign (for attributes)
 	AT TokenType = "@"
 
 	// Keywords
@@ -103,7 +103,7 @@ const (
 	NEW        TokenType = "NEW"
 	TRUE       TokenType = "TRUE"
 	FALSE      TokenType = "FALSE"
-	IGNORE     TokenType = "IGNORE"
+	BLANK TokenType = "BLANK" // _ blank identifier
 	SUPPRESS   TokenType = "SUPPRESS"
 
 	// Module system keywords
@@ -141,7 +141,7 @@ var keywords = map[string]TokenType{
 	"new":        NEW,
 	"true":       TRUE,
 	"false":      FALSE,
-	"@ignore":    IGNORE,
+	"_": BLANK,
 	"module":     MODULE,
 	"private":    PRIVATE,
 	"from":       FROM,
@@ -164,7 +164,7 @@ func IsKeyword(t TokenType) bool {
 	case TEMP, CONST, DO, RETURN, IF, OR_KW, OTHERWISE,
 		FOR, FOR_EACH, AS_LONG_AS, LOOP, BREAK, CONTINUE,
 		IN, NOT_IN, RANGE, IMPORT, USING, STRUCT, ENUM,
-		NIL, NEW, TRUE, FALSE, IGNORE, MODULE, PRIVATE, FROM, USE:
+		NIL, NEW, TRUE, FALSE, BLANK, MODULE, PRIVATE, FROM, USE:
 		return true
 	}
 	return false

--- a/pkg/tokenizer/token_test.go
+++ b/pkg/tokenizer/token_test.go
@@ -99,7 +99,7 @@ func TestTokenTypeConstants(t *testing.T) {
 		{"NEW", NEW, "NEW"},
 		{"TRUE", TRUE, "TRUE"},
 		{"FALSE", FALSE, "FALSE"},
-		{"IGNORE", IGNORE, "IGNORE"},
+		{"BLANK", BLANK, "BLANK"},
 		{"SUPPRESS", SUPPRESS, "SUPPRESS"},
 		{"MODULE", MODULE, "MODULE"},
 		{"PRIVATE", PRIVATE, "PRIVATE"},
@@ -147,7 +147,7 @@ func TestLookupIdentifier(t *testing.T) {
 		{"new", NEW},
 		{"true", TRUE},
 		{"false", FALSE},
-		{"@ignore", IGNORE},
+		{"_", BLANK},
 		{"module", MODULE},
 		{"private", PRIVATE},
 		{"from", FROM},
@@ -208,7 +208,7 @@ func TestTokenStruct(t *testing.T) {
 
 // TestKeywordCount verifies the expected number of keywords
 func TestKeywordCount(t *testing.T) {
-	// Count keywords in the map (including @ignore)
+	// Count keywords in the map (including _)
 	expectedCount := 29
 	actualCount := 0
 
@@ -217,7 +217,7 @@ func TestKeywordCount(t *testing.T) {
 		"temp", "const", "do", "return", "if", "or", "otherwise",
 		"for", "for_each", "as_long_as", "loop", "break", "continue",
 		"in", "not_in", "range", "import", "using", "struct", "enum",
-		"nil", "new", "true", "false", "@ignore", "module", "private",
+		"nil", "new", "true", "false", "_", "module", "private",
 		"from", "use",
 	}
 
@@ -239,7 +239,7 @@ func TestIsKeyword(t *testing.T) {
 		TEMP, CONST, DO, RETURN, IF, OR_KW, OTHERWISE,
 		FOR, FOR_EACH, AS_LONG_AS, LOOP, BREAK, CONTINUE,
 		IN, NOT_IN, RANGE, IMPORT, USING, STRUCT, ENUM,
-		NIL, NEW, TRUE, FALSE, IGNORE, MODULE, PRIVATE, FROM, USE,
+		NIL, NEW, TRUE, FALSE, BLANK, MODULE, PRIVATE, FROM, USE,
 	}
 
 	for _, tt := range keywordTypes {
@@ -301,7 +301,7 @@ func TestKeywordLiteral(t *testing.T) {
 		{NEW, "new"},
 		{TRUE, "true"},
 		{FALSE, "false"},
-		{IGNORE, "@ignore"},
+		{BLANK, "_"},
 		{MODULE, "module"},
 		{PRIVATE, "private"},
 		{FROM, "from"},

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1960,7 +1960,7 @@ func (tc *TypeChecker) inferExpressionType(expr ast.Expression) (string, bool) {
 	case *ast.InterpolatedString:
 		return "string", true
 
-	case *ast.IgnoreValue:
+	case *ast.BlankIdentifier:
 		return "void", true
 
 	default:

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -2105,7 +2105,7 @@ do test_stdlib_io() -> TestResult {
     }
 
     // Verify append worked
-    temp updated_content, @ignore = io.read_file(test_file)
+    temp updated_content, _ = io.read_file(test_file)
     temp has_append bool = strings.contains(updated_content, "Appended line")
     println("  Append verification: ${has_append}")
     passed += 1
@@ -2532,7 +2532,7 @@ do test_stdlib_os() -> TestResult {
     println("")
     println("  Directory Operations:")
 
-    temp original_dir, @ignore = os.cwd()
+    temp original_dir, _ = os.cwd()
     temp target_dir string = os.temp_dir()
 
     temp chdir_ok, chdir_err = os.chdir(target_dir)


### PR DESCRIPTION
## Summary
- Removes `@ignore` completely from the language
- Adds `_` (underscore) as the blank identifier for discarding values in multi-value assignments
- Example: `temp result, _ = some_function()` to discard the second return value

Closes #222

## Changes
- Remove IGNORE token type and lexer handling
- Add BLANK token type for `_` recognition
- Update parser to handle `_` in multi-value assignments
- Rename IgnoreValue to BlankIdentifier in AST
- Update interpreter to skip `_` in variable bindings
- Update comprehensive.ez examples

## Test plan
- [x] Tokenizer tests for BLANK token
- [x] Lexer tests for `_` special token
- [x] Parser tests for blank identifier in various positions
- [x] Interpreter tests for value discarding behavior
- [x] All existing tests pass