### PR TITLE
fix: resolve stdlib bugs for arrays, strings, and math modules

### DIFF
--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -129,10 +129,18 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7002", Message: "arrays.shift() requires an array"}
 			}
+			if !arr.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable array (declared as const)",
+					Code:    "E4005",
+				}
+			}
 			if len(arr.Elements) == 0 {
 				return &object.Error{Code: "E9001", Message: "arrays.shift() cannot shift from empty array"}
 			}
-			return arr.Elements[0]
+			firstElement := arr.Elements[0]
+			arr.Elements = arr.Elements[1:]
+			return firstElement
 		},
 	},
 
@@ -210,11 +218,18 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if len(args) != 1 {
 				return newError("arrays.clear() takes exactly 1 argument")
 			}
-			_, ok := args[0].(*object.Array)
+			arr, ok := args[0].(*object.Array)
 			if !ok {
 				return &object.Error{Code: "E7002", Message: "arrays.clear() requires an array"}
 			}
-			return &object.Array{Elements: []object.Object{}}
+			if !arr.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable array (declared as const)",
+					Code:    "E4005",
+				}
+			}
+			arr.Elements = []object.Object{}
+			return object.NIL
 		},
 	},
 
@@ -900,11 +915,16 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7002", Message: "arrays.fill() requires an array"}
 			}
-			elements := make([]object.Object, len(arr.Elements))
-			for i := range elements {
-				elements[i] = args[1]
+			if !arr.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable array (declared as const)",
+					Code:    "E4005",
+				}
 			}
-			return &object.Array{Elements: elements}
+			for i := range arr.Elements {
+				arr.Elements[i] = args[1]
+			}
+			return object.NIL
 		},
 	},
 

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -230,15 +230,20 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "strings.slice() requires integer indices"}
 			}
+
+			// Convert to runes for proper UTF-8 character handling
+			runes := []rune(str.Value)
+			runeLen := len(runes)
+
 			startIdx := int(start.Value)
 			if startIdx < 0 {
-				startIdx = len(str.Value) + startIdx
+				startIdx = runeLen + startIdx
 			}
 			if startIdx < 0 {
 				startIdx = 0
 			}
 
-			endIdx := len(str.Value)
+			endIdx := runeLen
 			if len(args) == 3 {
 				end, ok := args[2].(*object.Integer)
 				if !ok {
@@ -246,21 +251,21 @@ var StringsBuiltins = map[string]*object.Builtin{
 				}
 				endIdx = int(end.Value)
 				if endIdx < 0 {
-					endIdx = len(str.Value) + endIdx
+					endIdx = runeLen + endIdx
 				}
 			}
 
-			if startIdx > len(str.Value) {
-				startIdx = len(str.Value)
+			if startIdx > runeLen {
+				startIdx = runeLen
 			}
-			if endIdx > len(str.Value) {
-				endIdx = len(str.Value)
+			if endIdx > runeLen {
+				endIdx = runeLen
 			}
 			if startIdx > endIdx {
 				return &object.String{Value: ""}
 			}
 
-			return &object.String{Value: str.Value[startIdx:endIdx]}
+			return &object.String{Value: string(runes[startIdx:endIdx])}
 		},
 	},
 
@@ -310,14 +315,18 @@ var StringsBuiltins = map[string]*object.Builtin{
 					return &object.Error{Code: "E7003", Message: "strings.pad_left() requires a string as pad character"}
 				}
 				if len(pad.Value) > 0 {
-					padChar = string(pad.Value[0])
+					// Use first rune of pad string for proper UTF-8 handling
+					padRunes := []rune(pad.Value)
+					padChar = string(padRunes[0])
 				}
 			}
 			targetWidth := int(width.Value)
-			if len(str.Value) >= targetWidth {
+			// Use rune count instead of byte length for proper UTF-8 handling
+			strRuneLen := len([]rune(str.Value))
+			if strRuneLen >= targetWidth {
 				return str
 			}
-			padding := strings.Repeat(padChar, targetWidth-len(str.Value))
+			padding := strings.Repeat(padChar, targetWidth-strRuneLen)
 			return &object.String{Value: padding + str.Value}
 		},
 	},
@@ -342,14 +351,18 @@ var StringsBuiltins = map[string]*object.Builtin{
 					return &object.Error{Code: "E7003", Message: "strings.pad_right() requires a string as pad character"}
 				}
 				if len(pad.Value) > 0 {
-					padChar = string(pad.Value[0])
+					// Use first rune of pad string for proper UTF-8 handling
+					padRunes := []rune(pad.Value)
+					padChar = string(padRunes[0])
 				}
 			}
 			targetWidth := int(width.Value)
-			if len(str.Value) >= targetWidth {
+			// Use rune count instead of byte length for proper UTF-8 handling
+			strRuneLen := len([]rune(str.Value))
+			if strRuneLen >= targetWidth {
 				return str
 			}
-			padding := strings.Repeat(padChar, targetWidth-len(str.Value))
+			padding := strings.Repeat(padChar, targetWidth-strRuneLen)
 			return &object.String{Value: str.Value + padding}
 		},
 	},

--- a/tests/comprehensive.ez
+++ b/tests/comprehensive.ez
@@ -189,6 +189,10 @@ do main() {
     total_passed += result.passed
     total_failed += result.failed
 
+    result = test_bugfix_388_396()
+    total_passed += result.passed
+    total_failed += result.failed
+
     temp total int = total_passed + total_failed
 
     println("")
@@ -2751,6 +2755,139 @@ do test_bugfix_378_383() -> TestResult {
         passed += 1
     } otherwise {
         println("    Normal decrement: FAIL")
+        failed += 1
+    }
+
+    println("  PASSED: ${passed}, FAILED: ${failed}")
+    return TestResult{passed: passed, failed: failed}
+}
+
+// ==================================================
+// BUG FIXES #388-#396 (STDLIB BUGS)
+// ==================================================
+
+do test_bugfix_388_396() -> TestResult {
+    print_section("Bug Fixes #388-#396 (Stdlib)")
+    temp passed int = 0
+    temp failed int = 0
+
+    // ===== Test #388: arrays.clear() modifies in-place =====
+    println("  [#388] arrays.clear() in-place:")
+
+    temp clear_arr [int] = {1, 2, 3, 4, 5}
+    arrays.clear(clear_arr)
+    if len(clear_arr) == 0 {
+        println("    arrays.clear() modifies in-place: PASS")
+        passed += 1
+    } otherwise {
+        println("    arrays.clear() modifies in-place: FAIL (got ${len(clear_arr)} elements)")
+        failed += 1
+    }
+
+    // ===== Test #389: arrays.fill() modifies in-place =====
+    println("  [#389] arrays.fill() in-place:")
+
+    temp fill_arr [int] = {1, 2, 3}
+    arrays.fill(fill_arr, 0)
+    if fill_arr[0] == 0 && fill_arr[1] == 0 && fill_arr[2] == 0 {
+        println("    arrays.fill() modifies in-place: PASS")
+        passed += 1
+    } otherwise {
+        println("    arrays.fill() modifies in-place: FAIL")
+        failed += 1
+    }
+
+    // ===== Test #391: arrays.shift() removes element =====
+    println("  [#391] arrays.shift() removes element:")
+
+    temp shift_arr [int] = {10, 20, 30}
+    temp shifted int = arrays.shift(shift_arr)
+    if shifted == 10 && len(shift_arr) == 2 && shift_arr[0] == 20 {
+        println("    arrays.shift() removes element: PASS")
+        passed += 1
+    } otherwise {
+        println("    arrays.shift() removes element: FAIL (shifted=${shifted}, len=${len(shift_arr)})")
+        failed += 1
+    }
+
+    // ===== Test #392: strings.slice() UTF-8 support =====
+    println("  [#392] strings.slice() UTF-8:")
+
+    temp utf8_str string = "Hello 世界"
+
+    // Slice ASCII part
+    temp ascii_slice string = strings.slice(utf8_str, 0, 5)
+    if ascii_slice == "Hello" {
+        println("    ASCII slice: PASS")
+        passed += 1
+    } otherwise {
+        println("    ASCII slice: FAIL (got '${ascii_slice}')")
+        failed += 1
+    }
+
+    // Slice Chinese part
+    temp chinese_slice string = strings.slice(utf8_str, 6, 8)
+    if chinese_slice == "世界" {
+        println("    Chinese slice: PASS")
+        passed += 1
+    } otherwise {
+        println("    Chinese slice: FAIL (got '${chinese_slice}')")
+        failed += 1
+    }
+
+    // ===== Test #393: strings.pad_left/pad_right UTF-8 support =====
+    println("  [#393] strings.pad_left/pad_right UTF-8:")
+
+    temp chinese_str string = "世界"
+
+    // pad_left: "世界" is 2 characters, padding to 5 should add 3 spaces
+    temp padded_left string = strings.pad_left(chinese_str, 5)
+    if len(padded_left) == 5 && strings.ends_with(padded_left, "世界") {
+        println("    pad_left with UTF-8: PASS")
+        passed += 1
+    } otherwise {
+        println("    pad_left with UTF-8: FAIL (len=${len(padded_left)})")
+        failed += 1
+    }
+
+    // pad_right: "世界" is 2 characters, padding to 5 should add 3 spaces
+    temp padded_right string = strings.pad_right(chinese_str, 5)
+    if len(padded_right) == 5 && strings.starts_with(padded_right, "世界") {
+        println("    pad_right with UTF-8: PASS")
+        passed += 1
+    } otherwise {
+        println("    pad_right with UTF-8: FAIL (len=${len(padded_right)})")
+        failed += 1
+    }
+
+    // ===== Test #394-396: Math overflow handling =====
+    // Note: These tests verify normal behavior since we can't easily test errors in EZ scripts
+    println("  [#394-396] Math functions (normal behavior):")
+
+    // math.abs() with normal values
+    if math.abs(-42) == 42 {
+        println("    math.abs(-42): PASS")
+        passed += 1
+    } otherwise {
+        println("    math.abs(-42): FAIL")
+        failed += 1
+    }
+
+    // math.neg() with normal values
+    if math.neg(42) == -42 && math.neg(-42) == 42 {
+        println("    math.neg(): PASS")
+        passed += 1
+    } otherwise {
+        println("    math.neg(): FAIL")
+        failed += 1
+    }
+
+    // math.pow() with normal values
+    if math.pow(2, 10) == 1024 {
+        println("    math.pow(2, 10): PASS")
+        passed += 1
+    } otherwise {
+        println("    math.pow(2, 10): FAIL")
         failed += 1
     }
 


### PR DESCRIPTION
## Summary

- `arrays.clear()` now modifies array in-place (#388)
- `arrays.fill()` now modifies array in-place (#389)
- `arrays.shift()` now removes element from array (#391)
- `strings.slice()` now uses runes for proper UTF-8 handling (#392)
- `strings.pad_left/pad_right` now use rune count for UTF-8 (#393)
- `math.abs()` now returns error for MinInt64 overflow (#394)
- `math.neg()` now returns error for MinInt64 overflow (#395)
- `math.pow()` now returns error when result exceeds int64 (#396)

## Test plan

- [x] All Go unit tests pass (`go test ./...`)
- [x] Comprehensive EZ tests pass (250/250)
- [x] Added new unit tests for each bug fix
- [x] Added integration tests in `tests/comprehensive.ez`

Closes #388, #389, #391, #392, #393, #394, #395, #396