### PR TITLE
feat: add line editor for REPL with arrow key navigation and history

### DIFF
--- a/pkg/lineeditor/history.go
+++ b/pkg/lineeditor/history.go
@@ -1,0 +1,109 @@
+package lineeditor
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+// History manages command history for the line editor
+type History struct {
+	entries []string
+	index   int // Current position in history (-1 means not browsing)
+	maxSize int
+	current string // Stores current input when browsing history
+}
+
+// NewHistory creates a new History with the given maximum size
+func NewHistory(maxSize int) *History {
+	if maxSize <= 0 {
+		maxSize = 100
+	}
+	return &History{
+		entries: make([]string, 0, maxSize),
+		index:   -1,
+		maxSize: maxSize,
+	}
+}
+
+// Add adds a new entry to the history
+// Empty strings and duplicates of the last entry are ignored
+func (h *History) Add(entry string) {
+	if entry == "" {
+		return
+	}
+
+	// Don't add duplicates of the last entry
+	if len(h.entries) > 0 && h.entries[len(h.entries)-1] == entry {
+		return
+	}
+
+	h.entries = append(h.entries, entry)
+
+	// Trim if exceeds max size
+	if len(h.entries) > h.maxSize {
+		h.entries = h.entries[1:]
+	}
+
+	h.Reset()
+}
+
+// Previous returns the previous history entry
+// Returns the current entry and true if available, or empty string and false if at start
+func (h *History) Previous(currentInput string) (string, bool) {
+	if len(h.entries) == 0 {
+		return "", false
+	}
+
+	// Save current input when starting to browse
+	if h.index == -1 {
+		h.current = currentInput
+		h.index = len(h.entries)
+	}
+
+	if h.index > 0 {
+		h.index--
+		return h.entries[h.index], true
+	}
+
+	return h.entries[0], true
+}
+
+// Next returns the next history entry (more recent)
+// Returns the entry and true if available, or the saved current input if at end
+func (h *History) Next() (string, bool) {
+	if h.index == -1 {
+		return "", false
+	}
+
+	h.index++
+
+	if h.index >= len(h.entries) {
+		// Restore the original input
+		h.index = -1
+		return h.current, true
+	}
+
+	return h.entries[h.index], true
+}
+
+// Reset resets the browsing position
+func (h *History) Reset() {
+	h.index = -1
+	h.current = ""
+}
+
+// Len returns the number of entries in history
+func (h *History) Len() int {
+	return len(h.entries)
+}
+
+// Entries returns a copy of all history entries
+func (h *History) Entries() []string {
+	result := make([]string, len(h.entries))
+	copy(result, h.entries)
+	return result
+}
+
+// Clear removes all history entries
+func (h *History) Clear() {
+	h.entries = h.entries[:0]
+	h.Reset()
+}

--- a/pkg/lineeditor/keys.go
+++ b/pkg/lineeditor/keys.go
@@ -1,0 +1,196 @@
+package lineeditor
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+// Key represents a parsed keyboard input
+type Key int
+
+const (
+	KeyUnknown Key = iota
+	KeyChar        // Regular character
+	KeyEnter
+	KeyBackspace
+	KeyDelete
+	KeyLeft
+	KeyRight
+	KeyUp
+	KeyDown
+	KeyHome
+	KeyEnd
+	KeyTab
+	KeyCtrlC
+	KeyCtrlD
+	KeyCtrlL
+)
+
+// KeyEvent represents a keyboard event with the key type and optional rune
+type KeyEvent struct {
+	Key  Key
+	Char rune
+}
+
+// ParseKey parses raw input bytes into a KeyEvent
+// Returns the KeyEvent and number of bytes consumed
+func ParseKey(buf []byte, n int) (KeyEvent, int) {
+	if n == 0 {
+		return KeyEvent{Key: KeyUnknown}, 0
+	}
+
+	// Single byte characters
+	if n == 1 {
+		return parseSingleByte(buf[0]), 1
+	}
+
+	// Check for escape sequences
+	if buf[0] == 0x1b {
+		return parseEscapeSequence(buf, n)
+	}
+
+	// Multi-byte UTF-8 character
+	r, size := decodeUTF8(buf, n)
+	if size > 0 {
+		return KeyEvent{Key: KeyChar, Char: r}, size
+	}
+
+	return KeyEvent{Key: KeyUnknown}, 1
+}
+
+// parseSingleByte handles single byte input
+func parseSingleByte(b byte) KeyEvent {
+	switch b {
+	case 0x03: // Ctrl+C
+		return KeyEvent{Key: KeyCtrlC}
+	case 0x04: // Ctrl+D
+		return KeyEvent{Key: KeyCtrlD}
+	case 0x09: // Tab
+		return KeyEvent{Key: KeyTab}
+	case 0x0c: // Ctrl+L
+		return KeyEvent{Key: KeyCtrlL}
+	case 0x0d, 0x0a: // Enter (CR or LF)
+		return KeyEvent{Key: KeyEnter}
+	case 0x7f, 0x08: // Backspace (DEL or BS)
+		return KeyEvent{Key: KeyBackspace}
+	case 0x1b: // Escape - but alone, treat as unknown
+		return KeyEvent{Key: KeyUnknown}
+	default:
+		if b >= 32 && b < 127 {
+			return KeyEvent{Key: KeyChar, Char: rune(b)}
+		}
+		return KeyEvent{Key: KeyUnknown}
+	}
+}
+
+// parseEscapeSequence handles ANSI escape sequences
+func parseEscapeSequence(buf []byte, n int) (KeyEvent, int) {
+	if n < 2 {
+		return KeyEvent{Key: KeyUnknown}, 1
+	}
+
+	// CSI sequences: ESC [
+	if buf[1] == '[' {
+		if n < 3 {
+			return KeyEvent{Key: KeyUnknown}, 2
+		}
+
+		switch buf[2] {
+		case 'A': // Up arrow
+			return KeyEvent{Key: KeyUp}, 3
+		case 'B': // Down arrow
+			return KeyEvent{Key: KeyDown}, 3
+		case 'C': // Right arrow
+			return KeyEvent{Key: KeyRight}, 3
+		case 'D': // Left arrow
+			return KeyEvent{Key: KeyLeft}, 3
+		case 'H': // Home
+			return KeyEvent{Key: KeyHome}, 3
+		case 'F': // End
+			return KeyEvent{Key: KeyEnd}, 3
+		case '1': // Could be Home (ESC[1~) or other
+			if n >= 4 && buf[3] == '~' {
+				return KeyEvent{Key: KeyHome}, 4
+			}
+		case '3': // Delete (ESC[3~)
+			if n >= 4 && buf[3] == '~' {
+				return KeyEvent{Key: KeyDelete}, 4
+			}
+		case '4': // End (ESC[4~)
+			if n >= 4 && buf[3] == '~' {
+				return KeyEvent{Key: KeyEnd}, 4
+			}
+		}
+	}
+
+	// SS3 sequences: ESC O (alternate arrow keys on some terminals)
+	if buf[1] == 'O' && n >= 3 {
+		switch buf[2] {
+		case 'A':
+			return KeyEvent{Key: KeyUp}, 3
+		case 'B':
+			return KeyEvent{Key: KeyDown}, 3
+		case 'C':
+			return KeyEvent{Key: KeyRight}, 3
+		case 'D':
+			return KeyEvent{Key: KeyLeft}, 3
+		case 'H':
+			return KeyEvent{Key: KeyHome}, 3
+		case 'F':
+			return KeyEvent{Key: KeyEnd}, 3
+		}
+	}
+
+	return KeyEvent{Key: KeyUnknown}, 1
+}
+
+// decodeUTF8 decodes a UTF-8 character from the buffer
+func decodeUTF8(buf []byte, n int) (rune, int) {
+	if n == 0 {
+		return 0, 0
+	}
+
+	b := buf[0]
+
+	// Single byte (ASCII)
+	if b < 0x80 {
+		return rune(b), 1
+	}
+
+	// Multi-byte sequence
+	var size int
+	var min rune
+	var r rune
+
+	switch {
+	case b&0xe0 == 0xc0: // 2-byte sequence
+		size = 2
+		min = 0x80
+		r = rune(b & 0x1f)
+	case b&0xf0 == 0xe0: // 3-byte sequence
+		size = 3
+		min = 0x800
+		r = rune(b & 0x0f)
+	case b&0xf8 == 0xf0: // 4-byte sequence
+		size = 4
+		min = 0x10000
+		r = rune(b & 0x07)
+	default:
+		return 0xFFFD, 1 // Invalid, return replacement char
+	}
+
+	if n < size {
+		return 0xFFFD, 1 // Incomplete sequence
+	}
+
+	for i := 1; i < size; i++ {
+		if buf[i]&0xc0 != 0x80 {
+			return 0xFFFD, 1 // Invalid continuation byte
+		}
+		r = r<<6 | rune(buf[i]&0x3f)
+	}
+
+	if r < min {
+		return 0xFFFD, 1 // Overlong encoding
+	}
+
+	return r, size
+}

--- a/pkg/lineeditor/lineeditor.go
+++ b/pkg/lineeditor/lineeditor.go
@@ -1,0 +1,292 @@
+package lineeditor
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Editor provides interactive line editing capabilities
+type Editor struct {
+	terminal *Terminal
+	history  *History
+	prompt   string
+
+	// Current line state
+	buffer []rune
+	cursor int // Cursor position in buffer
+}
+
+// New creates a new line editor with the given history size
+func New(historySize int) *Editor {
+	return &Editor{
+		terminal: NewTerminal(),
+		history:  NewHistory(historySize),
+		buffer:   make([]rune, 0, 128),
+	}
+}
+
+// SetPrompt sets the prompt string
+func (e *Editor) SetPrompt(prompt string) {
+	e.prompt = prompt
+}
+
+// ReadLine reads a line of input with full editing support
+// Returns the line and any error encountered
+func (e *Editor) ReadLine(prompt string) (string, error) {
+	e.prompt = prompt
+	e.buffer = e.buffer[:0]
+	e.cursor = 0
+
+	// Enable raw mode
+	if err := e.terminal.EnableRawMode(); err != nil {
+		// Fallback to simple input if raw mode fails
+		return e.fallbackReadLine()
+	}
+	defer e.terminal.DisableRawMode()
+
+	// Display prompt
+	e.terminal.WriteString(prompt)
+
+	buf := make([]byte, 32)
+	for {
+		n, err := e.terminal.Read(buf)
+		if err != nil {
+			return "", err
+		}
+
+		event, _ := ParseKey(buf, n)
+
+		switch event.Key {
+		case KeyEnter:
+			e.terminal.WriteString("\r\n")
+			line := string(e.buffer)
+			e.history.Add(line)
+			return line, nil
+
+		case KeyCtrlC:
+			e.terminal.WriteString("^C\r\n")
+			return "", ErrInterrupted
+
+		case KeyCtrlD:
+			if len(e.buffer) == 0 {
+				e.terminal.WriteString("\r\n")
+				return "", ErrEOF
+			}
+			// Delete character at cursor if buffer not empty
+			e.deleteChar()
+
+		case KeyCtrlL:
+			// Clear screen
+			e.terminal.WriteString("\033[H\033[2J")
+			e.terminal.WriteString(prompt)
+			e.redrawLine()
+
+		case KeyBackspace:
+			e.backspace()
+
+		case KeyDelete:
+			e.deleteChar()
+
+		case KeyLeft:
+			e.moveCursorLeft()
+
+		case KeyRight:
+			e.moveCursorRight()
+
+		case KeyUp:
+			e.historyPrevious()
+
+		case KeyDown:
+			e.historyNext()
+
+		case KeyHome:
+			e.moveCursorHome()
+
+		case KeyEnd:
+			e.moveCursorEnd()
+
+		case KeyTab:
+			// Tab completion placeholder - insert spaces for now
+			e.insertChar(' ')
+			e.insertChar(' ')
+
+		case KeyChar:
+			e.insertChar(event.Char)
+		}
+	}
+}
+
+// insertChar inserts a character at the cursor position
+func (e *Editor) insertChar(ch rune) {
+	// Insert character at cursor position
+	e.buffer = append(e.buffer, 0)
+	copy(e.buffer[e.cursor+1:], e.buffer[e.cursor:])
+	e.buffer[e.cursor] = ch
+	e.cursor++
+
+	// Redraw from cursor to end of line
+	e.terminal.WriteString(string(e.buffer[e.cursor-1:]))
+	// Move cursor back to correct position
+	if e.cursor < len(e.buffer) {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dD", len(e.buffer)-e.cursor))
+	}
+}
+
+// backspace deletes the character before the cursor
+func (e *Editor) backspace() {
+	if e.cursor == 0 {
+		return
+	}
+
+	// Remove character before cursor
+	copy(e.buffer[e.cursor-1:], e.buffer[e.cursor:])
+	e.buffer = e.buffer[:len(e.buffer)-1]
+	e.cursor--
+
+	// Move cursor back, redraw rest of line, clear trailing char
+	e.terminal.WriteString("\033[D")
+	e.terminal.WriteString(string(e.buffer[e.cursor:]))
+	e.terminal.WriteString(" \033[D")
+	// Move cursor back to correct position
+	if e.cursor < len(e.buffer) {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dD", len(e.buffer)-e.cursor))
+	}
+}
+
+// deleteChar deletes the character at the cursor position
+func (e *Editor) deleteChar() {
+	if e.cursor >= len(e.buffer) {
+		return
+	}
+
+	// Remove character at cursor
+	copy(e.buffer[e.cursor:], e.buffer[e.cursor+1:])
+	e.buffer = e.buffer[:len(e.buffer)-1]
+
+	// Redraw rest of line, clear trailing char
+	e.terminal.WriteString(string(e.buffer[e.cursor:]))
+	e.terminal.WriteString(" \033[D")
+	// Move cursor back to correct position
+	if e.cursor < len(e.buffer) {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dD", len(e.buffer)-e.cursor))
+	}
+}
+
+// moveCursorLeft moves the cursor one position to the left
+func (e *Editor) moveCursorLeft() {
+	if e.cursor > 0 {
+		e.cursor--
+		e.terminal.WriteString("\033[D")
+	}
+}
+
+// moveCursorRight moves the cursor one position to the right
+func (e *Editor) moveCursorRight() {
+	if e.cursor < len(e.buffer) {
+		e.cursor++
+		e.terminal.WriteString("\033[C")
+	}
+}
+
+// moveCursorHome moves the cursor to the beginning of the line
+func (e *Editor) moveCursorHome() {
+	if e.cursor > 0 {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dD", e.cursor))
+		e.cursor = 0
+	}
+}
+
+// moveCursorEnd moves the cursor to the end of the line
+func (e *Editor) moveCursorEnd() {
+	if e.cursor < len(e.buffer) {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dC", len(e.buffer)-e.cursor))
+		e.cursor = len(e.buffer)
+	}
+}
+
+// historyPrevious navigates to the previous history entry
+func (e *Editor) historyPrevious() {
+	entry, ok := e.history.Previous(string(e.buffer))
+	if ok {
+		e.replaceLine(entry)
+	}
+}
+
+// historyNext navigates to the next history entry
+func (e *Editor) historyNext() {
+	entry, ok := e.history.Next()
+	if ok {
+		e.replaceLine(entry)
+	}
+}
+
+// replaceLine replaces the current buffer with a new string
+func (e *Editor) replaceLine(s string) {
+	// Move to start of input
+	if e.cursor > 0 {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dD", e.cursor))
+	}
+
+	// Clear to end of line
+	e.terminal.WriteString("\033[K")
+
+	// Set new buffer and cursor
+	e.buffer = []rune(s)
+	e.cursor = len(e.buffer)
+
+	// Write new content
+	e.terminal.WriteString(s)
+}
+
+// redrawLine redraws the current line
+func (e *Editor) redrawLine() {
+	e.terminal.WriteString(string(e.buffer))
+	// Move cursor to correct position
+	if e.cursor < len(e.buffer) {
+		e.terminal.WriteString(fmt.Sprintf("\033[%dD", len(e.buffer)-e.cursor))
+	}
+}
+
+// fallbackReadLine provides simple line reading when raw mode is unavailable
+func (e *Editor) fallbackReadLine() (string, error) {
+	fmt.Print(e.prompt)
+	var line strings.Builder
+	buf := make([]byte, 1)
+	for {
+		n, err := os.Stdin.Read(buf)
+		if err != nil {
+			return line.String(), err
+		}
+		if n == 0 {
+			continue
+		}
+		if buf[0] == '\n' || buf[0] == '\r' {
+			return line.String(), nil
+		}
+		line.WriteByte(buf[0])
+	}
+}
+
+// History returns the editor's history for external access
+func (e *Editor) History() *History {
+	return e.history
+}
+
+// Close cleans up the editor resources
+func (e *Editor) Close() error {
+	return e.terminal.DisableRawMode()
+}
+
+// Sentinel errors
+type editorError string
+
+func (e editorError) Error() string { return string(e) }
+
+const (
+	ErrInterrupted editorError = "interrupted"
+	ErrEOF         editorError = "EOF"
+)

--- a/pkg/lineeditor/lineeditor_test.go
+++ b/pkg/lineeditor/lineeditor_test.go
@@ -1,0 +1,513 @@
+package lineeditor
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// Key Parsing Tests
+// ============================================================================
+
+func TestParseSingleByteKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    byte
+		wantKey  Key
+		wantChar rune
+	}{
+		{"enter CR", 0x0d, KeyEnter, 0},
+		{"enter LF", 0x0a, KeyEnter, 0},
+		{"backspace DEL", 0x7f, KeyBackspace, 0},
+		{"backspace BS", 0x08, KeyBackspace, 0},
+		{"tab", 0x09, KeyTab, 0},
+		{"ctrl-c", 0x03, KeyCtrlC, 0},
+		{"ctrl-d", 0x04, KeyCtrlD, 0},
+		{"ctrl-l", 0x0c, KeyCtrlL, 0},
+		{"letter a", 'a', KeyChar, 'a'},
+		{"letter Z", 'Z', KeyChar, 'Z'},
+		{"digit 5", '5', KeyChar, '5'},
+		{"space", ' ', KeyChar, ' '},
+		{"symbol @", '@', KeyChar, '@'},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, consumed := ParseKey([]byte{tt.input}, 1)
+			if event.Key != tt.wantKey {
+				t.Errorf("ParseKey(%x) key = %v, want %v", tt.input, event.Key, tt.wantKey)
+			}
+			if tt.wantChar != 0 && event.Char != tt.wantChar {
+				t.Errorf("ParseKey(%x) char = %v, want %v", tt.input, event.Char, tt.wantChar)
+			}
+			if consumed != 1 {
+				t.Errorf("ParseKey(%x) consumed = %d, want 1", tt.input, consumed)
+			}
+		})
+	}
+}
+
+func TestParseEscapeSequences(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []byte
+		wantKey      Key
+		wantConsumed int
+	}{
+		{"up arrow", []byte{0x1b, '[', 'A'}, KeyUp, 3},
+		{"down arrow", []byte{0x1b, '[', 'B'}, KeyDown, 3},
+		{"right arrow", []byte{0x1b, '[', 'C'}, KeyRight, 3},
+		{"left arrow", []byte{0x1b, '[', 'D'}, KeyLeft, 3},
+		{"home CSI H", []byte{0x1b, '[', 'H'}, KeyHome, 3},
+		{"end CSI F", []byte{0x1b, '[', 'F'}, KeyEnd, 3},
+		{"delete", []byte{0x1b, '[', '3', '~'}, KeyDelete, 4},
+		{"home tilde", []byte{0x1b, '[', '1', '~'}, KeyHome, 4},
+		{"end tilde", []byte{0x1b, '[', '4', '~'}, KeyEnd, 4},
+		// SS3 sequences
+		{"up SS3", []byte{0x1b, 'O', 'A'}, KeyUp, 3},
+		{"down SS3", []byte{0x1b, 'O', 'B'}, KeyDown, 3},
+		{"right SS3", []byte{0x1b, 'O', 'C'}, KeyRight, 3},
+		{"left SS3", []byte{0x1b, 'O', 'D'}, KeyLeft, 3},
+		{"home SS3", []byte{0x1b, 'O', 'H'}, KeyHome, 3},
+		{"end SS3", []byte{0x1b, 'O', 'F'}, KeyEnd, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, consumed := ParseKey(tt.input, len(tt.input))
+			if event.Key != tt.wantKey {
+				t.Errorf("ParseKey(%v) key = %v, want %v", tt.input, event.Key, tt.wantKey)
+			}
+			if consumed != tt.wantConsumed {
+				t.Errorf("ParseKey(%v) consumed = %d, want %d", tt.input, consumed, tt.wantConsumed)
+			}
+		})
+	}
+}
+
+func TestParseUTF8(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []byte
+		wantChar     rune
+		wantConsumed int
+	}{
+		{"2-byte é", []byte{0xc3, 0xa9}, 'é', 2},
+		{"2-byte ñ", []byte{0xc3, 0xb1}, 'ñ', 2},
+		{"3-byte euro", []byte{0xe2, 0x82, 0xac}, '€', 3},
+		{"3-byte chinese", []byte{0xe4, 0xb8, 0xad}, '中', 3},
+		{"4-byte emoji", []byte{0xf0, 0x9f, 0x98, 0x80}, '😀', 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, consumed := ParseKey(tt.input, len(tt.input))
+			if event.Key != KeyChar {
+				t.Errorf("ParseKey(%v) key = %v, want KeyChar", tt.input, event.Key)
+			}
+			if event.Char != tt.wantChar {
+				t.Errorf("ParseKey(%v) char = %c (%U), want %c (%U)", tt.input, event.Char, event.Char, tt.wantChar, tt.wantChar)
+			}
+			if consumed != tt.wantConsumed {
+				t.Errorf("ParseKey(%v) consumed = %d, want %d", tt.input, consumed, tt.wantConsumed)
+			}
+		})
+	}
+}
+
+func TestParseEmptyInput(t *testing.T) {
+	event, consumed := ParseKey([]byte{}, 0)
+	if event.Key != KeyUnknown {
+		t.Errorf("ParseKey(empty) key = %v, want KeyUnknown", event.Key)
+	}
+	if consumed != 0 {
+		t.Errorf("ParseKey(empty) consumed = %d, want 0", consumed)
+	}
+}
+
+// ============================================================================
+// History Tests
+// ============================================================================
+
+func TestNewHistory(t *testing.T) {
+	h := NewHistory(50)
+	if h.Len() != 0 {
+		t.Errorf("NewHistory().Len() = %d, want 0", h.Len())
+	}
+}
+
+func TestNewHistoryDefaultSize(t *testing.T) {
+	h := NewHistory(0)
+	if h.maxSize != 100 {
+		t.Errorf("NewHistory(0).maxSize = %d, want 100", h.maxSize)
+	}
+
+	h = NewHistory(-5)
+	if h.maxSize != 100 {
+		t.Errorf("NewHistory(-5).maxSize = %d, want 100", h.maxSize)
+	}
+}
+
+func TestHistoryAdd(t *testing.T) {
+	h := NewHistory(10)
+
+	h.Add("first")
+	h.Add("second")
+	h.Add("third")
+
+	if h.Len() != 3 {
+		t.Errorf("h.Len() = %d, want 3", h.Len())
+	}
+
+	entries := h.Entries()
+	expected := []string{"first", "second", "third"}
+	for i, e := range expected {
+		if entries[i] != e {
+			t.Errorf("entries[%d] = %q, want %q", i, entries[i], e)
+		}
+	}
+}
+
+func TestHistoryAddEmpty(t *testing.T) {
+	h := NewHistory(10)
+	h.Add("")
+	if h.Len() != 0 {
+		t.Errorf("Adding empty string should not increase history, got len %d", h.Len())
+	}
+}
+
+func TestHistoryAddDuplicate(t *testing.T) {
+	h := NewHistory(10)
+	h.Add("command")
+	h.Add("command")
+	if h.Len() != 1 {
+		t.Errorf("Adding duplicate should not increase history, got len %d", h.Len())
+	}
+}
+
+func TestHistoryMaxSize(t *testing.T) {
+	h := NewHistory(3)
+	h.Add("one")
+	h.Add("two")
+	h.Add("three")
+	h.Add("four")
+
+	if h.Len() != 3 {
+		t.Errorf("h.Len() = %d, want 3", h.Len())
+	}
+
+	entries := h.Entries()
+	if entries[0] != "two" {
+		t.Errorf("entries[0] = %q, want %q", entries[0], "two")
+	}
+}
+
+func TestHistoryPrevious(t *testing.T) {
+	h := NewHistory(10)
+	h.Add("first")
+	h.Add("second")
+	h.Add("third")
+
+	// Navigate backwards
+	entry, ok := h.Previous("current")
+	if !ok || entry != "third" {
+		t.Errorf("Previous() = %q, %v; want %q, true", entry, ok, "third")
+	}
+
+	entry, ok = h.Previous("")
+	if !ok || entry != "second" {
+		t.Errorf("Previous() = %q, %v; want %q, true", entry, ok, "second")
+	}
+
+	entry, ok = h.Previous("")
+	if !ok || entry != "first" {
+		t.Errorf("Previous() = %q, %v; want %q, true", entry, ok, "first")
+	}
+
+	// At beginning, should stay at first
+	entry, ok = h.Previous("")
+	if !ok || entry != "first" {
+		t.Errorf("Previous() at start = %q, %v; want %q, true", entry, ok, "first")
+	}
+}
+
+func TestHistoryNext(t *testing.T) {
+	h := NewHistory(10)
+	h.Add("first")
+	h.Add("second")
+
+	// Go back first
+	h.Previous("typing")
+	h.Previous("")
+
+	// Navigate forward
+	entry, ok := h.Next()
+	if !ok || entry != "second" {
+		t.Errorf("Next() = %q, %v; want %q, true", entry, ok, "second")
+	}
+
+	// Should return to original input
+	entry, ok = h.Next()
+	if !ok || entry != "typing" {
+		t.Errorf("Next() = %q, %v; want %q, true", entry, ok, "typing")
+	}
+
+	// No more next
+	entry, ok = h.Next()
+	if ok {
+		t.Errorf("Next() at end should return false, got %q, %v", entry, ok)
+	}
+}
+
+func TestHistoryPreviousEmpty(t *testing.T) {
+	h := NewHistory(10)
+	entry, ok := h.Previous("current")
+	if ok {
+		t.Errorf("Previous() on empty history should return false, got %q, %v", entry, ok)
+	}
+}
+
+func TestHistoryReset(t *testing.T) {
+	h := NewHistory(10)
+	h.Add("first")
+	h.Add("second")
+
+	h.Previous("current")
+	h.Reset()
+
+	// After reset, should start from end again
+	entry, ok := h.Previous("new")
+	if !ok || entry != "second" {
+		t.Errorf("After Reset(), Previous() = %q, %v; want %q, true", entry, ok, "second")
+	}
+}
+
+func TestHistoryClear(t *testing.T) {
+	h := NewHistory(10)
+	h.Add("first")
+	h.Add("second")
+	h.Clear()
+
+	if h.Len() != 0 {
+		t.Errorf("After Clear(), Len() = %d, want 0", h.Len())
+	}
+}
+
+// ============================================================================
+// Editor Tests
+// ============================================================================
+
+func TestNewEditor(t *testing.T) {
+	e := New(100)
+	if e == nil {
+		t.Fatal("New() returned nil")
+	}
+	if e.history == nil {
+		t.Error("New() editor has nil history")
+	}
+	if e.terminal == nil {
+		t.Error("New() editor has nil terminal")
+	}
+}
+
+func TestEditorHistory(t *testing.T) {
+	e := New(50)
+	h := e.History()
+	if h == nil {
+		t.Fatal("History() returned nil")
+	}
+	if h.maxSize != 50 {
+		t.Errorf("History maxSize = %d, want 50", h.maxSize)
+	}
+}
+
+func TestEditorSetPrompt(t *testing.T) {
+	e := New(10)
+	e.SetPrompt(">> ")
+	if e.prompt != ">> " {
+		t.Errorf("SetPrompt() prompt = %q, want %q", e.prompt, ">> ")
+	}
+}
+
+func TestEditorErrors(t *testing.T) {
+	if ErrInterrupted.Error() != "interrupted" {
+		t.Errorf("ErrInterrupted.Error() = %q, want %q", ErrInterrupted.Error(), "interrupted")
+	}
+	if ErrEOF.Error() != "EOF" {
+		t.Errorf("ErrEOF.Error() = %q, want %q", ErrEOF.Error(), "EOF")
+	}
+}
+
+// ============================================================================
+// Terminal Tests
+// ============================================================================
+
+func TestNewTerminal(t *testing.T) {
+	term := NewTerminal()
+	if term == nil {
+		t.Fatal("NewTerminal() returned nil")
+	}
+	if term.isRaw {
+		t.Error("New terminal should not be in raw mode")
+	}
+}
+
+// ============================================================================
+// Integration-style buffer tests
+// ============================================================================
+
+// TestBufferOperations tests internal buffer manipulation logic
+func TestBufferOperations(t *testing.T) {
+	e := New(10)
+
+	// Test insertChar logic by manually manipulating buffer
+	e.buffer = []rune("hello")
+	e.cursor = 5
+
+	// Simulate inserting at end
+	ch := '!'
+	e.buffer = append(e.buffer, 0)
+	copy(e.buffer[e.cursor+1:], e.buffer[e.cursor:])
+	e.buffer[e.cursor] = ch
+	e.cursor++
+
+	if string(e.buffer) != "hello!" {
+		t.Errorf("Insert at end: buffer = %q, want %q", string(e.buffer), "hello!")
+	}
+	if e.cursor != 6 {
+		t.Errorf("Insert at end: cursor = %d, want 6", e.cursor)
+	}
+}
+
+func TestBufferInsertMiddle(t *testing.T) {
+	e := New(10)
+	e.buffer = []rune("helo")
+	e.cursor = 2 // After 'e'
+
+	// Insert 'l' at cursor
+	ch := 'l'
+	e.buffer = append(e.buffer, 0)
+	copy(e.buffer[e.cursor+1:], e.buffer[e.cursor:])
+	e.buffer[e.cursor] = ch
+	e.cursor++
+
+	if string(e.buffer) != "hello" {
+		t.Errorf("Insert middle: buffer = %q, want %q", string(e.buffer), "hello")
+	}
+	if e.cursor != 3 {
+		t.Errorf("Insert middle: cursor = %d, want 3", e.cursor)
+	}
+}
+
+func TestBufferBackspace(t *testing.T) {
+	e := New(10)
+	e.buffer = []rune("hello")
+	e.cursor = 5
+
+	// Simulate backspace
+	if e.cursor > 0 {
+		copy(e.buffer[e.cursor-1:], e.buffer[e.cursor:])
+		e.buffer = e.buffer[:len(e.buffer)-1]
+		e.cursor--
+	}
+
+	if string(e.buffer) != "hell" {
+		t.Errorf("Backspace: buffer = %q, want %q", string(e.buffer), "hell")
+	}
+	if e.cursor != 4 {
+		t.Errorf("Backspace: cursor = %d, want 4", e.cursor)
+	}
+}
+
+func TestBufferBackspaceMiddle(t *testing.T) {
+	e := New(10)
+	e.buffer = []rune("hello")
+	e.cursor = 3 // After 'l'
+
+	// Simulate backspace
+	if e.cursor > 0 {
+		copy(e.buffer[e.cursor-1:], e.buffer[e.cursor:])
+		e.buffer = e.buffer[:len(e.buffer)-1]
+		e.cursor--
+	}
+
+	if string(e.buffer) != "helo" {
+		t.Errorf("Backspace middle: buffer = %q, want %q", string(e.buffer), "helo")
+	}
+	if e.cursor != 2 {
+		t.Errorf("Backspace middle: cursor = %d, want 2", e.cursor)
+	}
+}
+
+func TestBufferDelete(t *testing.T) {
+	e := New(10)
+	e.buffer = []rune("hello")
+	e.cursor = 0
+
+	// Simulate delete
+	if e.cursor < len(e.buffer) {
+		copy(e.buffer[e.cursor:], e.buffer[e.cursor+1:])
+		e.buffer = e.buffer[:len(e.buffer)-1]
+	}
+
+	if string(e.buffer) != "ello" {
+		t.Errorf("Delete: buffer = %q, want %q", string(e.buffer), "ello")
+	}
+	if e.cursor != 0 {
+		t.Errorf("Delete: cursor = %d, want 0", e.cursor)
+	}
+}
+
+func TestBufferCursorMovement(t *testing.T) {
+	e := New(10)
+	e.buffer = []rune("hello")
+	e.cursor = 2
+
+	// Move left
+	if e.cursor > 0 {
+		e.cursor--
+	}
+	if e.cursor != 1 {
+		t.Errorf("Move left: cursor = %d, want 1", e.cursor)
+	}
+
+	// Move right
+	if e.cursor < len(e.buffer) {
+		e.cursor++
+	}
+	if e.cursor != 2 {
+		t.Errorf("Move right: cursor = %d, want 2", e.cursor)
+	}
+
+	// Move home
+	e.cursor = 0
+	if e.cursor != 0 {
+		t.Errorf("Move home: cursor = %d, want 0", e.cursor)
+	}
+
+	// Move end
+	e.cursor = len(e.buffer)
+	if e.cursor != 5 {
+		t.Errorf("Move end: cursor = %d, want 5", e.cursor)
+	}
+}
+
+func TestBufferReplaceLine(t *testing.T) {
+	e := New(10)
+	e.buffer = []rune("hello")
+	e.cursor = 3
+
+	// Simulate replaceLine
+	newLine := "world"
+	e.buffer = []rune(newLine)
+	e.cursor = len(e.buffer)
+
+	if string(e.buffer) != "world" {
+		t.Errorf("ReplaceLine: buffer = %q, want %q", string(e.buffer), "world")
+	}
+	if e.cursor != 5 {
+		t.Errorf("ReplaceLine: cursor = %d, want 5", e.cursor)
+	}
+}

--- a/pkg/lineeditor/terminal.go
+++ b/pkg/lineeditor/terminal.go
@@ -1,3 +1,5 @@
+//go:build darwin || linux
+
 package lineeditor
 
 // Copyright (c) 2025-Present Marshall A Burns
@@ -104,7 +106,7 @@ func (t *Terminal) getTermios(termios *syscall.Termios) error {
 	_, _, errno := syscall.Syscall6(
 		syscall.SYS_IOCTL,
 		uintptr(t.fd),
-		uintptr(syscall.TIOCGETA),
+		ioctlReadTermios,
 		uintptr(unsafe.Pointer(termios)),
 		0, 0, 0,
 	)
@@ -119,7 +121,7 @@ func (t *Terminal) setTermios(termios *syscall.Termios) error {
 	_, _, errno := syscall.Syscall6(
 		syscall.SYS_IOCTL,
 		uintptr(t.fd),
-		uintptr(syscall.TIOCSETA),
+		ioctlWriteTermios,
 		uintptr(unsafe.Pointer(termios)),
 		0, 0, 0,
 	)
@@ -141,7 +143,7 @@ func (t *Terminal) GetSize() (width, height int, err error) {
 	_, _, errno := syscall.Syscall6(
 		syscall.SYS_IOCTL,
 		uintptr(t.stdoutFd),
-		uintptr(syscall.TIOCGWINSZ),
+		syscall.TIOCGWINSZ,
 		uintptr(unsafe.Pointer(&ws)),
 		0, 0, 0,
 	)

--- a/pkg/lineeditor/terminal.go
+++ b/pkg/lineeditor/terminal.go
@@ -1,0 +1,153 @@
+package lineeditor
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Terminal handles raw mode terminal operations
+type Terminal struct {
+	fd       int
+	origios  syscall.Termios
+	isRaw    bool
+	stdinFd  int
+	stdoutFd int
+}
+
+// NewTerminal creates a new Terminal for the given file descriptors
+func NewTerminal() *Terminal {
+	return &Terminal{
+		fd:       int(os.Stdin.Fd()),
+		stdinFd:  int(os.Stdin.Fd()),
+		stdoutFd: int(os.Stdout.Fd()),
+	}
+}
+
+// EnableRawMode puts the terminal into raw mode for character-by-character input
+func (t *Terminal) EnableRawMode() error {
+	if t.isRaw {
+		return nil
+	}
+
+	// Get current terminal attributes
+	if err := t.getTermios(&t.origios); err != nil {
+		return err
+	}
+
+	raw := t.origios
+
+	// Input modes: no break, no CR to NL, no parity check, no strip char,
+	// no start/stop output control
+	raw.Iflag &^= syscall.BRKINT | syscall.ICRNL | syscall.INPCK | syscall.ISTRIP | syscall.IXON
+
+	// Output modes: disable post processing
+	raw.Oflag &^= syscall.OPOST
+
+	// Control modes: set 8 bit chars
+	raw.Cflag |= syscall.CS8
+
+	// Local modes: echo off, canonical off, no extended functions, no signal chars
+	raw.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.IEXTEN | syscall.ISIG
+
+	// Control chars: set read to return after 1 byte, no timeout
+	raw.Cc[syscall.VMIN] = 1
+	raw.Cc[syscall.VTIME] = 0
+
+	if err := t.setTermios(&raw); err != nil {
+		return err
+	}
+
+	t.isRaw = true
+	return nil
+}
+
+// DisableRawMode restores the terminal to its original mode
+func (t *Terminal) DisableRawMode() error {
+	if !t.isRaw {
+		return nil
+	}
+
+	if err := t.setTermios(&t.origios); err != nil {
+		return err
+	}
+
+	t.isRaw = false
+	return nil
+}
+
+// IsRaw returns whether the terminal is in raw mode
+func (t *Terminal) IsRaw() bool {
+	return t.isRaw
+}
+
+// Read reads up to len(buf) bytes from stdin
+func (t *Terminal) Read(buf []byte) (int, error) {
+	return syscall.Read(t.stdinFd, buf)
+}
+
+// Write writes bytes to stdout
+func (t *Terminal) Write(buf []byte) (int, error) {
+	return syscall.Write(t.stdoutFd, buf)
+}
+
+// WriteString writes a string to stdout
+func (t *Terminal) WriteString(s string) (int, error) {
+	return t.Write([]byte(s))
+}
+
+// getTermios gets the terminal attributes
+func (t *Terminal) getTermios(termios *syscall.Termios) error {
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		uintptr(t.fd),
+		uintptr(syscall.TIOCGETA),
+		uintptr(unsafe.Pointer(termios)),
+		0, 0, 0,
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// setTermios sets the terminal attributes
+func (t *Terminal) setTermios(termios *syscall.Termios) error {
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		uintptr(t.fd),
+		uintptr(syscall.TIOCSETA),
+		uintptr(unsafe.Pointer(termios)),
+		0, 0, 0,
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// GetSize returns the terminal width and height
+func (t *Terminal) GetSize() (width, height int, err error) {
+	var ws struct {
+		Row    uint16
+		Col    uint16
+		Xpixel uint16
+		Ypixel uint16
+	}
+
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		uintptr(t.stdoutFd),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+		0, 0, 0,
+	)
+	if errno != 0 {
+		return 80, 24, errno // Return default size on error
+	}
+
+	return int(ws.Col), int(ws.Row), nil
+}

--- a/pkg/lineeditor/terminal_darwin.go
+++ b/pkg/lineeditor/terminal_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package lineeditor
+
+import "syscall"
+
+// Darwin/macOS ioctl constants for terminal control
+const (
+	ioctlReadTermios  = syscall.TIOCGETA
+	ioctlWriteTermios = syscall.TIOCSETA
+)

--- a/pkg/lineeditor/terminal_linux.go
+++ b/pkg/lineeditor/terminal_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package lineeditor
+
+import "syscall"
+
+// Linux ioctl constants for terminal control
+const (
+	ioctlReadTermios  = syscall.TCGETS
+	ioctlWriteTermios = syscall.TCSETS
+)

--- a/pkg/lineeditor/terminal_windows.go
+++ b/pkg/lineeditor/terminal_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package lineeditor
+
+import (
+	"os"
+)
+
+// Terminal handles terminal operations (limited support on Windows)
+type Terminal struct {
+	isRaw bool
+}
+
+// NewTerminal creates a new Terminal
+func NewTerminal() *Terminal {
+	return &Terminal{}
+}
+
+// EnableRawMode attempts to put the terminal into raw mode
+// On Windows, this currently returns an error to trigger fallback behavior
+func (t *Terminal) EnableRawMode() error {
+	// Windows console raw mode requires different APIs
+	// Return error to trigger fallback to simple line reading
+	return errNotSupported
+}
+
+// DisableRawMode restores the terminal to its original mode
+func (t *Terminal) DisableRawMode() error {
+	t.isRaw = false
+	return nil
+}
+
+// IsRaw returns whether the terminal is in raw mode
+func (t *Terminal) IsRaw() bool {
+	return t.isRaw
+}
+
+// Read reads up to len(buf) bytes from stdin
+func (t *Terminal) Read(buf []byte) (int, error) {
+	return os.Stdin.Read(buf)
+}
+
+// Write writes bytes to stdout
+func (t *Terminal) Write(buf []byte) (int, error) {
+	return os.Stdout.Write(buf)
+}
+
+// WriteString writes a string to stdout
+func (t *Terminal) WriteString(s string) (int, error) {
+	return t.Write([]byte(s))
+}
+
+// GetSize returns the terminal width and height
+func (t *Terminal) GetSize() (width, height int, err error) {
+	return 80, 24, nil // Default size on Windows
+}
+
+// errNotSupported indicates raw mode is not supported
+type notSupportedError struct{}
+
+func (notSupportedError) Error() string { return "raw mode not supported on Windows" }
+
+var errNotSupported = notSupportedError{}


### PR DESCRIPTION
## Summary
- Add new `pkg/lineeditor` package for interactive line editing
- Support left/right arrow key navigation within lines
- Support up/down arrow keys for command history browsing
- Support Home/End keys, backspace/delete at any position
- Ctrl+C cancels current line, Ctrl+D exits, Ctrl+L clears screen

## Test plan
- [x] Unit tests for key parsing (ANSI escape sequences, UTF-8)
- [x] Unit tests for history navigation
- [x] Unit tests for buffer operations
- [x] Manual testing of arrow keys, history, editing in REPL

Closes #95