### PR TITLE
fix: reject nil assignment to non-nullable types

### DIFF
--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1575,6 +1575,31 @@ do main() {
 	assertHasError(t, tc, errors.E3025) // enum members must all have the same type
 }
 
+func TestNilAssignmentToPrimitiveError(t *testing.T) {
+	input := `
+do main() {
+	temp x int = nil
+}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3001) // cannot assign nil to int
+}
+
+func TestNilAssignmentToStructAllowed(t *testing.T) {
+	input := `
+const Point struct {
+	x int
+	y int
+}
+
+do main() {
+	temp p Point = nil
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
 // ============================================================================
 // Global Variable Declaration Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `isNullableType()` helper to typechecker
- Only user-defined struct types can accept nil
- Primitives (int, float, string, bool, char, byte), arrays, and maps now reject nil at compile time

## Test plan
- [x] Added `TestNilAssignmentToPrimitiveError` - verifies nil rejected for int
- [x] Added `TestNilAssignmentToStructAllowed` - verifies structs can still be nil
- [x] All typechecker tests pass

Fixes #407