### PR TITLE
fix: allow byte to int conversion with int()

### DIFF
--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -250,6 +250,8 @@ var StdBuiltins = map[string]*object.Builtin{
 				return &object.Integer{Value: val}
 			case *object.Char:
 				return &object.Integer{Value: int64(arg.Value)}
+			case *object.Byte:
+				return &object.Integer{Value: int64(arg.Value)}
 			case *object.EnumValue:
 				// Extract the underlying value from the enum
 				switch v := arg.Value.(type) {


### PR DESCRIPTION
## Summary
- Adds missing `*object.Byte` case in `int()` builtin function
- Makes byte/int conversions symmetric (both directions now work)

## Test plan
- [x] `int(byte(255))` returns 255
- [x] `int(byte(0))` returns 0
- [x] Round-trip `byte(int(byte(42)))` works
- [x] All stdlib tests pass

Fixes #403