### PR TITLE
fix: float division by zero returns INF per IEEE 754

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1664,9 +1664,7 @@ func evalFloatInfixExpression(operator string, left, right Object, line, col int
 	case "*":
 		return &Float{Value: leftVal * rightVal}
 	case "/":
-		if rightVal == 0 {
-			return newErrorWithLocation("E5001", line, col, "division by zero")
-		}
+		// Float division by zero returns +Inf, -Inf, or NaN per IEEE 754
 		return &Float{Value: leftVal / rightVal}
 	case "<":
 		return nativeBoolToBooleanObject(leftVal < rightVal)


### PR DESCRIPTION
## Summary
- Removes division by zero error for float operations
- Float div by zero now returns `+Inf`, `-Inf`, or `NaN` per IEEE 754
- Integer division by zero still errors (as expected)

## Test plan
- [x] `10.0 / 0.0` returns `+Inf`
- [x] `-10.0 / 0.0` returns `-Inf`
- [x] `0.0 / 0.0` returns `NaN`
- [x] `math.is_inf()` works on results
- [x] Integer `10 / 0` still errors
- [x] All interpreter tests pass

Fixes #402