### PR TITLE
fix: implement arbitrary precision integers for i128/u128 support

### DIFF
--- a/integration-tests/fail/errors/E2027_integer_parse_error.ez
+++ b/integration-tests/fail/errors/E2027_integer_parse_error.ez
@@ -1,8 +1,0 @@
-/*
- * Error Test: E2027 - integer-parse-error
- * Expected: "cannot parse integer" or "parse"
- */
-
-do main() {
-    temp x int = 99999999999999999999999999999999  // too large
-}

--- a/integration-tests/fail/errors/E5005_i128_overflow_add.ez
+++ b/integration-tests/fail/errors/E5005_i128_overflow_add.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E5005 - integer-overflow (i128 addition)
+ * Expected: "integer overflow"
+ * Tests that i128 overflows at the correct bound (2^127 - 1)
+ */
+
+do main() {
+    temp max i128 = 170141183460469231731687303715884105727  // max i128 (2^127 - 1)
+    temp result i128 = max + 1  // Overflow
+}

--- a/integration-tests/fail/errors/E5005_u128_overflow_add.ez
+++ b/integration-tests/fail/errors/E5005_u128_overflow_add.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E5005 - integer-overflow (u128 addition)
+ * Expected: "integer overflow"
+ * Tests that u128 overflows at the correct bound (2^128 - 1)
+ */
+
+do main() {
+    temp max u128 = 340282366920938463463374607431768211455  // max u128 (2^128 - 1)
+    temp result u128 = max + 1  // Overflow
+}

--- a/integration-tests/fail/errors/E5006_i128_overflow_sub.ez
+++ b/integration-tests/fail/errors/E5006_i128_overflow_sub.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E5006 - integer-overflow (i128 subtraction)
+ * Expected: "integer overflow"
+ * Tests that i128 underflows at the correct bound (-2^127)
+ */
+
+do main() {
+    temp min i128 = -170141183460469231731687303715884105728  // min i128 (-2^127)
+    temp result i128 = min - 1  // Underflow
+}

--- a/integration-tests/fail/errors/E5006_u128_overflow_sub.ez
+++ b/integration-tests/fail/errors/E5006_u128_overflow_sub.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E5006 - integer-overflow (u128 subtraction)
+ * Expected: "integer overflow"
+ * Tests that u128 underflows (goes negative)
+ */
+
+do main() {
+    temp zero u128 = 0
+    temp result u128 = zero - 1  // Underflow (unsigned can't go negative)
+}

--- a/integration-tests/pass/core/large-integers.ez
+++ b/integration-tests/pass/core/large-integers.ez
@@ -1,0 +1,132 @@
+/*
+ * large-integers.ez - Test i128/u128 and other large integer types
+ * Tests parsing and arithmetic for integers beyond int64 range
+ */
+
+import @std
+using std
+
+do main() {
+    println("=== Large Integers Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: i128 literal larger than int64 max
+    temp big i128 = 10000000000000000000
+    if big == 10000000000000000000 {
+        println("  [PASS] i128 literal > int64 max")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 literal > int64 max")
+        failed += 1
+    }
+
+    // Test 2: i128 arithmetic beyond int64
+    temp a i128 = 9223372036854775807  // max int64
+    temp b i128 = 1
+    temp sum i128 = a + b
+    if sum == 9223372036854775808 {
+        println("  [PASS] i128 addition beyond int64 max")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 addition beyond int64 max: expected 9223372036854775808, got ${sum}")
+        failed += 1
+    }
+
+    // Test 3: u128 large value
+    temp u_big u128 = 18446744073709551615  // max uint64
+    if u_big == 18446744073709551615 {
+        println("  [PASS] u128 literal = uint64 max")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] u128 literal = uint64 max")
+        failed += 1
+    }
+
+    // Test 4: u128 arithmetic beyond uint64
+    temp u_max u128 = 18446744073709551615
+    temp u_one u128 = 1
+    temp u_sum u128 = u_max + u_one
+    if u_sum == 18446744073709551616 {
+        println("  [PASS] u128 addition beyond uint64 max")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] u128 addition beyond uint64 max: expected 18446744073709551616, got ${u_sum}")
+        failed += 1
+    }
+
+    // Test 5: i128 multiplication
+    temp x i128 = 10000000000
+    temp y i128 = 10000000000
+    temp product i128 = x * y
+    if product == 100000000000000000000 {
+        println("  [PASS] i128 multiplication")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 multiplication: expected 100000000000000000000, got ${product}")
+        failed += 1
+    }
+
+    // Test 6: i128 negative values
+    temp neg i128 = -9223372036854775808  // min int64
+    temp neg_minus i128 = neg - 1
+    if neg_minus == -9223372036854775809 {
+        println("  [PASS] i128 subtraction below int64 min")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 subtraction below int64 min: expected -9223372036854775809, got ${neg_minus}")
+        failed += 1
+    }
+
+    // Test 7: i64 at boundary (should work)
+    temp i64_max i64 = 9223372036854775807
+    if i64_max == 9223372036854775807 {
+        println("  [PASS] i64 max value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i64 max value")
+        failed += 1
+    }
+
+    // Test 8: u64 at boundary (should work)
+    temp u64_max u64 = 18446744073709551615
+    if u64_max == 18446744073709551615 {
+        println("  [PASS] u64 max value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] u64 max value")
+        failed += 1
+    }
+
+    // Test 9: i128 division
+    temp dividend i128 = 100000000000000000000
+    temp divisor i128 = 10000000000
+    temp quotient i128 = dividend / divisor
+    if quotient == 10000000000 {
+        println("  [PASS] i128 division")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 division: expected 10000000000, got ${quotient}")
+        failed += 1
+    }
+
+    // Test 10: i128 modulo
+    temp mod_result i128 = 100000000000000000001 % 10000000000
+    if mod_result == 1 {
+        println("  [PASS] i128 modulo")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 modulo: expected 1, got ${mod_result}")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -2,7 +2,11 @@ package ast
 
 // Copyright (c) 2025-Present Marshall A Burns
 // Licensed under the MIT License. See LICENSE for details.
-import . "github.com/marshallburns/ez/pkg/tokenizer"
+import (
+	"math/big"
+
+	. "github.com/marshallburns/ez/pkg/tokenizer"
+)
 
 // Node is the base interface for all AST nodes
 type Node interface {
@@ -71,7 +75,7 @@ func (l *Label) TokenLiteral() string { return l.Token.Literal }
 // Represents an integer value
 type IntegerValue struct {
 	Token Token
-	Value int64
+	Value *big.Int
 }
 
 // Takes in a pointer to an IntegerValue(v)

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/marshallburns/ez/pkg/tokenizer"
@@ -161,7 +162,7 @@ func TestLabelTokenLiteral(t *testing.T) {
 }
 
 func TestIntegerValueTokenLiteral(t *testing.T) {
-	v := &IntegerValue{Token: tok(tokenizer.INT, "42"), Value: 42}
+	v := &IntegerValue{Token: tok(tokenizer.INT, "42"), Value: big.NewInt(42)}
 	if v.TokenLiteral() != "42" {
 		t.Errorf("TokenLiteral() = %q, want %q", v.TokenLiteral(), "42")
 	}
@@ -406,7 +407,7 @@ func TestVariableDeclarationStructure(t *testing.T) {
 		Token:      tok(tokenizer.TEMP, "temp"),
 		Name:       &Label{Value: "x"},
 		TypeName:   "int",
-		Value:      &IntegerValue{Value: 42},
+		Value:      &IntegerValue{Value: big.NewInt(42)},
 		Mutable:    true,
 		Visibility: VisibilityPublic,
 	}
@@ -535,9 +536,9 @@ func TestImportStatementStructure(t *testing.T) {
 func TestInfixExpressionStructure(t *testing.T) {
 	i := &InfixExpression{
 		Token:    tok(tokenizer.PLUS, "+"),
-		Left:     &IntegerValue{Value: 1},
+		Left:     &IntegerValue{Value: big.NewInt(1)},
 		Operator: "+",
-		Right:    &IntegerValue{Value: 2},
+		Right:    &IntegerValue{Value: big.NewInt(2)},
 	}
 
 	if i.Operator != "+" {
@@ -584,9 +585,9 @@ func TestMapPairStructure(t *testing.T) {
 func TestRangeExpressionStructure(t *testing.T) {
 	r := &RangeExpression{
 		Token: tok(tokenizer.RANGE, "range"),
-		Start: &IntegerValue{Value: 0},
-		End:   &IntegerValue{Value: 10},
-		Step:  &IntegerValue{Value: 2},
+		Start: &IntegerValue{Value: big.NewInt(0)},
+		End:   &IntegerValue{Value: big.NewInt(10)},
+		Step:  &IntegerValue{Value: big.NewInt(2)},
 	}
 
 	if r.Start == nil {

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -5,6 +5,7 @@ package object
 
 import (
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
@@ -42,14 +43,14 @@ type Object interface {
 	Inspect() string
 }
 
-// Integer wraps int64
+// Integer wraps big.Int for arbitrary precision integer support
 type Integer struct {
-	Value        int64
+	Value        *big.Int
 	DeclaredType string
 }
 
 func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
-func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
+func (i *Integer) Inspect() string  { return i.Value.String() }
 
 func (i *Integer) GetDeclaredType() string {
 	if i.DeclaredType == "" {

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"math/big"
 	"strings"
 	"testing"
 )
@@ -48,7 +49,7 @@ func TestObjectTypeConstants(t *testing.T) {
 // ============================================================================
 
 func TestIntegerObject(t *testing.T) {
-	i := &Integer{Value: 42}
+	i := &Integer{Value: big.NewInt(42)}
 	if i.Type() != INTEGER_OBJ {
 		t.Errorf("Type() = %s, want %s", i.Type(), INTEGER_OBJ)
 	}
@@ -59,14 +60,14 @@ func TestIntegerObject(t *testing.T) {
 
 func TestIntegerDeclaredType(t *testing.T) {
 	t.Run("default type", func(t *testing.T) {
-		i := &Integer{Value: 42}
+		i := &Integer{Value: big.NewInt(42)}
 		if i.GetDeclaredType() != "int" {
 			t.Errorf("GetDeclaredType() = %q, want %q", i.GetDeclaredType(), "int")
 		}
 	})
 
 	t.Run("explicit type", func(t *testing.T) {
-		i := &Integer{Value: 42, DeclaredType: "i32"}
+		i := &Integer{Value: big.NewInt(42), DeclaredType: "i32"}
 		if i.GetDeclaredType() != "i32" {
 			t.Errorf("GetDeclaredType() = %q, want %q", i.GetDeclaredType(), "i32")
 		}
@@ -148,8 +149,8 @@ func TestNilObject(t *testing.T) {
 func TestReturnValueObject(t *testing.T) {
 	rv := &ReturnValue{
 		Values: []Object{
-			&Integer{Value: 1},
-			&Integer{Value: 2},
+			&Integer{Value: big.NewInt(1)},
+			&Integer{Value: big.NewInt(2)},
 		},
 	}
 	if rv.Type() != RETURN_VALUE_OBJ {
@@ -202,9 +203,9 @@ func TestBuiltinObject(t *testing.T) {
 func TestArrayObject(t *testing.T) {
 	a := &Array{
 		Elements: []Object{
-			&Integer{Value: 1},
-			&Integer{Value: 2},
-			&Integer{Value: 3},
+			&Integer{Value: big.NewInt(1)},
+			&Integer{Value: big.NewInt(2)},
+			&Integer{Value: big.NewInt(3)},
 		},
 		Mutable: true,
 	}
@@ -240,8 +241,8 @@ func TestEnumObject(t *testing.T) {
 	e := &Enum{
 		Name: "Status",
 		Values: map[string]Object{
-			"TODO": &Integer{Value: 0},
-			"DONE": &Integer{Value: 1},
+			"TODO": &Integer{Value: big.NewInt(0)},
+			"DONE": &Integer{Value: big.NewInt(1)},
 		},
 	}
 	if e.Type() != ENUM_OBJ {
@@ -257,7 +258,7 @@ func TestEnumValueObject(t *testing.T) {
 	ev := &EnumValue{
 		EnumType: "Status",
 		Name:     "TODO",
-		Value:    &Integer{Value: 0},
+		Value:    &Integer{Value: big.NewInt(0)},
 	}
 	if ev.Type() != ENUM_VALUE_OBJ {
 		t.Errorf("Type() = %s, want %s", ev.Type(), ENUM_VALUE_OBJ)
@@ -301,7 +302,7 @@ func TestStructObject(t *testing.T) {
 		TypeName: "Person",
 		Fields: map[string]Object{
 			"name": &String{Value: "Alice"},
-			"age":  &Integer{Value: 30},
+			"age":  &Integer{Value: big.NewInt(30)},
 		},
 	}
 	if s.Type() != STRUCT_OBJ {
@@ -350,23 +351,23 @@ func TestMapSetAndGet(t *testing.T) {
 	m := NewMap()
 
 	// Set values
-	m.Set(&String{Value: "key1"}, &Integer{Value: 1})
-	m.Set(&String{Value: "key2"}, &Integer{Value: 2})
+	m.Set(&String{Value: "key1"}, &Integer{Value: big.NewInt(1)})
+	m.Set(&String{Value: "key2"}, &Integer{Value: big.NewInt(2)})
 
 	// Get values
 	val, ok := m.Get(&String{Value: "key1"})
 	if !ok {
 		t.Error("Get(key1) should return true")
 	}
-	if val.(*Integer).Value != 1 {
-		t.Errorf("Get(key1) = %d, want 1", val.(*Integer).Value)
+	if val.(*Integer).Value.Cmp(big.NewInt(1)) != 0 {
+		t.Errorf("Get(key1) = %s, want 1", val.(*Integer).Value.String())
 	}
 
 	// Update existing key
-	m.Set(&String{Value: "key1"}, &Integer{Value: 100})
+	m.Set(&String{Value: "key1"}, &Integer{Value: big.NewInt(100)})
 	val, _ = m.Get(&String{Value: "key1"})
-	if val.(*Integer).Value != 100 {
-		t.Errorf("Updated key1 = %d, want 100", val.(*Integer).Value)
+	if val.(*Integer).Value.Cmp(big.NewInt(100)) != 0 {
+		t.Errorf("Updated key1 = %s, want 100", val.(*Integer).Value.String())
 	}
 
 	// Get non-existent key
@@ -378,9 +379,9 @@ func TestMapSetAndGet(t *testing.T) {
 
 func TestMapDelete(t *testing.T) {
 	m := NewMap()
-	m.Set(&String{Value: "a"}, &Integer{Value: 1})
-	m.Set(&String{Value: "b"}, &Integer{Value: 2})
-	m.Set(&String{Value: "c"}, &Integer{Value: 3})
+	m.Set(&String{Value: "a"}, &Integer{Value: big.NewInt(1)})
+	m.Set(&String{Value: "b"}, &Integer{Value: big.NewInt(2)})
+	m.Set(&String{Value: "c"}, &Integer{Value: big.NewInt(3)})
 
 	// Delete middle key
 	ok := m.Delete(&String{Value: "b"})
@@ -428,7 +429,7 @@ func TestHashKey(t *testing.T) {
 		ok       bool
 	}{
 		{&String{Value: "hello"}, "s:hello", true},
-		{&Integer{Value: 42}, "i:42", true},
+		{&Integer{Value: big.NewInt(42)}, "i:42", true},
 		{&Boolean{Value: true}, "b:true", true},
 		{&Boolean{Value: false}, "b:false", true},
 		{&Char{Value: 'A'}, "c:65", true},
@@ -490,15 +491,15 @@ func TestEnvironmentGetSet(t *testing.T) {
 	env := NewEnvironment()
 
 	// Set value
-	env.Set("x", &Integer{Value: 42}, true)
+	env.Set("x", &Integer{Value: big.NewInt(42)}, true)
 
 	// Get value
 	val, ok := env.Get("x")
 	if !ok {
 		t.Error("Get(x) should return true")
 	}
-	if val.(*Integer).Value != 42 {
-		t.Errorf("Get(x) = %d, want 42", val.(*Integer).Value)
+	if val.(*Integer).Value.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("Get(x) = %s, want 42", val.(*Integer).Value.String())
 	}
 
 	// Get non-existent
@@ -510,18 +511,18 @@ func TestEnvironmentGetSet(t *testing.T) {
 
 func TestEnvironmentScopeChain(t *testing.T) {
 	outer := NewEnvironment()
-	outer.Set("x", &Integer{Value: 1}, true)
+	outer.Set("x", &Integer{Value: big.NewInt(1)}, true)
 
 	inner := NewEnclosedEnvironment(outer)
-	inner.Set("y", &Integer{Value: 2}, true)
+	inner.Set("y", &Integer{Value: big.NewInt(2)}, true)
 
 	// Inner can see outer's variables
 	val, ok := inner.Get("x")
 	if !ok {
 		t.Error("inner.Get(x) should return true")
 	}
-	if val.(*Integer).Value != 1 {
-		t.Errorf("inner.Get(x) = %d, want 1", val.(*Integer).Value)
+	if val.(*Integer).Value.Cmp(big.NewInt(1)) != 0 {
+		t.Errorf("inner.Get(x) = %s, want 1", val.(*Integer).Value.String())
 	}
 
 	// Outer cannot see inner's variables
@@ -533,21 +534,21 @@ func TestEnvironmentScopeChain(t *testing.T) {
 
 func TestEnvironmentUpdate(t *testing.T) {
 	env := NewEnvironment()
-	env.Set("x", &Integer{Value: 1}, true)  // mutable
-	env.Set("y", &Integer{Value: 2}, false) // immutable
+	env.Set("x", &Integer{Value: big.NewInt(1)}, true)  // mutable
+	env.Set("y", &Integer{Value: big.NewInt(2)}, false) // immutable
 
 	// Update mutable
-	found, updated := env.Update("x", &Integer{Value: 10})
+	found, updated := env.Update("x", &Integer{Value: big.NewInt(10)})
 	if !found || !updated {
 		t.Error("Update(x) should succeed")
 	}
 	val, _ := env.Get("x")
-	if val.(*Integer).Value != 10 {
-		t.Errorf("After update, x = %d, want 10", val.(*Integer).Value)
+	if val.(*Integer).Value.Cmp(big.NewInt(10)) != 0 {
+		t.Errorf("After update, x = %s, want 10", val.(*Integer).Value.String())
 	}
 
 	// Update immutable
-	found, updated = env.Update("y", &Integer{Value: 20})
+	found, updated = env.Update("y", &Integer{Value: big.NewInt(20)})
 	if !found {
 		t.Error("Update(y) should find the variable")
 	}
@@ -556,7 +557,7 @@ func TestEnvironmentUpdate(t *testing.T) {
 	}
 
 	// Update non-existent
-	found, _ = env.Update("z", &Integer{Value: 30})
+	found, _ = env.Update("z", &Integer{Value: big.NewInt(30)})
 	if found {
 		t.Error("Update(z) should not find variable")
 	}
@@ -564,8 +565,8 @@ func TestEnvironmentUpdate(t *testing.T) {
 
 func TestEnvironmentIsMutable(t *testing.T) {
 	env := NewEnvironment()
-	env.Set("mutable", &Integer{Value: 1}, true)
-	env.Set("immutable", &Integer{Value: 2}, false)
+	env.Set("mutable", &Integer{Value: big.NewInt(1)}, true)
+	env.Set("immutable", &Integer{Value: big.NewInt(2)}, false)
 
 	isMut, ok := env.IsMutable("mutable")
 	if !ok || !isMut {
@@ -687,8 +688,8 @@ func TestEnvironmentStructDefs(t *testing.T) {
 
 func TestEnvironmentVisibility(t *testing.T) {
 	env := NewEnvironment()
-	env.SetWithVisibility("public", &Integer{Value: 1}, true, VisibilityPublic)
-	env.SetWithVisibility("private", &Integer{Value: 2}, true, VisibilityPrivate)
+	env.SetWithVisibility("public", &Integer{Value: big.NewInt(1)}, true, VisibilityPublic)
+	env.SetWithVisibility("private", &Integer{Value: big.NewInt(2)}, true, VisibilityPrivate)
 
 	vis, ok := env.GetVisibility("public")
 	if !ok || vis != VisibilityPublic {
@@ -703,9 +704,9 @@ func TestEnvironmentVisibility(t *testing.T) {
 
 func TestEnvironmentGetPublicBindings(t *testing.T) {
 	env := NewEnvironment()
-	env.SetWithVisibility("public1", &Integer{Value: 1}, true, VisibilityPublic)
-	env.SetWithVisibility("public2", &Integer{Value: 2}, true, VisibilityPublic)
-	env.SetWithVisibility("private", &Integer{Value: 3}, true, VisibilityPrivate)
+	env.SetWithVisibility("public1", &Integer{Value: big.NewInt(1)}, true, VisibilityPublic)
+	env.SetWithVisibility("public2", &Integer{Value: big.NewInt(2)}, true, VisibilityPublic)
+	env.SetWithVisibility("private", &Integer{Value: big.NewInt(3)}, true, VisibilityPrivate)
 
 	bindings := env.GetPublicBindings()
 	if len(bindings) != 2 {

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -5,6 +5,7 @@ package stdlib
 
 import (
 	"fmt"
+	"math/big"
 	"math/rand"
 	"sort"
 
@@ -92,7 +93,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.insert() requires an integer index"}
 			}
-			index := int(idx.Value)
+			index := int(idx.Value.Int64())
 			if index < 0 || index > len(arr.Elements) {
 				return &object.Error{Code: "E5003", Message: "arrays.insert() index out of bounds"}
 			}
@@ -165,7 +166,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.remove_at() requires an integer index"}
 			}
-			index := int(idx.Value)
+			index := int(idx.Value.Int64())
 			if index < 0 || index >= len(arr.Elements) {
 				return &object.Error{Code: "E5003", Message: "arrays.remove_at() index out of bounds"}
 			}
@@ -198,7 +199,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.remove() requires an integer index"}
 			}
-			index := int(idx.Value)
+			index := int(idx.Value.Int64())
 			if index < 0 || index >= len(arr.Elements) {
 				return &object.Error{Code: "E9001", Message: fmt.Sprintf("arrays.remove() index out of bounds: %d (array length: %d)", index, len(arr.Elements))}
 			}
@@ -290,7 +291,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.get() requires an integer index"}
 			}
-			index := int(idx.Value)
+			index := int(idx.Value.Int64())
 			if index < 0 || index >= len(arr.Elements) {
 				return &object.Error{Code: "E5003", Message: "arrays.get() index out of bounds"}
 			}
@@ -343,7 +344,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.set() requires an integer index"}
 			}
-			index := int(idx.Value)
+			index := int(idx.Value.Int64())
 			if index < 0 || index >= len(arr.Elements) {
 				return &object.Error{Code: "E5003", Message: "arrays.set() index out of bounds"}
 			}
@@ -367,7 +368,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return newError("arrays.slice() requires integer indices")
 			}
-			startIdx := int(start.Value)
+			startIdx := int(start.Value.Int64())
 			if startIdx < 0 {
 				startIdx = len(arr.Elements) + startIdx
 			}
@@ -381,7 +382,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return newError("arrays.slice() requires integer indices")
 				}
-				endIdx = int(end.Value)
+				endIdx = int(end.Value.Int64())
 				if endIdx < 0 {
 					endIdx = len(arr.Elements) + endIdx
 				}
@@ -416,7 +417,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.take() requires an integer"}
 			}
-			count := int(n.Value)
+			count := int(n.Value.Int64())
 			if count < 0 {
 				count = 0
 			}
@@ -442,7 +443,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.drop() requires an integer"}
 			}
-			count := int(n.Value)
+			count := int(n.Value.Int64())
 			if count < 0 {
 				count = 0
 			}
@@ -484,10 +485,10 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			}
 			for i, el := range arr.Elements {
 				if objectsEqual(el, args[1]) {
-					return &object.Integer{Value: int64(i)}
+					return &object.Integer{Value: big.NewInt(int64(i))}
 				}
 			}
-			return &object.Integer{Value: -1}
+			return &object.Integer{Value: big.NewInt(-1)}
 		},
 	},
 
@@ -502,10 +503,10 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			}
 			for i, el := range arr.Elements {
 				if objectsEqual(el, args[1]) {
-					return &object.Integer{Value: int64(i)}
+					return &object.Integer{Value: big.NewInt(int64(i))}
 				}
 			}
-			return &object.Integer{Value: -1}
+			return &object.Integer{Value: big.NewInt(-1)}
 		},
 	},
 
@@ -520,10 +521,10 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			}
 			for i := len(arr.Elements) - 1; i >= 0; i-- {
 				if objectsEqual(arr.Elements[i], args[1]) {
-					return &object.Integer{Value: int64(i)}
+					return &object.Integer{Value: big.NewInt(int64(i))}
 				}
 			}
-			return &object.Integer{Value: -1}
+			return &object.Integer{Value: big.NewInt(-1)}
 		},
 	},
 
@@ -542,7 +543,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					count++
 				}
 			}
-			return &object.Integer{Value: int64(count)}
+			return &object.Integer{Value: big.NewInt(int64(count))}
 		},
 	},
 
@@ -785,7 +786,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			for _, el := range arr.Elements {
 				switch v := el.(type) {
 				case *object.Integer:
-					sum += float64(v.Value)
+					f, _ := new(big.Float).SetInt(v.Value).Float64()
+					sum += f
 				case *object.Float:
 					sum += v.Value
 					hasFloat = true
@@ -796,7 +798,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if hasFloat {
 				return &object.Float{Value: sum}
 			}
-			return &object.Integer{Value: int64(sum)}
+			return &object.Integer{Value: big.NewInt(int64(sum))}
 		},
 	},
 
@@ -810,7 +812,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7002", Message: "arrays.product() requires an array"}
 			}
 			if len(arr.Elements) == 0 {
-				return &object.Integer{Value: 1}
+				return &object.Integer{Value: big.NewInt(1)}
 			}
 
 			product := 1.0
@@ -818,7 +820,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			for _, el := range arr.Elements {
 				switch v := el.(type) {
 				case *object.Integer:
-					product *= float64(v.Value)
+					f, _ := new(big.Float).SetInt(v.Value).Float64()
+					product *= f
 				case *object.Float:
 					product *= v.Value
 					hasFloat = true
@@ -829,7 +832,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if hasFloat {
 				return &object.Float{Value: product}
 			}
-			return &object.Integer{Value: int64(product)}
+			return &object.Integer{Value: big.NewInt(int64(product))}
 		},
 	},
 
@@ -896,7 +899,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			for _, el := range arr.Elements {
 				switch v := el.(type) {
 				case *object.Integer:
-					sum += float64(v.Value)
+					f, _ := new(big.Float).SetInt(v.Value).Float64()
+					sum += f
 				case *object.Float:
 					sum += v.Value
 				default:
@@ -916,17 +920,17 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			var start, end, step int64
 
 			if len(args) == 1 {
-				end = args[0].(*object.Integer).Value
+				end = args[0].(*object.Integer).Value.Int64()
 				start = 0
 				step = 1
 			} else if len(args) == 2 {
-				start = args[0].(*object.Integer).Value
-				end = args[1].(*object.Integer).Value
+				start = args[0].(*object.Integer).Value.Int64()
+				end = args[1].(*object.Integer).Value.Int64()
 				step = 1
 			} else {
-				start = args[0].(*object.Integer).Value
-				end = args[1].(*object.Integer).Value
-				step = args[2].(*object.Integer).Value
+				start = args[0].(*object.Integer).Value.Int64()
+				end = args[1].(*object.Integer).Value.Int64()
+				step = args[2].(*object.Integer).Value.Int64()
 			}
 
 			if step == 0 {
@@ -936,11 +940,11 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			var elements []object.Object
 			if step > 0 {
 				for i := start; i < end; i += step {
-					elements = append(elements, &object.Integer{Value: i})
+					elements = append(elements, &object.Integer{Value: big.NewInt(i)})
 				}
 			} else {
 				for i := start; i > end; i += step {
-					elements = append(elements, &object.Integer{Value: i})
+					elements = append(elements, &object.Integer{Value: big.NewInt(i)})
 				}
 			}
 			return &object.Array{Elements: elements}
@@ -956,7 +960,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return newError("arrays.repeat() requires integer count")
 			}
-			count := int(n.Value)
+			count := int(n.Value.Int64())
 			if count < 0 {
 				count = 0
 			}
@@ -1051,11 +1055,11 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.chunk() requires an integer size"}
 			}
-			if size.Value <= 0 {
+			if size.Value.Sign() <= 0 {
 				return &object.Error{Code: "E9004", Message: "arrays.chunk() size must be greater than 0"}
 			}
 
-			chunkSize := int(size.Value)
+			chunkSize := int(size.Value.Int64())
 			var chunks []object.Object
 
 			for i := 0; i < len(arr.Elements); i += chunkSize {
@@ -1088,12 +1092,7 @@ func objectsEqual(a, b object.Object) bool {
 func compareObjects(a, b object.Object) int {
 	if ai, ok := a.(*object.Integer); ok {
 		if bi, ok := b.(*object.Integer); ok {
-			if ai.Value < bi.Value {
-				return -1
-			} else if ai.Value > bi.Value {
-				return 1
-			}
-			return 0
+			return ai.Value.Cmp(bi.Value)
 		}
 	}
 	if af, ok := a.(*object.Float); ok {

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -6,6 +6,7 @@ package stdlib
 import (
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -211,7 +212,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.write_file() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			err := atomicWriteFile(path.Value, []byte(content.Value), perms)
@@ -256,7 +257,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.write_bytes() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			// Convert byte array to []byte
@@ -310,7 +311,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.append_file() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			f, err := os.OpenFile(path.Value, os.O_APPEND|os.O_CREATE|os.O_WRONLY, perms)
@@ -421,7 +422,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.append_line() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			f, err := os.OpenFile(path.Value, os.O_APPEND|os.O_CREATE|os.O_WRONLY, perms)
@@ -776,7 +777,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.copy() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			} else {
 				perms = srcInfo.Mode()
 			}
@@ -842,7 +843,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.mkdir() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			err := os.Mkdir(path.Value, perms)
@@ -882,7 +883,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.mkdir_all() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			err := os.MkdirAll(path.Value, perms)
@@ -958,7 +959,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Integer{Value: info.Size()},
+				&object.Integer{Value: big.NewInt(info.Size())},
 				object.NIL,
 			}}
 		},
@@ -987,7 +988,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Integer{Value: info.ModTime().Unix()},
+				&object.Integer{Value: big.NewInt(info.ModTime().Unix())},
 				object.NIL,
 			}}
 		},
@@ -1144,54 +1145,54 @@ var IOBuiltins = map[string]*object.Builtin{
 	// File open mode constants
 	"io.READ_ONLY": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_RDONLY)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_RDONLY))}
 		},
 	},
 	"io.WRITE_ONLY": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_WRONLY)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_WRONLY))}
 		},
 	},
 	"io.READ_WRITE": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_RDWR)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_RDWR))}
 		},
 	},
 	"io.APPEND": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_APPEND)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_APPEND))}
 		},
 	},
 	"io.CREATE": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_CREATE)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_CREATE))}
 		},
 	},
 	"io.TRUNCATE": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_TRUNC)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_TRUNC))}
 		},
 	},
 	"io.EXCLUSIVE": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.O_EXCL)}
+			return &object.Integer{Value: big.NewInt(int64(os.O_EXCL))}
 		},
 	},
 
 	// Seek whence constants
 	"io.SEEK_START": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(io.SeekStart)}
+			return &object.Integer{Value: big.NewInt(int64(io.SeekStart))}
 		},
 	},
 	"io.SEEK_CURRENT": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(io.SeekCurrent)}
+			return &object.Integer{Value: big.NewInt(int64(io.SeekCurrent))}
 		},
 	},
 	"io.SEEK_END": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(io.SeekEnd)}
+			return &object.Integer{Value: big.NewInt(int64(io.SeekEnd))}
 		},
 	},
 
@@ -1224,7 +1225,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.open() mode must be an integer"}
 				}
-				mode = int(modeVal.Value)
+				mode = int(modeVal.Value.Int64())
 			}
 
 			// Default permissions
@@ -1234,7 +1235,7 @@ var IOBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "io.open() permissions must be an integer"}
 				}
-				perms = os.FileMode(permVal.Value)
+				perms = os.FileMode(permVal.Value.Int64())
 			}
 
 			file, err := os.OpenFile(path.Value, mode, perms)
@@ -1275,11 +1276,11 @@ var IOBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "io.read() requires an integer as second argument"}
 			}
-			if n.Value < 0 {
+			if n.Value.Sign() < 0 {
 				return &object.Error{Code: "E7011", Message: "io.read() byte count cannot be negative"}
 			}
 
-			buf := make([]byte, n.Value)
+			buf := make([]byte, n.Value.Int64())
 			bytesRead, err := handle.File.Read(buf)
 
 			// Handle EOF - not an error, just return what we got
@@ -1357,11 +1358,11 @@ var IOBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "io.read_string() requires an integer as second argument"}
 			}
-			if n.Value < 0 {
+			if n.Value.Sign() < 0 {
 				return &object.Error{Code: "E7011", Message: "io.read_string() byte count cannot be negative"}
 			}
 
-			buf := make([]byte, n.Value)
+			buf := make([]byte, n.Value.Int64())
 			bytesRead, err := handle.File.Read(buf)
 
 			// Handle EOF - not an error, just return what we got
@@ -1421,7 +1422,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Integer{Value: int64(bytesWritten)},
+				&object.Integer{Value: big.NewInt(int64(bytesWritten))},
 				object.NIL,
 			}}
 		},
@@ -1453,13 +1454,13 @@ var IOBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7004", Message: "io.seek() whence must be an integer"}
 			}
 
-			newPos, err := handle.File.Seek(offset.Value, int(whence.Value))
+			newPos, err := handle.File.Seek(offset.Value.Int64(), int(whence.Value.Int64()))
 			if err != nil {
 				return createIOErrorResult(err, "seek")
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Integer{Value: newPos},
+				&object.Integer{Value: big.NewInt(newPos)},
 				object.NIL,
 			}}
 		},
@@ -1490,7 +1491,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Integer{Value: pos},
+				&object.Integer{Value: big.NewInt(pos)},
 				object.NIL,
 			}}
 		},

--- a/pkg/stdlib/io_test.go
+++ b/pkg/stdlib/io_test.go
@@ -4,6 +4,7 @@ package stdlib
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
+	"math/big"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -126,7 +127,7 @@ func TestIOReadFile(t *testing.T) {
 	})
 
 	t.Run("wrong argument type", func(t *testing.T) {
-		result := readFileFn(&object.Integer{Value: 123})
+		result := readFileFn(&object.Integer{Value: big.NewInt(123)})
 		if !isErrorObject(result) {
 			t.Error("expected error for wrong argument type")
 		}
@@ -579,8 +580,8 @@ func TestIOFileSize(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", vals[0])
 		}
-		if size.Value != int64(len(content)) {
-			t.Errorf("expected %d, got %d", len(content), size.Value)
+		if size.Value.Cmp(big.NewInt(int64(len(content)))) != 0 {
+			t.Errorf("expected %d, got %s", len(content), size.Value.String())
 		}
 	})
 
@@ -607,7 +608,7 @@ func TestIOFileModTime(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", vals[0])
 		}
-		if timestamp.Value <= 0 {
+		if timestamp.Value.Sign() <= 0 {
 			t.Error("timestamp should be positive")
 		}
 	})
@@ -1270,7 +1271,7 @@ func TestIOWriteBytes(t *testing.T) {
 		result := writeBytesFn(
 			&object.String{Value: path},
 			makeByteArray(content),
-			&object.Integer{Value: 0600},
+			&object.Integer{Value: big.NewInt(0600)},
 		)
 		assertNoError(t, result)
 
@@ -1418,8 +1419,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_RDONLY) {
-			t.Errorf("expected %d (O_RDONLY), got %d", os.O_RDONLY, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_RDONLY))) != 0 {
+			t.Errorf("expected %d (O_RDONLY), got %s", os.O_RDONLY, val.Value.String())
 		}
 	})
 
@@ -1430,8 +1431,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_WRONLY) {
-			t.Errorf("expected %d (O_WRONLY), got %d", os.O_WRONLY, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_WRONLY))) != 0 {
+			t.Errorf("expected %d (O_WRONLY), got %s", os.O_WRONLY, val.Value.String())
 		}
 	})
 
@@ -1442,8 +1443,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_RDWR) {
-			t.Errorf("expected %d (O_RDWR), got %d", os.O_RDWR, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_RDWR))) != 0 {
+			t.Errorf("expected %d (O_RDWR), got %s", os.O_RDWR, val.Value.String())
 		}
 	})
 
@@ -1454,8 +1455,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_APPEND) {
-			t.Errorf("expected %d (O_APPEND), got %d", os.O_APPEND, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_APPEND))) != 0 {
+			t.Errorf("expected %d (O_APPEND), got %s", os.O_APPEND, val.Value.String())
 		}
 	})
 
@@ -1466,8 +1467,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_CREATE) {
-			t.Errorf("expected %d (O_CREATE), got %d", os.O_CREATE, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_CREATE))) != 0 {
+			t.Errorf("expected %d (O_CREATE), got %s", os.O_CREATE, val.Value.String())
 		}
 	})
 
@@ -1478,8 +1479,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_TRUNC) {
-			t.Errorf("expected %d (O_TRUNC), got %d", os.O_TRUNC, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_TRUNC))) != 0 {
+			t.Errorf("expected %d (O_TRUNC), got %s", os.O_TRUNC, val.Value.String())
 		}
 	})
 
@@ -1490,8 +1491,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != int64(os.O_EXCL) {
-			t.Errorf("expected %d (O_EXCL), got %d", os.O_EXCL, val.Value)
+		if val.Value.Cmp(big.NewInt(int64(os.O_EXCL))) != 0 {
+			t.Errorf("expected %d (O_EXCL), got %s", os.O_EXCL, val.Value.String())
 		}
 	})
 
@@ -1503,8 +1504,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != 0 {
-			t.Errorf("expected 0 (SEEK_START), got %d", val.Value)
+		if val.Value.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("expected 0 (SEEK_START), got %s", val.Value.String())
 		}
 	})
 
@@ -1515,8 +1516,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != 1 {
-			t.Errorf("expected 1 (SEEK_CURRENT), got %d", val.Value)
+		if val.Value.Cmp(big.NewInt(1)) != 0 {
+			t.Errorf("expected 1 (SEEK_CURRENT), got %s", val.Value.String())
 		}
 	})
 
@@ -1527,8 +1528,8 @@ func TestIOConstants(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", result)
 		}
-		if val.Value != 2 {
-			t.Errorf("expected 2 (SEEK_END), got %d", val.Value)
+		if val.Value.Cmp(big.NewInt(2)) != 0 {
+			t.Errorf("expected 2 (SEEK_END), got %s", val.Value.String())
 		}
 	})
 }
@@ -1569,7 +1570,7 @@ func TestIOOpen(t *testing.T) {
 
 	t.Run("open new file for writing", func(t *testing.T) {
 		path := filepath.Join(dir, "open_write.txt")
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_CREATE)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_CREATE))}
 
 		result := openFn(&object.String{Value: path}, mode)
 		assertNoError(t, result)
@@ -1590,8 +1591,8 @@ func TestIOOpen(t *testing.T) {
 
 	t.Run("open with custom permissions", func(t *testing.T) {
 		path := filepath.Join(dir, "open_perms.txt")
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_CREATE)}
-		perms := &object.Integer{Value: 0600}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_CREATE))}
+		perms := &object.Integer{Value: big.NewInt(0600)}
 
 		result := openFn(&object.String{Value: path}, mode, perms)
 		assertNoError(t, result)
@@ -1642,7 +1643,7 @@ func TestIOReadHandle(t *testing.T) {
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 
 		// Read 5 bytes
-		readResult := readFn(handle, &object.Integer{Value: 5})
+		readResult := readFn(handle, &object.Integer{Value: big.NewInt(5)})
 		assertNoError(t, readResult)
 
 		vals := getReturnValues(t, readResult)
@@ -1674,7 +1675,7 @@ func TestIOReadHandle(t *testing.T) {
 		closeFn(handle)
 
 		// Try to read from closed handle
-		readResult := readFn(handle, &object.Integer{Value: 5})
+		readResult := readFn(handle, &object.Integer{Value: big.NewInt(5)})
 		errStruct := assertHasError(t, readResult)
 		code := errStruct.Fields["code"].(*object.String)
 		if code.Value != "E7050" {
@@ -1687,7 +1688,7 @@ func TestIOReadHandle(t *testing.T) {
 		result := openFn(&object.String{Value: path})
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 
-		readResult := readFn(handle, &object.Integer{Value: -1})
+		readResult := readFn(handle, &object.Integer{Value: big.NewInt(-1)})
 		_, ok := readResult.(*object.Error)
 		if !ok {
 			t.Errorf("expected Error for negative count, got %T", readResult)
@@ -1754,7 +1755,7 @@ func TestIOReadString(t *testing.T) {
 		result := openFn(&object.String{Value: path})
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 
-		readResult := readStringFn(handle, &object.Integer{Value: 5})
+		readResult := readStringFn(handle, &object.Integer{Value: big.NewInt(5)})
 		assertNoError(t, readResult)
 
 		vals := getReturnValues(t, readResult)
@@ -1780,7 +1781,7 @@ func TestIOWriteHandle(t *testing.T) {
 
 	t.Run("write string to file", func(t *testing.T) {
 		path := filepath.Join(dir, "write_string.txt")
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_CREATE)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_CREATE))}
 
 		result := openFn(&object.String{Value: path}, mode)
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
@@ -1793,8 +1794,8 @@ func TestIOWriteHandle(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer, got %T", vals[0])
 		}
-		if bytesWritten.Value != 13 {
-			t.Errorf("expected 13 bytes written, got %d", bytesWritten.Value)
+		if bytesWritten.Value.Cmp(big.NewInt(13)) != 0 {
+			t.Errorf("expected 13 bytes written, got %s", bytesWritten.Value.String())
 		}
 
 		closeFn(handle)
@@ -1808,7 +1809,7 @@ func TestIOWriteHandle(t *testing.T) {
 
 	t.Run("write byte array to file", func(t *testing.T) {
 		path := filepath.Join(dir, "write_bytes.txt")
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_CREATE)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_CREATE))}
 
 		result := openFn(&object.String{Value: path}, mode)
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
@@ -1832,7 +1833,7 @@ func TestIOWriteHandle(t *testing.T) {
 
 	t.Run("write to closed handle", func(t *testing.T) {
 		path := filepath.Join(dir, "write_closed.txt")
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_CREATE)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_CREATE))}
 
 		result := openFn(&object.String{Value: path}, mode)
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
@@ -1865,17 +1866,17 @@ func TestIOSeekAndTell(t *testing.T) {
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 
 		// Seek to position 7
-		seekResult := seekFn(handle, &object.Integer{Value: 7}, &object.Integer{Value: 0}) // SEEK_START
+		seekResult := seekFn(handle, &object.Integer{Value: big.NewInt(7)}, &object.Integer{Value: big.NewInt(0)}) // SEEK_START
 		assertNoError(t, seekResult)
 
 		vals := getReturnValues(t, seekResult)
 		pos := vals[0].(*object.Integer)
-		if pos.Value != 7 {
-			t.Errorf("expected position 7, got %d", pos.Value)
+		if pos.Value.Cmp(big.NewInt(7)) != 0 {
+			t.Errorf("expected position 7, got %s", pos.Value.String())
 		}
 
 		// Read from current position
-		readResult := readStringFn(handle, &object.Integer{Value: 5})
+		readResult := readStringFn(handle, &object.Integer{Value: big.NewInt(5)})
 		assertNoError(t, readResult)
 
 		str := getReturnValues(t, readResult)[0].(*object.String)
@@ -1897,18 +1898,18 @@ func TestIOSeekAndTell(t *testing.T) {
 		tellResult := tellFn(handle)
 		assertNoError(t, tellResult)
 		pos := getReturnValues(t, tellResult)[0].(*object.Integer)
-		if pos.Value != 0 {
-			t.Errorf("expected position 0, got %d", pos.Value)
+		if pos.Value.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("expected position 0, got %s", pos.Value.String())
 		}
 
 		// Read 3 bytes
-		readStringFn(handle, &object.Integer{Value: 3})
+		readStringFn(handle, &object.Integer{Value: big.NewInt(3)})
 
 		// Position should now be 3
 		tellResult = tellFn(handle)
 		pos = getReturnValues(t, tellResult)[0].(*object.Integer)
-		if pos.Value != 3 {
-			t.Errorf("expected position 3, got %d", pos.Value)
+		if pos.Value.Cmp(big.NewInt(3)) != 0 {
+			t.Errorf("expected position 3, got %s", pos.Value.String())
 		}
 
 		closeFn(handle)
@@ -1922,12 +1923,12 @@ func TestIOSeekAndTell(t *testing.T) {
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 
 		// Seek to 2 bytes before end
-		seekResult := seekFn(handle, &object.Integer{Value: -2}, &object.Integer{Value: 2}) // SEEK_END
+		seekResult := seekFn(handle, &object.Integer{Value: big.NewInt(-2)}, &object.Integer{Value: big.NewInt(2)}) // SEEK_END
 		assertNoError(t, seekResult)
 
 		pos := getReturnValues(t, seekResult)[0].(*object.Integer)
-		if pos.Value != 3 {
-			t.Errorf("expected position 3, got %d", pos.Value)
+		if pos.Value.Cmp(big.NewInt(3)) != 0 {
+			t.Errorf("expected position 3, got %s", pos.Value.String())
 		}
 
 		closeFn(handle)
@@ -1939,7 +1940,7 @@ func TestIOSeekAndTell(t *testing.T) {
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 		closeFn(handle)
 
-		seekResult := seekFn(handle, &object.Integer{Value: 0}, &object.Integer{Value: 0})
+		seekResult := seekFn(handle, &object.Integer{Value: big.NewInt(0)}, &object.Integer{Value: big.NewInt(0)})
 		errStruct := assertHasError(t, seekResult)
 		code := errStruct.Fields["code"].(*object.String)
 		if code.Value != "E7050" {
@@ -1973,7 +1974,7 @@ func TestIOFlushAndClose(t *testing.T) {
 
 	t.Run("flush written data", func(t *testing.T) {
 		path := filepath.Join(dir, "flush_test.txt")
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_CREATE)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_CREATE))}
 
 		result := openFn(&object.String{Value: path}, mode)
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
@@ -2088,7 +2089,7 @@ func TestIOFileHandleIntegration(t *testing.T) {
 
 	t.Run("write then read with seek", func(t *testing.T) {
 		path := filepath.Join(dir, "rw_test.txt")
-		mode := &object.Integer{Value: int64(os.O_RDWR | os.O_CREATE)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_RDWR | os.O_CREATE))}
 
 		// Open for read/write
 		result := openFn(&object.String{Value: path}, mode)
@@ -2098,10 +2099,10 @@ func TestIOFileHandleIntegration(t *testing.T) {
 		writeFn(handle, &object.String{Value: "Hello, World!"})
 
 		// Seek back to start
-		seekFn(handle, &object.Integer{Value: 0}, &object.Integer{Value: 0})
+		seekFn(handle, &object.Integer{Value: big.NewInt(0)}, &object.Integer{Value: big.NewInt(0)})
 
 		// Read data back
-		readResult := readFn(handle, &object.Integer{Value: 5})
+		readResult := readFn(handle, &object.Integer{Value: big.NewInt(5)})
 		assertNoError(t, readResult)
 
 		arr := getReturnValues(t, readResult)[0].(*object.Array)
@@ -2120,7 +2121,7 @@ func TestIOFileHandleIntegration(t *testing.T) {
 		path := createTempFile(t, dir, "append_test.txt", "Hello")
 
 		// Open in append mode
-		mode := &object.Integer{Value: int64(os.O_WRONLY | os.O_APPEND)}
+		mode := &object.Integer{Value: big.NewInt(int64(os.O_WRONLY | os.O_APPEND))}
 		result := openFn(&object.String{Value: path}, mode)
 		handle := getReturnValues(t, result)[0].(*object.FileHandle)
 
@@ -2258,7 +2259,7 @@ func TestIOAppendLine(t *testing.T) {
 		result := appendLineFn(
 			&object.String{Value: path},
 			&object.String{Value: "test"},
-			&object.Integer{Value: 0600},
+			&object.Integer{Value: big.NewInt(0600)},
 		)
 		assertNoError(t, result)
 
@@ -2322,7 +2323,7 @@ func TestIOWriteFileWithPerms(t *testing.T) {
 		result := writeFileFn(
 			&object.String{Value: path},
 			&object.String{Value: "test content"},
-			&object.Integer{Value: 0600},
+			&object.Integer{Value: big.NewInt(0600)},
 		)
 		assertNoError(t, result)
 
@@ -2363,7 +2364,7 @@ func TestIOMkdirWithPerms(t *testing.T) {
 
 		result := mkdirFn(
 			&object.String{Value: path},
-			&object.Integer{Value: 0700},
+			&object.Integer{Value: big.NewInt(0700)},
 		)
 		assertNoError(t, result)
 
@@ -2387,7 +2388,7 @@ func TestIOMkdirAllWithPerms(t *testing.T) {
 
 		result := mkdirAllFn(
 			&object.String{Value: path},
-			&object.Integer{Value: 0700},
+			&object.Integer{Value: big.NewInt(0700)},
 		)
 		assertNoError(t, result)
 
@@ -2413,7 +2414,7 @@ func TestIOCopyWithPerms(t *testing.T) {
 		result := copyFn(
 			&object.String{Value: srcPath},
 			&object.String{Value: dstPath},
-			&object.Integer{Value: 0600},
+			&object.Integer{Value: big.NewInt(0600)},
 		)
 		assertNoError(t, result)
 

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -5,6 +5,7 @@ package stdlib
 
 import (
 	"fmt"
+	"math/big"
 	"os"
 	"os/exec"
 	"os/user"
@@ -150,7 +151,7 @@ var OSBuiltins = map[string]*object.Builtin{
 			code := 0
 			if len(args) > 0 {
 				if codeObj, ok := args[0].(*object.Integer); ok {
-					code = int(codeObj.Value)
+					code = int(codeObj.Value.Int64())
 				} else {
 					return &object.Error{Code: "E7003", Message: "os.exit() requires an integer exit code"}
 				}
@@ -269,14 +270,14 @@ var OSBuiltins = map[string]*object.Builtin{
 	// Returns the process ID of the current process
 	"os.pid": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.Getpid())}
+			return &object.Integer{Value: big.NewInt(int64(os.Getpid()))}
 		},
 	},
 
 	// Returns the parent process ID
 	"os.ppid": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(os.Getppid())}
+			return &object.Integer{Value: big.NewInt(int64(os.Getppid()))}
 		},
 	},
 
@@ -287,17 +288,17 @@ var OSBuiltins = map[string]*object.Builtin{
 	// OS Constants - use these for comparison with CURRENT_OS
 	"os.MAC_OS": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: 0}
+			return &object.Integer{Value: big.NewInt(0)}
 		},
 	},
 	"os.LINUX": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: 1}
+			return &object.Integer{Value: big.NewInt(1)}
 		},
 	},
 	"os.WINDOWS": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: 2}
+			return &object.Integer{Value: big.NewInt(2)}
 		},
 	},
 
@@ -306,13 +307,13 @@ var OSBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			switch runtime.GOOS {
 			case "darwin":
-				return &object.Integer{Value: 0} // MAC_OS
+				return &object.Integer{Value: big.NewInt(0)} // MAC_OS
 			case "linux":
-				return &object.Integer{Value: 1} // LINUX
+				return &object.Integer{Value: big.NewInt(1)} // LINUX
 			case "windows":
-				return &object.Integer{Value: 2} // WINDOWS
+				return &object.Integer{Value: big.NewInt(2)} // WINDOWS
 			default:
-				return &object.Integer{Value: -1} // Unknown
+				return &object.Integer{Value: big.NewInt(-1)} // Unknown
 			}
 		},
 	},
@@ -366,7 +367,7 @@ var OSBuiltins = map[string]*object.Builtin{
 	// Returns the number of CPUs available
 	"os.num_cpu": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: int64(runtime.NumCPU())}
+			return &object.Integer{Value: big.NewInt(int64(runtime.NumCPU()))}
 		},
 	},
 
@@ -429,14 +430,14 @@ var OSBuiltins = map[string]*object.Builtin{
 				} else {
 					// Command failed to start entirely
 					return &object.ReturnValue{Values: []object.Object{
-						&object.Integer{Value: -1},
+						&object.Integer{Value: big.NewInt(-1)},
 						createOSError("E7030", fmt.Sprintf("command failed to execute: %s", err.Error())),
 					}}
 				}
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Integer{Value: exitCode},
+				&object.Integer{Value: big.NewInt(exitCode)},
 				object.NIL,
 			}}
 		},

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -4,6 +4,7 @@ package stdlib
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
+	"math/big"
 	"os"
 	"os/user"
 	"runtime"
@@ -50,7 +51,7 @@ func TestOSGetEnv(t *testing.T) {
 	}
 
 	// Test wrong argument type
-	result = fn.Fn(&object.Integer{Value: 123})
+	result = fn.Fn(&object.Integer{Value: big.NewInt(123)})
 	errResult, ok = result.(*object.Error)
 	if !ok {
 		t.Fatalf("Expected Error, got %T", result)
@@ -339,8 +340,8 @@ func TestOSPid(t *testing.T) {
 		t.Fatalf("Expected Integer, got %T", result)
 	}
 
-	if intResult.Value != int64(os.Getpid()) {
-		t.Errorf("Expected %d, got %d", os.Getpid(), intResult.Value)
+	if intResult.Value.Cmp(big.NewInt(int64(os.Getpid()))) != 0 {
+		t.Errorf("Expected %d, got %s", os.Getpid(), intResult.Value.String())
 	}
 }
 
@@ -353,8 +354,8 @@ func TestOSPpid(t *testing.T) {
 		t.Fatalf("Expected Integer, got %T", result)
 	}
 
-	if intResult.Value != int64(os.Getppid()) {
-		t.Errorf("Expected %d, got %d", os.Getppid(), intResult.Value)
+	if intResult.Value.Cmp(big.NewInt(int64(os.Getppid()))) != 0 {
+		t.Errorf("Expected %d, got %s", os.Getppid(), intResult.Value.String())
 	}
 }
 
@@ -373,30 +374,30 @@ func TestOSConstants(t *testing.T) {
 	linuxResult := linux.Fn().(*object.Integer)
 	windowsResult := windows.Fn().(*object.Integer)
 
-	if macResult.Value != 0 {
-		t.Errorf("Expected MAC_OS = 0, got %d", macResult.Value)
+	if macResult.Value.Cmp(big.NewInt(0)) != 0 {
+		t.Errorf("Expected MAC_OS = 0, got %s", macResult.Value.String())
 	}
-	if linuxResult.Value != 1 {
-		t.Errorf("Expected LINUX = 1, got %d", linuxResult.Value)
+	if linuxResult.Value.Cmp(big.NewInt(1)) != 0 {
+		t.Errorf("Expected LINUX = 1, got %s", linuxResult.Value.String())
 	}
-	if windowsResult.Value != 2 {
-		t.Errorf("Expected WINDOWS = 2, got %d", windowsResult.Value)
+	if windowsResult.Value.Cmp(big.NewInt(2)) != 0 {
+		t.Errorf("Expected WINDOWS = 2, got %s", windowsResult.Value.String())
 	}
 
 	// Check CURRENT_OS matches expected constant for this platform
 	currentResult := currentOS.Fn().(*object.Integer)
 	switch runtime.GOOS {
 	case "darwin":
-		if currentResult.Value != 0 {
-			t.Errorf("Expected CURRENT_OS = MAC_OS (0) on darwin, got %d", currentResult.Value)
+		if currentResult.Value.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("Expected CURRENT_OS = MAC_OS (0) on darwin, got %s", currentResult.Value.String())
 		}
 	case "linux":
-		if currentResult.Value != 1 {
-			t.Errorf("Expected CURRENT_OS = LINUX (1) on linux, got %d", currentResult.Value)
+		if currentResult.Value.Cmp(big.NewInt(1)) != 0 {
+			t.Errorf("Expected CURRENT_OS = LINUX (1) on linux, got %s", currentResult.Value.String())
 		}
 	case "windows":
-		if currentResult.Value != 2 {
-			t.Errorf("Expected CURRENT_OS = WINDOWS (2) on windows, got %d", currentResult.Value)
+		if currentResult.Value.Cmp(big.NewInt(2)) != 0 {
+			t.Errorf("Expected CURRENT_OS = WINDOWS (2) on windows, got %s", currentResult.Value.String())
 		}
 	}
 }
@@ -483,8 +484,8 @@ func TestOSNumCpu(t *testing.T) {
 		t.Fatalf("Expected Integer, got %T", result)
 	}
 
-	if intResult.Value != int64(runtime.NumCPU()) {
-		t.Errorf("Expected %d, got %d", runtime.NumCPU(), intResult.Value)
+	if intResult.Value.Cmp(big.NewInt(int64(runtime.NumCPU()))) != 0 {
+		t.Errorf("Expected %d, got %s", runtime.NumCPU(), intResult.Value.String())
 	}
 }
 
@@ -604,8 +605,8 @@ func TestOSExec(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected Integer exit code, got %T", rv.Values[0])
 		}
-		if exitCode.Value != 0 {
-			t.Errorf("expected exit code 0, got %d", exitCode.Value)
+		if exitCode.Value.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("expected exit code 0, got %s", exitCode.Value.String())
 		}
 
 		if rv.Values[1] != object.NIL {
@@ -618,8 +619,8 @@ func TestOSExec(t *testing.T) {
 		rv := result.(*object.ReturnValue)
 
 		exitCode := rv.Values[0].(*object.Integer)
-		if exitCode.Value != 42 {
-			t.Errorf("expected exit code 42, got %d", exitCode.Value)
+		if exitCode.Value.Cmp(big.NewInt(42)) != 0 {
+			t.Errorf("expected exit code 42, got %s", exitCode.Value.String())
 		}
 
 		// Error should still be nil for non-zero exit
@@ -629,7 +630,7 @@ func TestOSExec(t *testing.T) {
 	})
 
 	t.Run("wrong argument type", func(t *testing.T) {
-		result := execFn(&object.Integer{Value: 123})
+		result := execFn(&object.Integer{Value: big.NewInt(123)})
 		if _, ok := result.(*object.Error); !ok {
 			t.Errorf("expected Error for wrong type, got %T", result)
 		}

--- a/pkg/stdlib/random.go
+++ b/pkg/stdlib/random.go
@@ -4,6 +4,7 @@ package stdlib
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
+	"math/big"
 	"math/rand"
 
 	"github.com/marshallburns/ez/pkg/object"
@@ -47,7 +48,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				if max <= 0 {
 					return &object.Error{Code: "E8006", Message: "random.int() max must be positive"}
 				}
-				return &object.Integer{Value: int64(rand.Intn(int(max)))}
+				return &object.Integer{Value: big.NewInt(int64(rand.Intn(int(max))))}
 			} else if len(args) == 2 {
 				min, err := getRandomNumber(args[0])
 				if err != nil {
@@ -60,7 +61,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				if max <= min {
 					return &object.Error{Code: "E8006", Message: "random.int() max must be greater than min"}
 				}
-				return &object.Integer{Value: int64(min) + int64(rand.Intn(int(max-min)))}
+				return &object.Integer{Value: big.NewInt(int64(min) + int64(rand.Intn(int(max-min))))}
 			}
 			return &object.Error{Code: "E7001", Message: "random.int() takes 1 or 2 arguments"}
 		},
@@ -104,7 +105,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				case *object.Char:
 					minVal = v.Value
 				case *object.Integer:
-					minVal = rune(v.Value)
+					minVal = rune(v.Value.Int64())
 				default:
 					return &object.Error{Code: "E7003", Message: "random.char() requires char or integer arguments"}
 				}
@@ -114,7 +115,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				case *object.Char:
 					maxVal = v.Value
 				case *object.Integer:
-					maxVal = rune(v.Value)
+					maxVal = rune(v.Value.Int64())
 				default:
 					return &object.Error{Code: "E7003", Message: "random.char() requires char or integer arguments"}
 				}
@@ -185,7 +186,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "random.sample() requires an integer as second argument"}
 			}
-			n := int(nObj.Value)
+			n := int(nObj.Value.Int64())
 
 			if n < 0 {
 				return &object.Error{Code: "E10001", Message: "random.sample() count cannot be negative"}
@@ -220,7 +221,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 func getRandomNumber(obj object.Object) (float64, *object.Error) {
 	switch v := obj.(type) {
 	case *object.Integer:
-		return float64(v.Value), nil
+		f, _ := new(big.Float).SetInt(v.Value).Float64()
+		return f, nil
 	case *object.Float:
 		return v.Value, nil
 	default:

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -4,6 +4,7 @@ package stdlib
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
+	"math/big"
 	"strings"
 	"unicode"
 
@@ -153,7 +154,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "strings.index() requires string arguments"}
 			}
-			return &object.Integer{Value: int64(strings.Index(str.Value, substr.Value))}
+			return &object.Integer{Value: big.NewInt(int64(strings.Index(str.Value, substr.Value)))}
 		},
 	},
 
@@ -210,10 +211,10 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "strings.repeat() requires an integer as second argument"}
 			}
-			if count.Value < 0 {
+			if count.Value.Sign() < 0 {
 				return &object.Error{Code: "E10001", Message: "strings.repeat() count cannot be negative"}
 			}
-			return &object.String{Value: strings.Repeat(str.Value, int(count.Value))}
+			return &object.String{Value: strings.Repeat(str.Value, int(count.Value.Int64()))}
 		},
 	},
 
@@ -235,7 +236,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			runes := []rune(str.Value)
 			runeLen := len(runes)
 
-			startIdx := int(start.Value)
+			startIdx := int(start.Value.Int64())
 			if startIdx < 0 {
 				startIdx = runeLen + startIdx
 			}
@@ -249,7 +250,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "strings.slice() requires integer indices"}
 				}
-				endIdx = int(end.Value)
+				endIdx = int(end.Value.Int64())
 				if endIdx < 0 {
 					endIdx = runeLen + endIdx
 				}
@@ -320,7 +321,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 					padChar = string(padRunes[0])
 				}
 			}
-			targetWidth := int(width.Value)
+			targetWidth := int(width.Value.Int64())
 			// Use rune count instead of byte length for proper UTF-8 handling
 			strRuneLen := len([]rune(str.Value))
 			if strRuneLen >= targetWidth {
@@ -356,7 +357,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 					padChar = string(padRunes[0])
 				}
 			}
-			targetWidth := int(width.Value)
+			targetWidth := int(width.Value.Int64())
 			// Use rune count instead of byte length for proper UTF-8 handling
 			strRuneLen := len([]rune(str.Value))
 			if strRuneLen >= targetWidth {
@@ -397,7 +398,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "strings.count() requires string arguments"}
 			}
-			return &object.Integer{Value: int64(strings.Count(str.Value, substr.Value))}
+			return &object.Integer{Value: big.NewInt(int64(strings.Count(str.Value, substr.Value)))}
 		},
 	},
 
@@ -474,7 +475,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "strings.last_index() requires string arguments"}
 			}
-			return &object.Integer{Value: int64(strings.LastIndex(str.Value, substr.Value))}
+			return &object.Integer{Value: big.NewInt(int64(strings.LastIndex(str.Value, substr.Value)))}
 		},
 	},
 
@@ -541,7 +542,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "strings.replace_n() requires an integer as fourth argument"}
 			}
-			return &object.String{Value: strings.Replace(str.Value, old.Value, newStr.Value, int(n.Value))}
+			return &object.String{Value: strings.Replace(str.Value, old.Value, newStr.Value, int(n.Value.Int64()))}
 		},
 	},
 
@@ -605,12 +606,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7003", Message: "strings.truncate() requires a string as third argument"}
 			}
 
-			if maxLen.Value < 0 {
+			if maxLen.Value.Sign() < 0 {
 				return &object.Error{Code: "E10001", Message: "strings.truncate() length cannot be negative"}
 			}
 
 			runes := []rune(str.Value)
-			targetLen := int(maxLen.Value)
+			targetLen := int(maxLen.Value.Int64())
 
 			if len(runes) <= targetLen {
 				return str
@@ -640,7 +641,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "strings.compare() requires string arguments"}
 			}
-			return &object.Integer{Value: int64(strings.Compare(a.Value, b.Value))}
+			return &object.Integer{Value: big.NewInt(int64(strings.Compare(a.Value, b.Value)))}
 		},
 	},
 }

--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -4,6 +4,7 @@ package stdlib
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/marshallburns/ez/pkg/object"
@@ -14,17 +15,17 @@ var TimeBuiltins = map[string]*object.Builtin{
 	// Current time
 	"time.now": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: time.Now().Unix()}
+			return &object.Integer{Value: big.NewInt(time.Now().Unix())}
 		},
 	},
 	"time.now_ms": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: time.Now().UnixMilli()}
+			return &object.Integer{Value: big.NewInt(time.Now().UnixMilli())}
 		},
 	},
 	"time.now_ns": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: time.Now().UnixNano()}
+			return &object.Integer{Value: big.NewInt(time.Now().UnixNano())}
 		},
 	},
 
@@ -36,7 +37,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 			}
 			switch v := args[0].(type) {
 			case *object.Integer:
-				time.Sleep(time.Duration(v.Value) * time.Second)
+				time.Sleep(time.Duration(v.Value.Int64()) * time.Second)
 			case *object.Float:
 				time.Sleep(time.Duration(v.Value * float64(time.Second)))
 			default:
@@ -54,7 +55,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.sleep_ms() requires an integer"}
 			}
-			time.Sleep(time.Duration(ms.Value) * time.Millisecond)
+			time.Sleep(time.Duration(ms.Value.Int64()) * time.Millisecond)
 			return object.NIL
 		},
 	},
@@ -63,43 +64,43 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Year())}
+			return &object.Integer{Value: big.NewInt(int64(t.Year()))}
 		},
 	},
 	"time.month": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Month())}
+			return &object.Integer{Value: big.NewInt(int64(t.Month()))}
 		},
 	},
 	"time.day": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Day())}
+			return &object.Integer{Value: big.NewInt(int64(t.Day()))}
 		},
 	},
 	"time.hour": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Hour())}
+			return &object.Integer{Value: big.NewInt(int64(t.Hour()))}
 		},
 	},
 	"time.minute": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Minute())}
+			return &object.Integer{Value: big.NewInt(int64(t.Minute()))}
 		},
 	},
 	"time.second": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Second())}
+			return &object.Integer{Value: big.NewInt(int64(t.Second()))}
 		},
 	},
 	"time.weekday": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.Weekday())}
+			return &object.Integer{Value: big.NewInt(int64(t.Weekday()))}
 		},
 	},
 	"time.weekday_name": {
@@ -117,7 +118,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.day_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
-			return &object.Integer{Value: int64(t.YearDay())}
+			return &object.Integer{Value: big.NewInt(int64(t.YearDay()))}
 		},
 	},
 
@@ -149,7 +150,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "time.format() requires an integer timestamp as second argument"}
 				}
-				t = time.Unix(ts.Value, 0)
+				t = time.Unix(ts.Value.Int64(), 0)
 			}
 
 			goFormat := convertFormat(format)
@@ -195,7 +196,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if err != nil {
 				return &object.Error{Code: "E11001", Message: "time.parse() failed: " + err.Error()}
 			}
-			return &object.Integer{Value: t.Unix()}
+			return &object.Integer{Value: big.NewInt(t.Unix())}
 		},
 	},
 
@@ -225,26 +226,26 @@ var TimeBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "time.make() requires integer arguments"}
 				}
-				hour = int(h.Value)
+				hour = int(h.Value.Int64())
 			}
 			if len(args) > 4 {
 				m, ok := args[4].(*object.Integer)
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "time.make() requires integer arguments"}
 				}
-				minute = int(m.Value)
+				minute = int(m.Value.Int64())
 			}
 			if len(args) > 5 {
 				s, ok := args[5].(*object.Integer)
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "time.make() requires integer arguments"}
 				}
-				second = int(s.Value)
+				second = int(s.Value.Int64())
 			}
 
-			t := time.Date(int(year.Value), time.Month(month.Value), int(day.Value),
+			t := time.Date(int(year.Value.Int64()), time.Month(month.Value.Int64()), int(day.Value.Int64()),
 				hour, minute, second, 0, time.Local)
-			return &object.Integer{Value: t.Unix()}
+			return &object.Integer{Value: big.NewInt(t.Unix())}
 		},
 	},
 
@@ -262,7 +263,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_seconds() requires integer seconds"}
 			}
-			return &object.Integer{Value: ts.Value + secs.Value}
+			result := new(big.Int).Add(ts.Value, secs.Value)
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.add_minutes": {
@@ -278,7 +280,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_minutes() requires integer minutes"}
 			}
-			return &object.Integer{Value: ts.Value + mins.Value*60}
+			result := new(big.Int).Add(ts.Value, new(big.Int).Mul(mins.Value, big.NewInt(60)))
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.add_hours": {
@@ -294,7 +297,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_hours() requires integer hours"}
 			}
-			return &object.Integer{Value: ts.Value + hours.Value*3600}
+			result := new(big.Int).Add(ts.Value, new(big.Int).Mul(hours.Value, big.NewInt(3600)))
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.add_days": {
@@ -310,7 +314,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_days() requires integer days"}
 			}
-			return &object.Integer{Value: ts.Value + days.Value*86400}
+			result := new(big.Int).Add(ts.Value, new(big.Int).Mul(days.Value, big.NewInt(86400)))
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.add_weeks": {
@@ -326,7 +331,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_weeks() requires integer weeks"}
 			}
-			return &object.Integer{Value: ts.Value + weeks.Value*604800}
+			result := new(big.Int).Add(ts.Value, new(big.Int).Mul(weeks.Value, big.NewInt(604800)))
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.add_months": {
@@ -342,12 +348,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_months() requires integer months"}
 			}
-			t := time.Unix(ts.Value, 0)
+			t := time.Unix(ts.Value.Int64(), 0)
 			originalDay := t.Day()
 
 			// Move to target month (first of month to avoid overflow issues)
 			targetYear := t.Year()
-			targetMonth := int(t.Month()) + int(months.Value)
+			targetMonth := int(t.Month()) + int(months.Value.Int64())
 
 			// Normalize month/year
 			for targetMonth > 12 {
@@ -370,7 +376,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 
 			result := time.Date(targetYear, time.Month(targetMonth), day,
 				t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
-			return &object.Integer{Value: result.Unix()}
+			return &object.Integer{Value: big.NewInt(result.Unix())}
 		},
 	},
 	"time.add_years": {
@@ -386,9 +392,9 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.add_years() requires integer years"}
 			}
-			t := time.Unix(ts.Value, 0)
-			t = t.AddDate(int(years.Value), 0, 0)
-			return &object.Integer{Value: t.Unix()}
+			t := time.Unix(ts.Value.Int64(), 0)
+			t = t.AddDate(int(years.Value.Int64()), 0, 0)
+			return &object.Integer{Value: big.NewInt(t.Unix())}
 		},
 	},
 
@@ -406,7 +412,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.diff() requires integer timestamps"}
 			}
-			return &object.Integer{Value: ts1.Value - ts2.Value}
+			result := new(big.Int).Sub(ts1.Value, ts2.Value)
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.diff_days": {
@@ -422,7 +429,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.diff_days() requires integer timestamps"}
 			}
-			return &object.Integer{Value: (ts1.Value - ts2.Value) / 86400}
+			result := new(big.Int).Quo(new(big.Int).Sub(ts1.Value, ts2.Value), big.NewInt(86400))
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.diff_hours": {
@@ -438,7 +446,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.diff_hours() requires integer timestamps"}
 			}
-			return &object.Integer{Value: (ts1.Value - ts2.Value) / 3600}
+			result := new(big.Int).Quo(new(big.Int).Sub(ts1.Value, ts2.Value), big.NewInt(3600))
+			return &object.Integer{Value: result}
 		},
 	},
 	"time.diff_minutes": {
@@ -454,7 +463,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.diff_minutes() requires integer timestamps"}
 			}
-			return &object.Integer{Value: (ts1.Value - ts2.Value) / 60}
+			result := new(big.Int).Quo(new(big.Int).Sub(ts1.Value, ts2.Value), big.NewInt(60))
+			return &object.Integer{Value: result}
 		},
 	},
 
@@ -472,7 +482,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.is_before() requires integer timestamps"}
 			}
-			if ts1.Value < ts2.Value {
+			if ts1.Value.Cmp(ts2.Value) < 0 {
 				return object.TRUE
 			}
 			return object.FALSE
@@ -491,7 +501,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.is_after() requires integer timestamps"}
 			}
-			if ts1.Value > ts2.Value {
+			if ts1.Value.Cmp(ts2.Value) > 0 {
 				return object.TRUE
 			}
 			return object.FALSE
@@ -508,7 +518,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.utc_offset": {
 		Fn: func(args ...object.Object) object.Object {
 			_, offset := time.Now().Zone()
-			return &object.Integer{Value: int64(offset)}
+			return &object.Integer{Value: big.NewInt(int64(offset))}
 		},
 	},
 
@@ -523,7 +533,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "time.is_leap_year() requires an integer year"}
 				}
-				year = int(y.Value)
+				year = int(y.Value.Int64())
 			}
 			if year%4 == 0 && (year%100 != 0 || year%400 == 0) {
 				return object.TRUE
@@ -547,14 +557,14 @@ var TimeBuiltins = map[string]*object.Builtin{
 				if !ok {
 					return &object.Error{Code: "E7004", Message: "time.days_in_month() requires integer arguments"}
 				}
-				year = int(y.Value)
-				month = int(m.Value)
+				year = int(y.Value.Int64())
+				month = int(m.Value.Int64())
 			} else {
 				return &object.Error{Code: "E7001", Message: "time.days_in_month() takes 0 or 2 arguments"}
 			}
 
 			t := time.Date(year, time.Month(month+1), 0, 0, 0, 0, 0, time.UTC)
-			return &object.Integer{Value: int64(t.Day())}
+			return &object.Integer{Value: big.NewInt(int64(t.Day()))}
 		},
 	},
 
@@ -563,42 +573,42 @@ var TimeBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			start := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
-			return &object.Integer{Value: start.Unix()}
+			return &object.Integer{Value: big.NewInt(start.Unix())}
 		},
 	},
 	"time.end_of_day": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			end := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
-			return &object.Integer{Value: end.Unix()}
+			return &object.Integer{Value: big.NewInt(end.Unix())}
 		},
 	},
 	"time.start_of_month": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			start := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
-			return &object.Integer{Value: start.Unix()}
+			return &object.Integer{Value: big.NewInt(start.Unix())}
 		},
 	},
 	"time.end_of_month": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			end := time.Date(t.Year(), t.Month()+1, 0, 23, 59, 59, 0, t.Location())
-			return &object.Integer{Value: end.Unix()}
+			return &object.Integer{Value: big.NewInt(end.Unix())}
 		},
 	},
 	"time.start_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			start := time.Date(t.Year(), 1, 1, 0, 0, 0, 0, t.Location())
-			return &object.Integer{Value: start.Unix()}
+			return &object.Integer{Value: big.NewInt(start.Unix())}
 		},
 	},
 	"time.end_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			end := time.Date(t.Year(), 12, 31, 23, 59, 59, 0, t.Location())
-			return &object.Integer{Value: end.Unix()}
+			return &object.Integer{Value: big.NewInt(end.Unix())}
 		},
 	},
 
@@ -608,21 +618,21 @@ var TimeBuiltins = map[string]*object.Builtin{
 			t := getTime(args)
 			month := int(t.Month())
 			quarter := (month-1)/3 + 1
-			return &object.Integer{Value: int64(quarter)}
+			return &object.Integer{Value: big.NewInt(int64(quarter))}
 		},
 	},
 	"time.week_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			_, week := t.ISOWeek()
-			return &object.Integer{Value: int64(week)}
+			return &object.Integer{Value: big.NewInt(int64(week))}
 		},
 	},
 
 	// Timing/benchmarking
 	"time.tick": {
 		Fn: func(args ...object.Object) object.Object {
-			return &object.Integer{Value: time.Now().UnixNano()}
+			return &object.Integer{Value: big.NewInt(time.Now().UnixNano())}
 		},
 	},
 	"time.elapsed_ms": {
@@ -634,7 +644,7 @@ var TimeBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "time.elapsed_ms() requires integer tick"}
 			}
-			elapsed := time.Now().UnixNano() - start.Value
+			elapsed := time.Now().UnixNano() - start.Value.Int64()
 			return &object.Float{Value: float64(elapsed) / 1e6}
 		},
 	},
@@ -646,7 +656,7 @@ func getTime(args []object.Object) time.Time {
 		return time.Now()
 	}
 	if ts, ok := args[0].(*object.Integer); ok {
-		return time.Unix(ts.Value, 0)
+		return time.Unix(ts.Value.Int64(), 0)
 	}
 	return time.Now()
 }

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5,6 +5,7 @@ package typechecker
 
 import (
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -881,10 +882,10 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 			// Check byte value range for single byte declaration
 			if declaredType == "byte" {
 				if intLit, ok := decl.Value.(*ast.IntegerValue); ok {
-					if intLit.Value < 0 || intLit.Value > 255 {
+					if intLit.Value.Sign() < 0 || intLit.Value.Cmp(big.NewInt(255)) > 0 {
 						tc.addError(
 							errors.E3025,
-							fmt.Sprintf("byte value %d out of range: must be between 0 and 255", intLit.Value),
+							fmt.Sprintf("byte value %s out of range: must be between 0 and 255", intLit.Value.String()),
 							decl.Name.Token.Line,
 							decl.Name.Token.Column,
 						)
@@ -897,7 +898,7 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 						if intLit, ok := prefixExpr.Right.(*ast.IntegerValue); ok {
 							tc.addError(
 								errors.E3025,
-								fmt.Sprintf("byte value -%d out of range: must be between 0 and 255", intLit.Value),
+								fmt.Sprintf("byte value -%s out of range: must be between 0 and 255", intLit.Value.String()),
 								decl.Name.Token.Line,
 								decl.Name.Token.Column,
 							)
@@ -912,10 +913,10 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 				if arrLit, ok := decl.Value.(*ast.ArrayValue); ok {
 					for i, elem := range arrLit.Elements {
 						if intLit, ok := elem.(*ast.IntegerValue); ok {
-							if intLit.Value < 0 || intLit.Value > 255 {
+							if intLit.Value.Sign() < 0 || intLit.Value.Cmp(big.NewInt(255)) > 0 {
 								tc.addError(
 									errors.E3026,
-									fmt.Sprintf("byte array element [%d] value %d out of range: must be between 0 and 255", i, intLit.Value),
+									fmt.Sprintf("byte array element [%d] value %s out of range: must be between 0 and 255", i, intLit.Value.String()),
 									intLit.Token.Line,
 									intLit.Token.Column,
 								)
@@ -927,7 +928,7 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 								if intLit, ok := prefixExpr.Right.(*ast.IntegerValue); ok {
 									tc.addError(
 										errors.E3026,
-										fmt.Sprintf("byte array element [%d] value -%d out of range: must be between 0 and 255", i, intLit.Value),
+										fmt.Sprintf("byte array element [%d] value -%s out of range: must be between 0 and 255", i, intLit.Value.String()),
 										prefixExpr.Token.Line,
 										prefixExpr.Token.Column,
 									)

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1703,3 +1703,108 @@ func TestTypeErrorLocationMapValue(t *testing.T) {
 		}
 	}
 }
+
+// ============================================================================
+// Large Integer Type Tests (i128/u128)
+// ============================================================================
+
+func TestLargeIntegerTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			"i128 with large positive value",
+			`do main() {
+				temp x i128 = 10000000000000000000
+			}`,
+		},
+		{
+			"i128 with value larger than int64 max",
+			`do main() {
+				temp x i128 = 9223372036854775808
+			}`,
+		},
+		{
+			"u128 with large value",
+			`do main() {
+				temp x u128 = 18446744073709551615
+			}`,
+		},
+		{
+			"u128 with value larger than uint64 max",
+			`do main() {
+				temp x u128 = 18446744073709551616
+			}`,
+		},
+		{
+			"i128 with i128 max value",
+			`do main() {
+				temp x i128 = 170141183460469231731687303715884105727
+			}`,
+		},
+		{
+			"u128 with u128 max value",
+			`do main() {
+				temp x u128 = 340282366920938463463374607431768211455
+			}`,
+		},
+		{
+			"i128 arithmetic",
+			`do main() {
+				temp a i128 = 9223372036854775807
+				temp b i128 = 1
+				temp c i128 = a + b
+			}`,
+		},
+		{
+			"u128 arithmetic",
+			`do main() {
+				temp a u128 = 18446744073709551615
+				temp b u128 = 1
+				temp c u128 = a + b
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := typecheck(t, tt.input)
+			assertNoErrors(t, tc)
+		})
+	}
+}
+
+func TestLargeIntegerNegativeValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			"i128 with large negative value",
+			`do main() {
+				temp x i128 = -10000000000000000000
+			}`,
+		},
+		{
+			"i128 with value smaller than int64 min",
+			`do main() {
+				temp x i128 = -9223372036854775809
+			}`,
+		},
+		{
+			"i128 with i128 min value",
+			`do main() {
+				temp x i128 = -170141183460469231731687303715884105728
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := typecheck(t, tt.input)
+			assertNoErrors(t, tc)
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
- Replaces `int64` with `math/big.Int` for integer representation, enabling proper support for i128/u128 and other large integer types
- Adds type-aware overflow detection using DeclaredType bounds for arithmetic operations
- Updates all stdlib functions and tests to work with arbitrary precision integers

## Changes
- **Core**: Changed `Integer.Value` from `int64` to `*big.Int` in `object.go`
- **Parser**: Updated to use `big.Int.SetString()` for parsing integer literals of any size
- **Evaluator**: Modified arithmetic operations to use `big.Int` methods with proper overflow checking
- **Stdlib**: Updated all stdlib functions (arrays, builtins, bytes, io, math, os, random, strings, time) to work with `*big.Int`
- **Tests**: Added comprehensive unit tests for parser, typechecker, and evaluator; updated all existing tests for `big.Int` compatibility

## Test plan
- [x] All Go unit tests pass (`go test ./...`)
- [x] All 195 integration tests pass
- [x] Large integer parsing works (values > int64 max)
- [x] i128/u128 overflow detection works correctly
- [x] Arithmetic operations preserve precision

Closes #437