### PR TITLE
fix(parser): prevent unclosed brace error with return in if blocks

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -904,12 +904,13 @@ func (p *Parser) parseReturnStatement() *ReturnStatement {
 	stmt := &ReturnStatement{Token: p.currentToken}
 	stmt.Values = []Expression{}
 
-	p.nextToken()
-
-	// Check for empty return
-	if p.currentTokenMatches(RBRACE) || p.currentTokenMatches(EOF) {
+	// Check for empty return BEFORE advancing
+	// This prevents consuming the closing brace which would leave the block unclosed
+	if p.peekTokenMatches(RBRACE) || p.peekTokenMatches(EOF) || p.peekTokenMatches(NEWLINE) {
 		return stmt
 	}
+
+	p.nextToken() // Only advance if there's a value to parse
 
 	// Parse return values
 	stmt.Values = append(stmt.Values, p.parseExpression(LOWEST))


### PR DESCRIPTION
## Summary
- Fixes parser error when using `return` inside `if` blocks in void functions
- Fixes bare `return` statement causing subsequent functions to be parsed as nested
- Root cause: `parseReturnStatement()` was consuming the closing brace before the block parser could see it

## Test plan
- [x] Manual test: `return` inside `if` block now works correctly
- [x] Manual test: bare `return` in functions parses correctly
- [x] All parser unit tests pass
- [x] Integration tests pass (pre-existing `large-integers` failure unrelated)

Fixes #445
Fixes #442