### PR TITLE
fix(stdlib): use shared stdin reader for read_int()

### DIFF
--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -158,8 +158,7 @@ var StdBuiltins = map[string]*object.Builtin{
 	// Reads an integer from standard input
 	"read_int": {
 		Fn: func(args ...object.Object) object.Object {
-			reader := bufio.NewReader(os.Stdin)
-			text, readErr := reader.ReadString('\n')
+			text, readErr := stdinReader.ReadString('\n')
 			if len(text) > 0 && text[len(text)-1] == '\n' {
 				text = text[:len(text)-1]
 			}


### PR DESCRIPTION
## Summary
- `read_int()` was creating a new `bufio.Reader(os.Stdin)` on each call
- The first reader buffers data from stdin, but subsequent calls created new readers that lost access to the buffered data
- Fix: Use the existing package-level `stdinReader` instead of creating a new reader each time

## Test plan
- [x] Manual test: multiple `read_int()` calls now work correctly with piped input
- [x] All stdlib tests pass

Fixes #446