### PR TITLE
fix: resolve uppercase constants being parsed as struct literals (#462)

### DIFF
--- a/integration-tests/pass/core/constant-comparison.ez
+++ b/integration-tests/pass/core/constant-comparison.ez
@@ -1,0 +1,94 @@
+/*
+ * constant-comparison.ez - Test constants on right side of comparisons
+ * Regression test for bug #462
+ */
+
+import @std
+using std
+
+const MAX_VALUE int = 100
+const MIN_VALUE int = 0
+const THRESHOLD float = 3.14
+
+do main() {
+    println("=== Constant Comparison Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: constant on right side of > comparison
+    temp val1 int = 50
+    if val1 > MIN_VALUE {
+        println("  [PASS] val > MIN_VALUE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] val > MIN_VALUE")
+        failed += 1
+    }
+
+    // Test 2: constant on right side of < comparison
+    if val1 < MAX_VALUE {
+        println("  [PASS] val < MAX_VALUE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] val < MAX_VALUE")
+        failed += 1
+    }
+
+    // Test 3: constant on left side (should still work)
+    if MAX_VALUE > val1 {
+        println("  [PASS] MAX_VALUE > val")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] MAX_VALUE > val")
+        failed += 1
+    }
+
+    // Test 4: both sides are constants
+    if MAX_VALUE > MIN_VALUE {
+        println("  [PASS] MAX_VALUE > MIN_VALUE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] MAX_VALUE > MIN_VALUE")
+        failed += 1
+    }
+
+    // Test 5: constant in complex expression
+    temp val2 int = 25
+    if val1 + val2 > MIN_VALUE && val1 - val2 < MAX_VALUE {
+        println("  [PASS] complex expression with constants")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] complex expression with constants")
+        failed += 1
+    }
+
+    // Test 6: float constant comparison
+    temp pi float = 3.0
+    if pi < THRESHOLD {
+        println("  [PASS] float constant comparison")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] float constant comparison")
+        failed += 1
+    }
+
+    // Test 7: equality with constant
+    temp exact int = 100
+    if exact == MAX_VALUE {
+        println("  [PASS] equality with constant")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] equality with constant")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -79,6 +79,35 @@ func (l *Lexer) peekChar() byte {
 	return l.input[l.readPosition]
 }
 
+// LexerState holds the lexer state for save/restore operations
+type LexerState struct {
+	position     int
+	readPosition int
+	ch           byte
+	line         int
+	column       int
+}
+
+// SaveState returns the current lexer state for later restoration
+func (l *Lexer) SaveState() LexerState {
+	return LexerState{
+		position:     l.position,
+		readPosition: l.readPosition,
+		ch:           l.ch,
+		line:         l.line,
+		column:       l.column,
+	}
+}
+
+// RestoreState restores the lexer to a previously saved state
+func (l *Lexer) RestoreState(state LexerState) {
+	l.position = state.position
+	l.readPosition = state.readPosition
+	l.ch = state.ch
+	l.line = state.line
+	l.column = state.column
+}
+
 func (l *Lexer) NextToken() tokenizer.Token {
 	var tok tokenizer.Token
 


### PR DESCRIPTION
## Summary
- Fixes bug where uppercase constants on the right side of comparisons were incorrectly parsed as struct literals
- `if val > MAX_VALUE {` was failing because `MAX_VALUE {` was treated as a struct literal attempt

## Changes
- Added `SaveState()`/`RestoreState()` to Lexer for speculative lookahead
- Added `looksLikeStructLiteral()` helper to distinguish struct literals from block braces
- Struct literals require `{}` or `{field: ...}` pattern; block braces don't match

## Test plan
- [x] Added regression test `integration-tests/pass/core/constant-comparison.ez`
- [x] All 196 integration tests pass
- [x] All Go unit tests pass

- Fixes #462 