### PR TITLE
fix: handle module-prefixed types in type compatibility checks (#463)

### DIFF
--- a/integration-tests/pass/multi-file/module-prefix-type/main.ez
+++ b/integration-tests/pass/multi-file/module-prefix-type/main.ez
@@ -1,0 +1,44 @@
+/*
+ * main.ez - Test module-prefixed types in return annotations
+ * Regression test for bug #463
+ */
+import @std
+import "./testmod"
+
+using std
+
+do main() {
+    println("=== Module Prefix Type Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: Function with module-prefixed return type
+    temp hero1 = testmod.make_hero()
+    if hero1.name == "Test Hero" && hero1.lvl == 1 {
+        println("  [PASS] module-prefixed return type")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] module-prefixed return type")
+        failed += 1
+    }
+
+    // Test 2: Function with non-prefixed return type
+    temp hero2 = testmod.make_hero_direct()
+    if hero2.name == "Direct Hero" && hero2.lvl == 2 {
+        println("  [PASS] non-prefixed return type")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] non-prefixed return type")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/multi-file/module-prefix-type/testmod/helpers.ez
+++ b/integration-tests/pass/multi-file/module-prefix-type/testmod/helpers.ez
@@ -1,0 +1,19 @@
+/*
+ * helpers.ez - Helper functions with module-prefixed return types
+ * Regression test for bug #463
+ */
+module testmod
+
+do make_hero() -> testmod.Hero {
+    temp h = new(Hero)
+    h.name = "Test Hero"
+    h.lvl = 1
+    return h
+}
+
+do make_hero_direct() -> Hero {
+    temp h = new(Hero)
+    h.name = "Direct Hero"
+    h.lvl = 2
+    return h
+}

--- a/integration-tests/pass/multi-file/module-prefix-type/testmod/types.ez
+++ b/integration-tests/pass/multi-file/module-prefix-type/testmod/types.ez
@@ -1,0 +1,10 @@
+/*
+ * types.ez - Type definitions for module prefix test
+ * Regression test for bug #463
+ */
+module testmod
+
+const Hero struct {
+    name string
+    lvl u8
+}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2296,6 +2296,15 @@ func typeMatches(obj Object, ezType string) bool {
 		return true
 	}
 
+	// Handle module-prefixed types (e.g., utils.Hero vs Hero)
+	// Strip module prefix and compare base type names
+	actualBase := stripModulePrefix(actualType)
+	expectedBase := stripModulePrefix(ezType)
+	if actualBase == expectedBase && (actualBase != actualType || expectedBase != ezType) {
+		// Base names match and at least one had a module prefix
+		return true
+	}
+
 	// Integer family compatibility rules
 	if isIntegerType(actualType) && isIntegerType(ezType) {
 		// Within same family: always OK
@@ -2326,6 +2335,15 @@ func typeMatches(obj Object, ezType string) bool {
 	}
 
 	return false
+}
+
+// stripModulePrefix removes the module prefix from a type name
+// e.g., "utils.Hero" -> "Hero", "Hero" -> "Hero"
+func stripModulePrefix(typeName string) string {
+	if idx := strings.LastIndex(typeName, "."); idx != -1 {
+		return typeName[idx+1:]
+	}
+	return typeName
 }
 
 // objectTypeToEZ converts Object type to EZ language type name

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2524,6 +2524,15 @@ func (tc *TypeChecker) typesCompatible(declared, actual string) bool {
 		return true
 	}
 
+	// Handle module-prefixed types (e.g., utils.Hero vs Hero)
+	// Strip module prefix and compare base type names
+	declaredBase := tc.stripModulePrefix(declared)
+	actualBase := tc.stripModulePrefix(actual)
+	if declaredBase == actualBase && declaredBase != declared {
+		// Base names match and at least one had a module prefix
+		return true
+	}
+
 	// nil is only compatible with reference types (arrays, maps, structs)
 	// Primitive types (int, float, string, bool, char, byte) cannot be nil
 	if actual == "nil" {
@@ -2613,6 +2622,15 @@ func (tc *TypeChecker) typesCompatible(declared, actual string) bool {
 	}
 
 	return false
+}
+
+// stripModulePrefix removes the module prefix from a type name
+// e.g., "utils.Hero" -> "Hero", "Hero" -> "Hero"
+func (tc *TypeChecker) stripModulePrefix(typeName string) string {
+	if idx := strings.LastIndex(typeName, "."); idx != -1 {
+		return typeName[idx+1:]
+	}
+	return typeName
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Fixes bug where `utils.Hero` and `Hero` were treated as incompatible types
- Resolves return type mismatch errors when using module-prefixed return annotations

## Changes
- Added `stripModulePrefix()` to typechecker and interpreter
- Both `typesCompatible()` and `typeMatches()` now normalize type names before comparison

## Test plan
- [x] Added regression test `integration-tests/pass/multi-file/module-prefix-type/`
- [x] All 197 integration tests pass
- [x] All Go unit tests pass

Closes #463