### PR TITLE
test: add regression test for for_each with module constants (#465)

### DIFF
--- a/integration-tests/pass/multi-file/foreach-module-constant/main.ez
+++ b/integration-tests/pass/multi-file/foreach-module-constant/main.ez
@@ -1,0 +1,40 @@
+/*
+ * Test for_each with same-module array constants
+ * Regression test for bug #465
+ */
+import @std
+import "./testmod"
+
+using std
+
+do main() {
+    println("=== For_each Module Constant Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: for_each over string array constant
+    println("Items:")
+    testmod.print_items()
+    println("  [PASS] for_each over string array")
+    passed += 1
+
+    // Test 2: for_each over int array constant with accumulation
+    temp sum = testmod.sum_numbers()
+    if sum == 100 {
+        println("  [PASS] for_each over int array (sum=${sum})")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] for_each over int array: expected 100, got ${sum}")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/multi-file/foreach-module-constant/testmod/constants.ez
+++ b/integration-tests/pass/multi-file/foreach-module-constant/testmod/constants.ez
@@ -1,0 +1,4 @@
+module testmod
+
+const ITEMS [string, 3] = {"apple", "banana", "cherry"}
+const NUMBERS [int, 4] = {10, 20, 30, 40}

--- a/integration-tests/pass/multi-file/foreach-module-constant/testmod/helpers.ez
+++ b/integration-tests/pass/multi-file/foreach-module-constant/testmod/helpers.ez
@@ -1,0 +1,18 @@
+module testmod
+
+import @std
+using std
+
+do print_items() {
+    for_each item in ITEMS {
+        println(item)
+    }
+}
+
+do sum_numbers() -> int {
+    temp total int = 0
+    for_each n in NUMBERS {
+        total += n
+    }
+    return total
+}


### PR DESCRIPTION
## Summary
Issue #465 was already fixed by the struct literal parsing fix in PR #467.

This PR adds a regression test to ensure `for_each` continues to work with same-module array constants.

## Root Cause
The original bug had the same root cause as #462 - uppercase constants followed by `{` were incorrectly parsed as struct literals. The fix in #467 resolved both issues.

## Test plan
- [x] Added regression test `integration-tests/pass/multi-file/foreach-module-constant/`
- [x] All 198 integration tests pass

Closes #465