### PR TITLE
fix: suppress module name warning for files in matching directories (#464)

### DIFF
--- a/integration-tests/pass/multi-file/no-warning-matching-dir/main.ez
+++ b/integration-tests/pass/multi-file/no-warning-matching-dir/main.ez
@@ -1,0 +1,34 @@
+/*
+ * Test that no W4001 warning is shown for files in matching directory
+ * Regression test for bug #464
+ */
+import @std
+import "./mymod"
+
+using std
+
+do main() {
+    println("=== No Warning Matching Dir Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test that module works correctly (no warnings should be shown)
+    temp val = mymod.get_value()
+    if val == 42 {
+        println("  [PASS] multi-file module works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] multi-file module: expected 42, got ${val}")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/multi-file/no-warning-matching-dir/mymod/helpers.ez
+++ b/integration-tests/pass/multi-file/no-warning-matching-dir/mymod/helpers.ez
@@ -1,0 +1,5 @@
+module mymod
+
+do get_value() -> int {
+    return VALUE
+}

--- a/integration-tests/pass/multi-file/no-warning-matching-dir/mymod/types.ez
+++ b/integration-tests/pass/multi-file/no-warning-matching-dir/mymod/types.ez
@@ -1,0 +1,3 @@
+module mymod
+
+const VALUE int = 42

--- a/pkg/interpreter/loader.go
+++ b/pkg/interpreter/loader.go
@@ -208,7 +208,10 @@ func (l *ModuleLoader) loadFileModule(mod *Module, filePath string) error {
 	if program.Module != nil {
 		mod.Name = program.Module.Name.Value
 		// Warn if declared name doesn't match filename
-		if mod.Name != fileName {
+		// But don't warn if the file is in a directory that matches the module name
+		// (this supports multi-file modules where files are in a module directory)
+		parentDir := filepath.Base(filepath.Dir(filePath))
+		if mod.Name != fileName && mod.Name != parentDir {
 			l.AddWarning(fmt.Sprintf("warning[W4001]: module declares name '%s' but file is named '%s.ez'\n  --> %s\n  = help: consider renaming the module or file to match",
 				mod.Name, fileName, filePath))
 		}


### PR DESCRIPTION
## Summary
- Fixes spurious W4001 warning for files in multi-file modules
- `mymod/helpers.ez` declaring `module mymod` no longer warns about name mismatch

## Changes
- Updated `loadFileModule()` to check if parent directory matches module name
- Added unit test `TestLoadModuleNameNoWarningWhenInMatchingDir`
- Added integration test `integration-tests/pass/multi-file/no-warning-matching-dir/`

## Test plan
- [x] Unit test for no warning when parent dir matches module name
- [x] Existing warning test still passes (warning shown when no match)
- [x] All 199 integration tests pass
- [x] All Go unit tests pass

Closes #464