### PR TITLE
fix: auto-elevate to sudo when update needs root permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This will check for new versions, show the changelog, and prompt you to upgrade.
 
 If you're upgrading from **v0.17.1 or earlier**, you'll need to manually update once:
 
+**macOS/Linux:**
 ```bash
 # macOS (Apple Silicon)
 curl -L https://github.com/SchoolyB/EZ/releases/latest/download/ez-darwin-arm64.tar.gz | tar xz
@@ -67,6 +68,17 @@ sudo mv ez /usr/local/bin/ez
 # Linux (ARM64)
 curl -L https://github.com/SchoolyB/EZ/releases/latest/download/ez-linux-arm64.tar.gz | tar xz
 sudo mv ez /usr/local/bin/ez
+```
+
+**Windows (PowerShell as Administrator):**
+```powershell
+# Download and extract
+Invoke-WebRequest -Uri "https://github.com/SchoolyB/EZ/releases/latest/download/ez-windows-amd64.zip" -OutFile ez.zip
+Expand-Archive ez.zip -DestinationPath .
+Remove-Item ez.zip
+
+# Move to a directory in your PATH (e.g., C:\Program Files\ez)
+Move-Item ez.exe "C:\Program Files\ez\ez.exe"
 ```
 
 After this one-time manual update, `ez update` will work automatically for all future versions.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,42 @@ For pre-built binaries and installation instructions, visit the [documentation](
 
 ---
 
+## Updating
+
+EZ includes a built-in update command:
+
+```bash
+ez update
+```
+
+This will check for new versions, show the changelog, and prompt you to upgrade. If EZ is installed in a system directory (like `/usr/local/bin`), it will automatically prompt for your password.
+
+### Upgrading from v0.17.1 or earlier
+
+If you're upgrading from **v0.17.1 or earlier**, you'll need to manually update once:
+
+```bash
+# macOS (Apple Silicon)
+curl -L https://github.com/SchoolyB/EZ/releases/latest/download/ez-darwin-arm64.tar.gz | tar xz
+sudo mv ez /usr/local/bin/ez
+
+# macOS (Intel)
+curl -L https://github.com/SchoolyB/EZ/releases/latest/download/ez-darwin-amd64.tar.gz | tar xz
+sudo mv ez /usr/local/bin/ez
+
+# Linux (x86_64)
+curl -L https://github.com/SchoolyB/EZ/releases/latest/download/ez-linux-amd64.tar.gz | tar xz
+sudo mv ez /usr/local/bin/ez
+
+# Linux (ARM64)
+curl -L https://github.com/SchoolyB/EZ/releases/latest/download/ez-linux-arm64.tar.gz | tar xz
+sudo mv ez /usr/local/bin/ez
+```
+
+After this one-time manual update, `ez update` will work automatically for all future versions.
+
+---
+
 ## Running Tests
 
 EZ has two types of tests: **EZ language tests** (written in EZ) and **Go unit tests** (for the interpreter internals).

--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -41,7 +41,7 @@ func main() {
 	case "version", "-v", "--version":
 		printVersion()
 	case "update":
-		runUpdate()
+		runUpdate(os.Args[2:])
 	case "repl":
 		startREPL()
 	case "check", "build":


### PR DESCRIPTION
## Summary
- Fix `ez update` failing with "permission denied" when installed in `/usr/local/bin`
- Automatically detect when elevated permissions are needed
- Re-exec with `sudo` to prompt user for password

## Changes
- Add `checkWritePermission()` to test write access before downloading
- If permission denied on Unix, re-exec with `sudo ez update --confirm <url>`
- On Windows, show error message to run as Administrator
- `runUpdate()` now accepts args to handle `--confirm` flag for sudo re-exec

## Test plan
- [x] All 200 integration tests pass
- [x] Manual test: install to `/usr/local/bin`, run `ez update`, should prompt for sudo password