### PR TITLE
feat: add default parameter values for functions (#312)

### DIFF
--- a/integration-tests/fail/errors/E2039_required_after_default.ez
+++ b/integration-tests/fail/errors/E2039_required_after_default.ez
@@ -1,0 +1,10 @@
+// E2039: required parameter after parameter with default value
+
+do bad_func(x int = 10, y int) {
+    // This should fail - y is required but comes after x which has a default
+    println(x + y)
+}
+
+do main() {
+    bad_func(5, 10)
+}

--- a/integration-tests/fail/errors/E2040_mutable_with_default.ez
+++ b/integration-tests/fail/errors/E2040_mutable_with_default.ez
@@ -1,0 +1,12 @@
+// E2040: mutable parameter cannot have default value
+
+do bad_func(&x int = 10) {
+    // This should fail - mutable params can't have defaults
+    x = x + 1
+    println(x)
+}
+
+do main() {
+    temp val int = 5
+    bad_func(val)
+}

--- a/integration-tests/pass/core/default-params.ez
+++ b/integration-tests/pass/core/default-params.ez
@@ -1,0 +1,156 @@
+/*
+ * default-params.ez - Test default parameter values for functions
+ */
+
+import @std
+using std
+
+// Test basic default parameter
+do greet(name string = "World") -> string {
+    return "Hello, ${name}!"
+}
+
+// Test multiple parameters with some having defaults
+do create_player(name string, health int = 100, mana int = 50) -> string {
+    return "${name}: HP=${health}, MP=${mana}"
+}
+
+// Test all parameters with defaults
+do config(debug bool = false, verbose bool = true, level int = 1) -> string {
+    return "debug=${debug}, verbose=${verbose}, level=${level}"
+}
+
+// Test expression as default value
+do calculate(multiplier float = 3.14 * 2.0) -> float {
+    return multiplier
+}
+
+// Test grouped params where only last gets default: x is required, y defaults to 0
+do point(x, y int = 0) -> string {
+    return "(${x}, ${y})"
+}
+
+do main() {
+    println("=== Default Parameters Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: greet with default
+    temp result1 = greet()
+    if result1 == "Hello, World!" {
+        println("  [PASS] greet() uses default")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] greet() expected 'Hello, World!', got '${result1}'")
+        failed += 1
+    }
+
+    // Test 2: greet with provided value
+    temp result2 = greet("Alice")
+    if result2 == "Hello, Alice!" {
+        println("  [PASS] greet('Alice') uses provided value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] greet('Alice') expected 'Hello, Alice!', got '${result2}'")
+        failed += 1
+    }
+
+    // Test 3: create_player with only required arg
+    temp player1 = create_player("Hero")
+    if player1 == "Hero: HP=100, MP=50" {
+        println("  [PASS] create_player('Hero') uses defaults")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] create_player('Hero') expected 'Hero: HP=100, MP=50', got '${player1}'")
+        failed += 1
+    }
+
+    // Test 4: create_player with health provided
+    temp player2 = create_player("Boss", 200)
+    if player2 == "Boss: HP=200, MP=50" {
+        println("  [PASS] create_player('Boss', 200) uses default for mana")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] expected 'Boss: HP=200, MP=50', got '${player2}'")
+        failed += 1
+    }
+
+    // Test 5: create_player with all args
+    temp player3 = create_player("Wizard", 80, 150)
+    if player3 == "Wizard: HP=80, MP=150" {
+        println("  [PASS] create_player('Wizard', 80, 150) uses all provided")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] expected 'Wizard: HP=80, MP=150', got '${player3}'")
+        failed += 1
+    }
+
+    // Test 6: all defaults
+    temp cfg1 = config()
+    if cfg1 == "debug=false, verbose=true, level=1" {
+        println("  [PASS] config() uses all defaults")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] config() expected 'debug=false, verbose=true, level=1', got '${cfg1}'")
+        failed += 1
+    }
+
+    // Test 7: partial override
+    temp cfg2 = config(true)
+    if cfg2 == "debug=true, verbose=true, level=1" {
+        println("  [PASS] config(true) overrides first param")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] config(true) expected 'debug=true, verbose=true, level=1', got '${cfg2}'")
+        failed += 1
+    }
+
+    // Test 8: expression default
+    temp calc1 = calculate()
+    if calc1 >= 6.28 && calc1 < 6.29 {
+        println("  [PASS] calculate() evaluates expression default")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] calculate() expected ~6.28, got ${calc1}")
+        failed += 1
+    }
+
+    // Test 9: expression default with provided value
+    temp calc2 = calculate(2.0)
+    if calc2 == 2.0 {
+        println("  [PASS] calculate(2.0) uses provided value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] calculate(2.0) expected 2.0, got ${calc2}")
+        failed += 1
+    }
+
+    // Test 10: grouped params - x is required, y has default
+    temp pt1 = point(5)
+    if pt1 == "(5, 0)" {
+        println("  [PASS] point(5) uses default for y")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] point(5) expected '(5, 0)', got '${pt1}'")
+        failed += 1
+    }
+
+    // Test 11: grouped params - both provided
+    temp pt2 = point(3, 4)
+    if pt2 == "(3, 4)" {
+        println("  [PASS] point(3, 4) uses both provided")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] point(3, 4) expected '(3, 4)', got '${pt2}'")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("All tests passed!")
+    }
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -419,9 +419,10 @@ func (f *FunctionDeclaration) TokenLiteral() string { return f.Token.Literal }
 
 // Parameter represents a function parameter
 type Parameter struct {
-	Name     *Label
-	TypeName string
-	Mutable  bool // true if declared with & prefix
+	Name         *Label
+	TypeName     string
+	Mutable      bool       // true if declared with & prefix
+	DefaultValue Expression // nil if no default value
 }
 
 // ImportItem represents a single module import with optional alias

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -74,6 +74,8 @@ var (
 	E2036 = ErrorCode{"E2036", "import-inside-block", "import must be at file level"}
 	E2037 = ErrorCode{"E2037", "reserved-struct-name", "struct name is reserved"}
 	E2038 = ErrorCode{"E2038", "reserved-enum-name", "enum name is reserved"}
+	E2039 = ErrorCode{"E2039", "required-after-default", "required parameter after parameter with default"}
+	E2040 = ErrorCode{"E2040", "mutable-with-default", "mutable parameter cannot have default value"}
 )
 
 // =============================================================================

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1808,3 +1808,111 @@ func TestLargeIntegerNegativeValues(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// DEFAULT PARAMETER TESTS
+// =============================================================================
+
+func TestDefaultParameterBasic(t *testing.T) {
+	input := `
+	do greet(name string = "World") {
+		println(name)
+	}
+	do main() {
+		greet()
+		greet("Alice")
+	}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestDefaultParameterMixedRequiredAndOptional(t *testing.T) {
+	input := `
+	do create(name string, health int = 100, mana int = 50) {
+		println(name)
+	}
+	do main() {
+		create("Hero")
+		create("Boss", 200)
+		create("Wizard", 80, 150)
+	}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestDefaultParameterAllOptional(t *testing.T) {
+	input := `
+	do config(debug bool = false, level int = 1) {
+		println(debug)
+	}
+	do main() {
+		config()
+		config(true)
+		config(true, 5)
+	}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestDefaultParameterExpressionDefault(t *testing.T) {
+	input := `
+	do calc(mult float = 3.14 * 2.0) -> float {
+		return mult
+	}
+	do main() {
+		temp a = calc()
+		temp b = calc(10.0)
+	}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestDefaultParameterGroupedParams(t *testing.T) {
+	// x, y int = 0 means x is required, y has default
+	input := `
+	do point(x, y int = 0) {
+		println(x + y)
+	}
+	do main() {
+		point(5)
+		point(3, 4)
+	}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestDefaultParameterTooFewArgs(t *testing.T) {
+	input := `
+	do create(name string, health int = 100) {
+		println(name)
+	}
+	do main() {
+		create()
+	}`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E5008)
+}
+
+func TestDefaultParameterTooManyArgs(t *testing.T) {
+	input := `
+	do greet(name string = "World") {
+		println(name)
+	}
+	do main() {
+		greet("Alice", "extra")
+	}`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E5008)
+}
+
+func TestDefaultParameterWithReturnType(t *testing.T) {
+	input := `
+	do greet(name string = "World") -> string {
+		return "Hello, ${name}!"
+	}
+	do main() {
+		temp msg1 = greet()
+		temp msg2 = greet("Alice")
+	}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}


### PR DESCRIPTION
## Summary
- Add support for optional default values in function parameters
- Functions can now define defaults for trailing parameters: `do greet(name string = "World") { ... }`
- Callers can omit arguments with defaults: `greet()` uses "World", `greet("Alice")` uses "Alice"

## Design Decisions
| Decision | Choice | Rationale |
|----------|--------|-----------|
| Required params after defaults? | Disallow (E2039) | Standard convention, avoids ambiguity |
| Defaults on `&` params? | Disallow (E2040) | Can't take reference to a literal |
| Grouped params `a, b int = 0`? | Only last gets default | Clear semantics |
| Default expressions | Any expression | Evaluated at call time in function's closure |

## Changes
- `pkg/ast/ast.go`: Add `DefaultValue` field to Parameter struct
- `pkg/parser/parser.go`: Parse `= expr` after param type, validate ordering
- `pkg/errors/codes.go`: Add E2039 (required-after-default), E2040 (mutable-with-default)
- `pkg/typechecker/typechecker.go`: Calculate minRequired args, validate counts
- `pkg/interpreter/evaluator.go`: Fill defaults for missing args at runtime

## Test Coverage
- **Parser**: 9 unit tests for syntax parsing
- **Typechecker**: 8 unit tests for validation
- **Interpreter**: 13 unit tests for runtime behavior  
- **Integration**: 3 tests (pass + fail cases)

All tests pass:
- 203 integration tests ✅
- All Go unit tests ✅

## Test Plan
- [x] Verify basic default works: `greet()` uses "World"
- [x] Verify override works: `greet("Alice")` uses "Alice"
- [x] Verify multiple defaults: `create("Hero")` uses defaults for health/mana
- [x] Verify grouped params: `point(5)` uses default y=0
- [x] Verify expression default: `calc()` evaluates `3.14 * 2.0`
- [x] Verify E2039 on required after default
- [x] Verify E2040 on mutable with default

Closes #312