### PR TITLE
fix: correct error codes for immutable variable/map errors

### DIFF
--- a/integration-tests/fail/errors/E12002_map_immutable.ez
+++ b/integration-tests/fail/errors/E12002_map_immutable.ez
@@ -6,6 +6,6 @@
 import @maps
 
 do main() {
-    const m = maps.from_pairs({{"key", "value"}})
+    const m map[string:string] = {"key": "value"}
     maps.set(m, "new_key", "new_value")  // cannot modify const map
 }

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -977,7 +977,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 		if ident, ok := target.Left.(*ast.Label); ok {
 			isMutable, exists := env.IsMutable(ident.Value)
 			if exists && !isMutable {
-				return newErrorWithLocation("E5014", node.Token.Line, node.Token.Column,
+				return newErrorWithLocation("E5006", node.Token.Line, node.Token.Column,
 					"cannot modify immutable variable '%s' (declared as const)", ident.Value)
 			}
 		}
@@ -1066,7 +1066,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 
 			// Check if map is mutable
 			if !obj.Mutable {
-				return newErrorWithLocation("E5014", node.Token.Line, node.Token.Column,
+				return newErrorWithLocation("E12002", node.Token.Line, node.Token.Column,
 					"cannot modify immutable map (declared as const)")
 			}
 

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -85,7 +85,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12003",
+					Code:    "E12002",
 				}
 			}
 			key := args[1]
@@ -109,7 +109,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12003",
+					Code:    "E12002",
 				}
 			}
 			key := args[1]
@@ -136,7 +136,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12003",
+					Code:    "E12002",
 				}
 			}
 			m.Pairs = []*object.MapPair{}
@@ -287,7 +287,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12003",
+					Code:    "E12002",
 				}
 			}
 			m.Set(key, args[2])
@@ -308,7 +308,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !m.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12003",
+					Code:    "E12002",
 				}
 			}
 			key := args[1]
@@ -336,7 +336,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			if !target.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12003",
+					Code:    "E12002",
 				}
 			}
 			// Merge all source maps into target


### PR DESCRIPTION
## Summary
- Change E5014 to E5006 for general immutable variable modification
- Change E12003 to E12002 for immutable map modification
- Fix E12002_map_immutable.ez test to use valid syntax

## Details
The error codes were inconsistent with their definitions:

| Error | Correct Meaning | Was Used For |
|-------|-----------------|--------------|
| E5006 | immutable-variable | *(not used)* |
| E5014 | range-end-not-integer | immutable variable ❌ |
| E12002 | map-immutable | *(not used)* |
| E12003 | map-key-not-found | immutable map ❌ |

### Files Changed
- `pkg/interpreter/evaluator.go`: Fix error codes for index assignment on immutable containers
- `pkg/stdlib/maps.go`: Fix error codes for maps.set, maps.delete, maps.clear, maps.remove, maps.update, maps.get_default
- `integration-tests/fail/errors/E12002_map_immutable.ez`: Fix test to use valid const map syntax

## Test Plan
- [x] All 203 integration tests pass
- [x] All Go unit tests pass
- [x] E12002 test correctly triggers map-immutable error