### PR TITLE
fix: restrict `@suppress` attribute to function declarations only (#507)

### DIFF
--- a/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
+++ b/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E2051 - suppress-invalid-target
+ * Expected: "@suppress can only be applied to function declarations"
+ */
+
+module main
+
+@suppress(W1001)
+const x = 5  // @suppress on variable declaration is not allowed
+
+do main() {
+    println(x)
+}

--- a/integration-tests/fail/errors/E2052_suppress_invalid_code.ez
+++ b/integration-tests/fail/errors/E2052_suppress_invalid_code.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E2052 - suppress-invalid-code
+ * Expected: "is not a valid warning code"
+ */
+
+module main
+
+@suppress(W9999)
+do foo() {
+    // W9999 does not exist
+}
+
+do main() {
+    foo()
+}

--- a/integration-tests/fail/errors/E2052_suppress_non_suppressible.ez
+++ b/integration-tests/fail/errors/E2052_suppress_non_suppressible.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E2052 - suppress-invalid-code (non-suppressible)
+ * Expected: "warning code W1002 cannot be suppressed"
+ */
+
+module main
+
+@suppress(W1002)
+do foo() {
+    // W1002 (unused-import) is a valid code but cannot be suppressed
+}
+
+do main() {
+    foo()
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -86,6 +86,8 @@ var (
 	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean. Use if/or/otherwise instead"}
 	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil. Use if/otherwise to check for nil"}
 	E2050 = ErrorCode{"E2050", "when-collection-condition", "when condition cannot be an array or map"}
+	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "@suppress can only be applied to function declarations"}
+	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds E2051 error when `@suppress` is applied to non-function declarations
- Adds E2052 error for invalid or non-suppressible warning codes
- Defines which warnings are suppressible (function-body warnings) vs non-suppressible (structural/module-level)

## Test plan
- [x] Integration tests added for E2051 and E2052
- [x] All 216 integration tests pass
- [x] `go test ./...` passes

Closes #507