### PR TITLE
fix: report E4001 for undefined variables in function calls and returns (#509)

### DIFF
--- a/integration-tests/fail/errors/E4001_undefined_var_in_call.ez
+++ b/integration-tests/fail/errors/E4001_undefined_var_in_call.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E4001 - undefined-variable (in function call argument)
+ * Expected: "undefined variable"
+ */
+
+module main
+
+do greet(name string) {
+    println(name)
+}
+
+do main() {
+    greet(undefinedVar)  // 'undefinedVar' is not defined
+}


### PR DESCRIPTION
## Summary
- Adds E4001 error when undefined variables are used as function call arguments
- Adds E4001 error when undefined variables are used in return statements
- Properly distinguishes between truly undefined variables vs variables with inferred types

## Test plan
- [x] Integration test added for E4001 undefined variable in function call
- [x] All 217 integration tests pass
- [x] `go test ./...` passes
- [x] `ez check main.ez` now catches `return x` where x is undefined

Closes #509