### PR TITLE
fix: change `@(strict)` syntax to `@strict` for when statements (#510)

### DIFF
--- a/integration-tests/fail/errors/E2042_when_strict_has_default.ez
+++ b/integration-tests/fail/errors/E2042_when_strict_has_default.ez
@@ -1,4 +1,4 @@
-// E2042: @(strict) when statement cannot have a default case
+// E2042: @strict when statement cannot have a default case
 import @std
 using std
 
@@ -10,7 +10,7 @@ const Status enum {
 do main() {
     temp s = Status.PENDING
 
-    @(strict)
+    @strict
     when s {
         is Status.PENDING { println("pending") }
         is Status.ACTIVE { println("active") }

--- a/integration-tests/fail/errors/E2045_when_strict_non_enum.ez
+++ b/integration-tests/fail/errors/E2045_when_strict_non_enum.ez
@@ -1,10 +1,10 @@
-// E2045: @(strict) attribute only allowed on enum when statements
+// E2045: @strict attribute only allowed on enum when statements
 import @std
 using std
 
 do main() {
     temp x = 1
-    @(strict)
+    @strict
     when x {
         is 1 { println("one") }
         is 2 { println("two") }

--- a/integration-tests/pass/core/when-statements.ez
+++ b/integration-tests/pass/core/when-statements.ez
@@ -109,7 +109,7 @@ do test_strict_enum() {
     temp s = Status.DONE
     temp result = ""
 
-    @(strict)
+    @strict
     when s {
         is Status.PENDING { result = "pending" }
         is Status.ACTIVE { result = "active" }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -359,8 +359,8 @@ type WhenStatement struct {
 	Value      Expression      // The value being matched
 	Cases      []*WhenCase     // All is cases
 	Default    *BlockStatement // Required default case
-	IsStrict   bool            // true if @(strict) attribute present
-	Attributes []*Attribute    // Any attributes like @(strict)
+	IsStrict   bool            // true if @strict attribute present
+	Attributes []*Attribute    // Any attributes like @strict
 }
 
 func (ws *WhenStatement) statementNode()       {}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -249,6 +249,16 @@ func (l *Lexer) NextToken() tokenizer.Token {
 			}
 			return tok
 		}
+		// Peek ahead to check for @strict
+		if l.peekAheadString(7) == "@strict" {
+			// Found @strict
+			tok = tokenizer.Token{Type: tokenizer.STRICT, Literal: "@strict", Line: l.line, Column: l.column}
+			// Consume the entire @strict token
+			for i := 0; i < 7; i++ {
+				l.readChar()
+			}
+			return tok
+		}
 		// Just a regular @ symbol (e.g., for imports like @std)
 		tok = newToken(tokenizer.AT, l.ch, l.line, l.column)
 	case '"':

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -106,6 +106,7 @@ const (
 	FALSE      TokenType = "FALSE"
 	BLANK      TokenType = "BLANK" // _ blank identifier
 	SUPPRESS   TokenType = "SUPPRESS"
+	STRICT     TokenType = "STRICT"
 
 	// Module system keywords
 	MODULE  TokenType = "MODULE"

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1853,17 +1853,17 @@ func (tc *TypeChecker) checkWhenStatement(whenStmt *ast.WhenStatement, expectedR
 	// Track seen case values for duplicate detection
 	seenCases := make(map[string]bool)
 
-	// Check if this is an enum type for @(strict) validation
+	// Check if this is an enum type for @strict validation
 	enumTypeInfo, isEnumType := tc.GetType(valueType)
 	if isEnumType && enumTypeInfo != nil && enumTypeInfo.Kind != EnumType {
 		isEnumType = false
 	}
 
-	// Validate @(strict) is only used with enums
+	// Validate @strict is only used with enums
 	if whenStmt.IsStrict && !isEnumType {
 		tc.addError(
 			errors.E2045,
-			"@(strict) attribute only allowed on enum when statements",
+			"@strict attribute only allowed on enum when statements",
 			whenStmt.Token.Line,
 			whenStmt.Token.Column,
 		)
@@ -1914,7 +1914,7 @@ func (tc *TypeChecker) checkWhenStatement(whenStmt *ast.WhenStatement, expectedR
 		tc.exitScope()
 	}
 
-	// Note: @(strict) enum exhaustiveness check is enforced at runtime
+	// Note: @strict enum exhaustiveness check is enforced at runtime
 	// A full compile-time check would require tracking enum members in the type system
 
 	// Check the default block if present


### PR DESCRIPTION
## Summary
- Add STRICT token type to tokenizer
- Add @strict recognition in lexer using peekAheadString()
- Update parser to handle @strict attribute with new parseStrictAttribute() function
- Update error messages and comments to reference @strict instead of @(strict)
- Update integration tests to use new syntax

Closes #510

## Test plan
- [x] All 217 integration tests pass
- [x] @strict syntax works in when statements
- [x] Old @(strict) syntax no longer works (as expected)