### PR TITLE
refactor: simplify enum attribute system to @enum(type) and @flags (#511)

### DIFF
--- a/integration-tests/pass/core/enums.ez
+++ b/integration-tests/pass/core/enums.ez
@@ -5,7 +5,7 @@
 import @std
 using std
 
-/* Basic int enum (auto-incremented) */
+/* Basic int enum (auto-incremented 0, 1, 2, 3) */
 const Direction enum {
     NORTH
     EAST
@@ -13,13 +13,13 @@ const Direction enum {
     WEST
 }
 
-/* Int enum with skip attribute */
-@(int, skip, 10)
-const Priority enum {
-    LOW       // 0
-    MEDIUM    // 10
-    HIGH      // 20
-    CRITICAL  // 30
+/* Flags enum with power-of-2 values (1, 2, 4, 8) */
+@flags
+const Permissions enum {
+    READ      // 1
+    WRITE     // 2
+    EXECUTE   // 4
+    DELETE    // 8
 }
 
 /* String enum with explicit values */
@@ -27,6 +27,14 @@ const Status enum {
     TODO = "todo"
     IN_PROGRESS = "in_progress"
     DONE = "done"
+}
+
+/* Explicit int enum (same as default) */
+@enum(int)
+const Priority enum {
+    LOW       // 0
+    MEDIUM    // 1
+    HIGH      // 2
 }
 
 do main() {
@@ -65,33 +73,33 @@ do main() {
         failed += 1
     }
 
-    // ==================== ENUM WITH SKIP ====================
-    println("  -- Enum with Skip Attribute --")
+    // ==================== FLAGS ENUM ====================
+    println("  -- Flags Enum (power-of-2) --")
 
-    // Test 4: first value is still 0
-    if Priority.LOW == 0 {
-        println("  [PASS] Priority.LOW = 0")
+    // Test 4: first flag value is 1
+    if Permissions.READ == 1 {
+        println("  [PASS] Permissions.READ = 1")
         passed += 1
     } otherwise {
-        println("  [FAIL] Priority.LOW: expected 0, got ${Priority.LOW}")
+        println("  [FAIL] Permissions.READ: expected 1, got ${Permissions.READ}")
         failed += 1
     }
 
-    // Test 5: skip by 10
-    if Priority.MEDIUM == 10 {
-        println("  [PASS] Priority.MEDIUM = 10 (skip 10)")
+    // Test 5: power-of-2 values
+    if Permissions.WRITE == 2 {
+        println("  [PASS] Permissions.WRITE = 2")
         passed += 1
     } otherwise {
-        println("  [FAIL] Priority.MEDIUM: expected 10, got ${Priority.MEDIUM}")
+        println("  [FAIL] Permissions.WRITE: expected 2, got ${Permissions.WRITE}")
         failed += 1
     }
 
-    // Test 6: continue skipping
-    if Priority.HIGH == 20 && Priority.CRITICAL == 30 {
-        println("  [PASS] Priority.HIGH=20, CRITICAL=30")
+    // Test 6: continue power-of-2
+    if Permissions.EXECUTE == 4 && Permissions.DELETE == 8 {
+        println("  [PASS] Permissions.EXECUTE=4, DELETE=8")
         passed += 1
     } otherwise {
-        println("  [FAIL] skip enum: HIGH=${Priority.HIGH}, CRITICAL=${Priority.CRITICAL}")
+        println("  [FAIL] flags enum: EXECUTE=${Permissions.EXECUTE}, DELETE=${Permissions.DELETE}")
         failed += 1
     }
 
@@ -126,25 +134,28 @@ do main() {
         failed += 1
     }
 
+    // ==================== EXPLICIT INT ENUM ====================
+    println("  -- Explicit @enum(int) --")
+
+    // Test 10: @enum(int) works like default
+    if Priority.LOW == 0 && Priority.MEDIUM == 1 && Priority.HIGH == 2 {
+        println("  [PASS] @enum(int) auto-increment (0, 1, 2)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] @enum(int): LOW=${Priority.LOW}, MEDIUM=${Priority.MEDIUM}, HIGH=${Priority.HIGH}")
+        failed += 1
+    }
+
     // ==================== ENUM COMPARISON ====================
     println("  -- Enum Comparison --")
 
-    // Test 10: compare enum values
+    // Test 11: compare enum values
     temp priority int = Priority.HIGH
     if priority >= Priority.MEDIUM {
         println("  [PASS] enum comparison (HIGH >= MEDIUM)")
         passed += 1
     } otherwise {
         println("  [FAIL] enum comparison")
-        failed += 1
-    }
-
-    // Test 11: enum equality
-    if priority == Priority.HIGH {
-        println("  [PASS] enum equality check")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] enum equality")
         failed += 1
     }
 

--- a/integration-tests/pass/multi-file/basic/models.ez
+++ b/integration-tests/pass/multi-file/basic/models.ez
@@ -12,13 +12,12 @@ import @std
 // ENUMS
 // ==================================================
 
-/* Priority levels with skip attribute */
-@(int, skip, 10)
+/* Priority levels (auto-increment: 0, 1, 2, 3) */
 const Priority enum {
     LOW       // 0
-    MEDIUM    // 10
-    HIGH      // 20
-    CRITICAL  // 30
+    MEDIUM    // 1
+    HIGH      // 2
+    CRITICAL  // 3
 }
 
 /* Task status as string enum */
@@ -62,11 +61,11 @@ const TaskStats struct {
 do get_priority_name(priority int) -> string {
     if priority == 0 {
         return "Low"
-    } or priority == 10 {
+    } or priority == 1 {
         return "Medium"
-    } or priority == 20 {
+    } or priority == 2 {
         return "High"
-    } or priority == 30 {
+    } or priority == 3 {
         return "Critical"
     } otherwise {
         return "Unknown"
@@ -96,5 +95,5 @@ do is_complete(task Task) -> bool {
 
 /* is_high_priority - Check if task is high priority or above */
 do is_high_priority(task Task) -> bool {
-    return task.priority >= 20
+    return task.priority >= 2
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -515,9 +515,8 @@ type EnumValue struct {
 	Value Expression // optional explicit value
 }
 
-// EnumAttributes represents @(type, skip, increment)
+// EnumAttributes represents @enum(type) or @flags
 type EnumAttributes struct {
-	TypeName  string
-	Skip      bool
-	Increment Expression
+	TypeName string // "int", "float", or "string"
+	IsFlags  bool   // true if @flags attribute present (power-of-2 values)
 }

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -472,7 +472,7 @@ func TestEnumDeclarationStructure(t *testing.T) {
 		},
 		Attributes: &EnumAttributes{
 			TypeName: "int",
-			Skip:     true,
+			IsFlags:  true,
 		},
 	}
 

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -259,6 +259,26 @@ func (l *Lexer) NextToken() tokenizer.Token {
 			}
 			return tok
 		}
+		// Peek ahead to check for @flags
+		if l.peekAheadString(6) == "@flags" {
+			// Found @flags
+			tok = tokenizer.Token{Type: tokenizer.FLAGS, Literal: "@flags", Line: l.line, Column: l.column}
+			// Consume the entire @flags token
+			for i := 0; i < 6; i++ {
+				l.readChar()
+			}
+			return tok
+		}
+		// Peek ahead to check for @enum
+		if l.peekAheadString(5) == "@enum" {
+			// Found @enum
+			tok = tokenizer.Token{Type: tokenizer.ENUM_ATTR, Literal: "@enum", Line: l.line, Column: l.column}
+			// Consume the entire @enum token
+			for i := 0; i < 5; i++ {
+				l.readChar()
+			}
+			return tok
+		}
 		// Just a regular @ symbol (e.g., for imports like @std)
 		tok = newToken(tokenizer.AT, l.ch, l.line, l.column)
 	case '"':

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -107,6 +107,8 @@ const (
 	BLANK      TokenType = "BLANK" // _ blank identifier
 	SUPPRESS   TokenType = "SUPPRESS"
 	STRICT     TokenType = "STRICT"
+	ENUM_ATTR  TokenType = "ENUM_ATTR" // @enum(type)
+	FLAGS      TokenType = "FLAGS"     // @flags
 
 	// Module system keywords
 	MODULE  TokenType = "MODULE"


### PR DESCRIPTION
## Summary
- Remove `@(type, skip, increment)` anonymous attribute syntax for enums
- Add `@enum(type)` for specifying enum type (int, float, string)
- Add `@flags` for power-of-2 enum values (1, 2, 4, 8, ...)
- Update parser, interpreter, and tests for new syntax

## New Syntax Examples

```ez
// Default int enum (0, 1, 2, ...)
const Direction enum {
    NORTH
    EAST
    SOUTH
    WEST
}

// Explicit type with @enum(type)
@enum(int)
const Priority enum {
    LOW     // 0
    MEDIUM  // 1
    HIGH    // 2
}

// Flags enum with power-of-2 values
@flags
const Permissions enum {
    READ      // 1
    WRITE     // 2
    EXECUTE   // 4
    DELETE    // 8
}

// String enum (requires explicit values)
const Status enum {
    TODO = "todo"
    DONE = "done"
}
```

## Breaking Change
`@(type, skip, increment)` syntax is no longer supported. Use `@enum(type)` or `@flags` instead.

Closes #511

## Test plan
- [x] All 217 integration tests pass
- [x] New @enum(type) syntax works correctly
- [x] @flags generates power-of-2 values
- [x] Old @(...) syntax generates appropriate errors