### PR TITLE
fix: recognize types from 'import & use' modules in return types (#513)

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -354,6 +354,12 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) bool {
 					moduleName = item.Module
 				}
 				tc.modules[moduleName] = true
+
+				// If this is an "import & use" statement, also register for file-level using
+				// This allows unqualified access to types from the module
+				if importStmt.AutoUse {
+					tc.fileUsingModules[moduleName] = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
When using `import & use` syntax, the typechecker now correctly registers the module in `fileUsingModules`, allowing unqualified types to be resolved in return type declarations.

## Before
```ez
import & use lib"./library"

do create_hero() -> Hero {  // ❌ Error: undefined return type 'Hero'
    return new(Hero)
}
```

## After
```ez
import & use lib"./library"

do create_hero() -> Hero {  // ✅ Works correctly
    return new(Hero)
}
```

## Changes
- Added check for `importStmt.AutoUse` in Phase 0 of `CheckProgram`
- When `AutoUse` is true, register the module in `tc.fileUsingModules`

Closes #513

## Test plan
- [x] All 217 integration tests pass
- [x] Manual test confirms `-> Hero` works with `import & use`