### PR TITLE
patch: December 12, 2025 bug fixes and improvements

### DIFF
--- a/integration-tests/fail/errors/E2042_when_strict_has_default.ez
+++ b/integration-tests/fail/errors/E2042_when_strict_has_default.ez
@@ -1,4 +1,4 @@
-// E2042: @(strict) when statement cannot have a default case
+// E2042: @strict when statement cannot have a default case
 import @std
 using std
 
@@ -10,7 +10,7 @@ const Status enum {
 do main() {
     temp s = Status.PENDING
 
-    @(strict)
+    @strict
     when s {
         is Status.PENDING { println("pending") }
         is Status.ACTIVE { println("active") }

--- a/integration-tests/fail/errors/E2045_when_strict_non_enum.ez
+++ b/integration-tests/fail/errors/E2045_when_strict_non_enum.ez
@@ -1,10 +1,10 @@
-// E2045: @(strict) attribute only allowed on enum when statements
+// E2045: @strict attribute only allowed on enum when statements
 import @std
 using std
 
 do main() {
     temp x = 1
-    @(strict)
+    @strict
     when x {
         is 1 { println("one") }
         is 2 { println("two") }

--- a/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
+++ b/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E2051 - suppress-invalid-target
+ * Expected: "@suppress can only be applied to function declarations"
+ */
+
+module main
+
+@suppress(W1001)
+const x = 5  // @suppress on variable declaration is not allowed
+
+do main() {
+    println(x)
+}

--- a/integration-tests/fail/errors/E2052_suppress_invalid_code.ez
+++ b/integration-tests/fail/errors/E2052_suppress_invalid_code.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E2052 - suppress-invalid-code
+ * Expected: "is not a valid warning code"
+ */
+
+module main
+
+@suppress(W9999)
+do foo() {
+    // W9999 does not exist
+}
+
+do main() {
+    foo()
+}

--- a/integration-tests/fail/errors/E2052_suppress_non_suppressible.ez
+++ b/integration-tests/fail/errors/E2052_suppress_non_suppressible.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E2052 - suppress-invalid-code (non-suppressible)
+ * Expected: "warning code W1002 cannot be suppressed"
+ */
+
+module main
+
+@suppress(W1002)
+do foo() {
+    // W1002 (unused-import) is a valid code but cannot be suppressed
+}
+
+do main() {
+    foo()
+}

--- a/integration-tests/fail/errors/E4001_undefined_var_in_call.ez
+++ b/integration-tests/fail/errors/E4001_undefined_var_in_call.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E4001 - undefined-variable (in function call argument)
+ * Expected: "undefined variable"
+ */
+
+module main
+
+do greet(name string) {
+    println(name)
+}
+
+do main() {
+    greet(undefinedVar)  // 'undefinedVar' is not defined
+}

--- a/integration-tests/pass/core/enums.ez
+++ b/integration-tests/pass/core/enums.ez
@@ -5,7 +5,7 @@
 import @std
 using std
 
-/* Basic int enum (auto-incremented) */
+/* Basic int enum (auto-incremented 0, 1, 2, 3) */
 const Direction enum {
     NORTH
     EAST
@@ -13,13 +13,13 @@ const Direction enum {
     WEST
 }
 
-/* Int enum with skip attribute */
-@(int, skip, 10)
-const Priority enum {
-    LOW       // 0
-    MEDIUM    // 10
-    HIGH      // 20
-    CRITICAL  // 30
+/* Flags enum with power-of-2 values (1, 2, 4, 8) */
+@flags
+const Permissions enum {
+    READ      // 1
+    WRITE     // 2
+    EXECUTE   // 4
+    DELETE    // 8
 }
 
 /* String enum with explicit values */
@@ -27,6 +27,14 @@ const Status enum {
     TODO = "todo"
     IN_PROGRESS = "in_progress"
     DONE = "done"
+}
+
+/* Explicit int enum (same as default) */
+@enum(int)
+const Priority enum {
+    LOW       // 0
+    MEDIUM    // 1
+    HIGH      // 2
 }
 
 do main() {
@@ -65,33 +73,33 @@ do main() {
         failed += 1
     }
 
-    // ==================== ENUM WITH SKIP ====================
-    println("  -- Enum with Skip Attribute --")
+    // ==================== FLAGS ENUM ====================
+    println("  -- Flags Enum (power-of-2) --")
 
-    // Test 4: first value is still 0
-    if Priority.LOW == 0 {
-        println("  [PASS] Priority.LOW = 0")
+    // Test 4: first flag value is 1
+    if Permissions.READ == 1 {
+        println("  [PASS] Permissions.READ = 1")
         passed += 1
     } otherwise {
-        println("  [FAIL] Priority.LOW: expected 0, got ${Priority.LOW}")
+        println("  [FAIL] Permissions.READ: expected 1, got ${Permissions.READ}")
         failed += 1
     }
 
-    // Test 5: skip by 10
-    if Priority.MEDIUM == 10 {
-        println("  [PASS] Priority.MEDIUM = 10 (skip 10)")
+    // Test 5: power-of-2 values
+    if Permissions.WRITE == 2 {
+        println("  [PASS] Permissions.WRITE = 2")
         passed += 1
     } otherwise {
-        println("  [FAIL] Priority.MEDIUM: expected 10, got ${Priority.MEDIUM}")
+        println("  [FAIL] Permissions.WRITE: expected 2, got ${Permissions.WRITE}")
         failed += 1
     }
 
-    // Test 6: continue skipping
-    if Priority.HIGH == 20 && Priority.CRITICAL == 30 {
-        println("  [PASS] Priority.HIGH=20, CRITICAL=30")
+    // Test 6: continue power-of-2
+    if Permissions.EXECUTE == 4 && Permissions.DELETE == 8 {
+        println("  [PASS] Permissions.EXECUTE=4, DELETE=8")
         passed += 1
     } otherwise {
-        println("  [FAIL] skip enum: HIGH=${Priority.HIGH}, CRITICAL=${Priority.CRITICAL}")
+        println("  [FAIL] flags enum: EXECUTE=${Permissions.EXECUTE}, DELETE=${Permissions.DELETE}")
         failed += 1
     }
 
@@ -126,25 +134,28 @@ do main() {
         failed += 1
     }
 
+    // ==================== EXPLICIT INT ENUM ====================
+    println("  -- Explicit @enum(int) --")
+
+    // Test 10: @enum(int) works like default
+    if Priority.LOW == 0 && Priority.MEDIUM == 1 && Priority.HIGH == 2 {
+        println("  [PASS] @enum(int) auto-increment (0, 1, 2)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] @enum(int): LOW=${Priority.LOW}, MEDIUM=${Priority.MEDIUM}, HIGH=${Priority.HIGH}")
+        failed += 1
+    }
+
     // ==================== ENUM COMPARISON ====================
     println("  -- Enum Comparison --")
 
-    // Test 10: compare enum values
+    // Test 11: compare enum values
     temp priority int = Priority.HIGH
     if priority >= Priority.MEDIUM {
         println("  [PASS] enum comparison (HIGH >= MEDIUM)")
         passed += 1
     } otherwise {
         println("  [FAIL] enum comparison")
-        failed += 1
-    }
-
-    // Test 11: enum equality
-    if priority == Priority.HIGH {
-        println("  [PASS] enum equality check")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] enum equality")
         failed += 1
     }
 

--- a/integration-tests/pass/core/when-statements.ez
+++ b/integration-tests/pass/core/when-statements.ez
@@ -109,7 +109,7 @@ do test_strict_enum() {
     temp s = Status.DONE
     temp result = ""
 
-    @(strict)
+    @strict
     when s {
         is Status.PENDING { result = "pending" }
         is Status.ACTIVE { result = "active" }

--- a/integration-tests/pass/multi-file/basic/models.ez
+++ b/integration-tests/pass/multi-file/basic/models.ez
@@ -12,13 +12,12 @@ import @std
 // ENUMS
 // ==================================================
 
-/* Priority levels with skip attribute */
-@(int, skip, 10)
+/* Priority levels (auto-increment: 0, 1, 2, 3) */
 const Priority enum {
     LOW       // 0
-    MEDIUM    // 10
-    HIGH      // 20
-    CRITICAL  // 30
+    MEDIUM    // 1
+    HIGH      // 2
+    CRITICAL  // 3
 }
 
 /* Task status as string enum */
@@ -62,11 +61,11 @@ const TaskStats struct {
 do get_priority_name(priority int) -> string {
     if priority == 0 {
         return "Low"
-    } or priority == 10 {
+    } or priority == 1 {
         return "Medium"
-    } or priority == 20 {
+    } or priority == 2 {
         return "High"
-    } or priority == 30 {
+    } or priority == 3 {
         return "Critical"
     } otherwise {
         return "Unknown"
@@ -96,5 +95,5 @@ do is_complete(task Task) -> bool {
 
 /* is_high_priority - Check if task is high priority or above */
 do is_high_priority(task Task) -> bool {
-    return task.priority >= 20
+    return task.priority >= 2
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -515,9 +515,8 @@ type EnumValue struct {
 	Value Expression // optional explicit value
 }
 
-// EnumAttributes represents @(type, skip, increment)
+// EnumAttributes represents @enum(type) or @flags
 type EnumAttributes struct {
-	TypeName  string
-	Skip      bool
-	Increment Expression
+	TypeName string // "int", "float", or "string"
+	IsFlags  bool   // true if @flags attribute present (power-of-2 values)
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -359,8 +359,8 @@ type WhenStatement struct {
 	Value      Expression      // The value being matched
 	Cases      []*WhenCase     // All is cases
 	Default    *BlockStatement // Required default case
-	IsStrict   bool            // true if @(strict) attribute present
-	Attributes []*Attribute    // Any attributes like @(strict)
+	IsStrict   bool            // true if @strict attribute present
+	Attributes []*Attribute    // Any attributes like @strict
 }
 
 func (ws *WhenStatement) statementNode()       {}

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -472,7 +472,7 @@ func TestEnumDeclarationStructure(t *testing.T) {
 		},
 		Attributes: &EnumAttributes{
 			TypeName: "int",
-			Skip:     true,
+			IsFlags:  true,
 		},
 	}
 

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -86,6 +86,8 @@ var (
 	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean. Use if/or/otherwise instead"}
 	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil. Use if/otherwise to check for nil"}
 	E2050 = ErrorCode{"E2050", "when-collection-condition", "when condition cannot be an array or map"}
+	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "@suppress can only be applied to function declarations"}
+	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}
 )
 
 // =============================================================================

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -259,6 +259,26 @@ func (l *Lexer) NextToken() tokenizer.Token {
 			}
 			return tok
 		}
+		// Peek ahead to check for @flags
+		if l.peekAheadString(6) == "@flags" {
+			// Found @flags
+			tok = tokenizer.Token{Type: tokenizer.FLAGS, Literal: "@flags", Line: l.line, Column: l.column}
+			// Consume the entire @flags token
+			for i := 0; i < 6; i++ {
+				l.readChar()
+			}
+			return tok
+		}
+		// Peek ahead to check for @enum
+		if l.peekAheadString(5) == "@enum" {
+			// Found @enum
+			tok = tokenizer.Token{Type: tokenizer.ENUM_ATTR, Literal: "@enum", Line: l.line, Column: l.column}
+			// Consume the entire @enum token
+			for i := 0; i < 5; i++ {
+				l.readChar()
+			}
+			return tok
+		}
 		// Just a regular @ symbol (e.g., for imports like @std)
 		tok = newToken(tokenizer.AT, l.ch, l.line, l.column)
 	case '"':

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -249,6 +249,16 @@ func (l *Lexer) NextToken() tokenizer.Token {
 			}
 			return tok
 		}
+		// Peek ahead to check for @strict
+		if l.peekAheadString(7) == "@strict" {
+			// Found @strict
+			tok = tokenizer.Token{Type: tokenizer.STRICT, Literal: "@strict", Line: l.line, Column: l.column}
+			// Consume the entire @strict token
+			for i := 0; i < 7; i++ {
+				l.readChar()
+			}
+			return tok
+		}
 		// Just a regular @ symbol (e.g., for imports like @std)
 		tok = newToken(tokenizer.AT, l.ch, l.line, l.column)
 	case '"':

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -107,6 +107,8 @@ const (
 	BLANK      TokenType = "BLANK" // _ blank identifier
 	SUPPRESS   TokenType = "SUPPRESS"
 	STRICT     TokenType = "STRICT"
+	ENUM_ATTR  TokenType = "ENUM_ATTR" // @enum(type)
+	FLAGS      TokenType = "FLAGS"     // @flags
 
 	// Module system keywords
 	MODULE  TokenType = "MODULE"

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -106,6 +106,7 @@ const (
 	FALSE      TokenType = "FALSE"
 	BLANK      TokenType = "BLANK" // _ blank identifier
 	SUPPRESS   TokenType = "SUPPRESS"
+	STRICT     TokenType = "STRICT"
 
 	// Module system keywords
 	MODULE  TokenType = "MODULE"

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1853,17 +1853,17 @@ func (tc *TypeChecker) checkWhenStatement(whenStmt *ast.WhenStatement, expectedR
 	// Track seen case values for duplicate detection
 	seenCases := make(map[string]bool)
 
-	// Check if this is an enum type for @(strict) validation
+	// Check if this is an enum type for @strict validation
 	enumTypeInfo, isEnumType := tc.GetType(valueType)
 	if isEnumType && enumTypeInfo != nil && enumTypeInfo.Kind != EnumType {
 		isEnumType = false
 	}
 
-	// Validate @(strict) is only used with enums
+	// Validate @strict is only used with enums
 	if whenStmt.IsStrict && !isEnumType {
 		tc.addError(
 			errors.E2045,
-			"@(strict) attribute only allowed on enum when statements",
+			"@strict attribute only allowed on enum when statements",
 			whenStmt.Token.Line,
 			whenStmt.Token.Column,
 		)
@@ -1914,7 +1914,7 @@ func (tc *TypeChecker) checkWhenStatement(whenStmt *ast.WhenStatement, expectedR
 		tc.exitScope()
 	}
 
-	// Note: @(strict) enum exhaustiveness check is enforced at runtime
+	// Note: @strict enum exhaustiveness check is enforced at runtime
 	// A full compile-time check would require tracking enum members in the type system
 
 	// Check the default block if present

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -354,6 +354,12 @@ func (tc *TypeChecker) CheckProgram(program *ast.Program) bool {
 					moduleName = item.Module
 				}
 				tc.modules[moduleName] = true
+
+				// If this is an "import & use" statement, also register for file-level using
+				// This allows unqualified access to types from the module
+				if importStmt.AutoUse {
+					tc.fileUsingModules[moduleName] = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This patch includes bug fixes and improvements from December 12, 2025.

## Changes

### Bug Fixes
- **#507**: Restrict `@suppress` attribute to function declarations only
- **#509**: Report E4001 for undefined variables in function calls and returns
- **#513**: Recognize types from `import & use` modules in return type declarations

### Improvements
- **#510**: Change `@(strict)` syntax to `@strict` for when statements
- **#511**: Simplify enum attribute system to `@enum(type)` and `@flags`
- **#512**: Add `@flags` attribute for bitwise flag enums (power-of-2 values)

## Breaking Changes

- `@(strict)` syntax is replaced by `@strict`
- `@(type, skip, increment)` enum syntax is replaced by `@enum(type)` and `@flags`

## Closes

Closes #507, #509, #510, #511, #512, #513