### PR TITLE
fix: W2006 byte overflow warning now applies to byte() calls (#527)

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2438,6 +2438,8 @@ func (tc *TypeChecker) inferBuiltinCallType(name string, args []ast.Expression) 
 		return "bool", true
 	case "char":
 		return "char", true
+	case "byte":
+		return "byte", true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- Fixes #527: W2006 byte overflow warning inconsistently applied
- Added `byte` case to `inferBuiltinCallType` in typechecker
- Now all three cases produce warnings:
  - `byte_var + byte(literal)` 
  - `byte_var + byte_var` (already worked)
  - `byte(literal) + byte(literal)`

## Root Cause
The `inferBuiltinCallType` function recognized `int`, `float`, `string`, `bool`, `char` conversion functions but was missing `byte`. This caused type inference to fail for `byte()` calls, so the typechecker couldn't detect byte arithmetic involving literals.

## Test plan
- [x] Manual test of all three cases from issue
- [x] All 222 integration tests pass
- [x] All Go unit tests pass