### PR TITLE
fix: partial struct initialization now zero-initializes missing fields (#523)

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2820,10 +2820,13 @@ func evalStructValue(node *ast.StructValue, env *Environment) Object {
 		}
 	}
 
-	// Create a new struct with the given fields
+	// Create a new struct with default values for all fields first
 	fields := make(map[string]Object)
+	for fieldName, fieldType := range structDef.Fields {
+		fields[fieldName] = getDefaultValue(fieldType)
+	}
 
-	// Evaluate each field expression
+	// Override with explicitly provided field values
 	for fieldName, fieldExpr := range node.Fields {
 		val := Eval(fieldExpr, env)
 		if isError(val) {


### PR DESCRIPTION
## Summary
- Fixes #523: Partial struct initialization creates struct with missing fields
- `Point{x: 5}` now correctly zero-initializes `y` field
- Behavior is now consistent with `new(Point)`

## Changes
Modified `evalStructValue` in evaluator.go to:
1. First initialize all fields with default values from struct definition
2. Then override with explicitly provided values

## Test plan
- [x] `Point{x: 5}` - y is now 0 (was E4003 error)
- [x] `Point{x: 10, y: 20}` - both values set correctly
- [x] `Point{}` - all fields zero-initialized
- [x] All 222 integration tests pass
- [x] All Go unit tests pass