### PR TITLE
fix: range(start, end) where start > end is now a compile-time error (#524)

### DIFF
--- a/integration-tests/fail/errors/E9005_range_invalid_bounds.ez
+++ b/integration-tests/fail/errors/E9005_range_invalid_bounds.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E9005 - range-invalid-bounds
+ * Expected: "invalid range" or "start" or "less than"
+ */
+
+do main() {
+    for i in range(10, 5) {
+        // This should error - start > end
+    }
+}

--- a/integration-tests/pass/core/control-flow.ez
+++ b/integration-tests/pass/core/control-flow.ez
@@ -77,20 +77,10 @@ do main() {
         failed += 1
     }
 
-    // Test 5: for descending range
-    temp desc_list string = ""
-    for i in range(5, 0) {
-        desc_list = "${desc_list}${i}"
-    }
-    if desc_list == "54321" {
-        println("  [PASS] for descending range(5, 0)")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] descending range: expected '54321', got '${desc_list}'")
-        failed += 1
-    }
+    // Note: Descending range like range(5, 0) is now a compile-time error (E9005)
+    // Use a for loop with decrement if you need to count backwards
 
-    // Test 6: for with type annotation
+    // Test 5: for with type annotation
     temp sum3 int = 0
     for i int in range(0, 3) {
         sum3 += i

--- a/integration-tests/pass/core/range-expressions.ez
+++ b/integration-tests/pass/core/range-expressions.ez
@@ -39,18 +39,8 @@ do main() {
         failed += 1
     }
 
-    // Test 3: Descending range
-    temp desc_list string = ""
-    for i in range(5, 0) {
-        desc_list = "${desc_list}${i}"
-    }
-    if desc_list == "54321" {
-        println("  [PASS] range(5, 0) descending")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] range(5, 0): expected '54321', got '${desc_list}'")
-        failed += 1
-    }
+    // Note: Descending range like range(5, 0) is now a compile-time error (E9005)
+    // Use a for loop with decrement if you need to count backwards
 
     // ==================== RANGE IN 'IN' OPERATOR ====================
     println("  -- range in 'in' operator --")

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -275,6 +275,7 @@ var (
 	E9002 = ErrorCode{"E9002", "array-non-numeric", "operation requires numeric array"}
 	E9003 = ErrorCode{"E9003", "range-step-zero", "range step cannot be zero"}
 	E9004 = ErrorCode{"E9004", "chunk-size-invalid", "chunk size must be greater than zero"}
+	E9005 = ErrorCode{"E9005", "range-invalid-bounds", "range start must be less than or equal to end"}
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Fixes #524: `range(10, 5)` where start > end is now E9005 compile-time error
- Previously produced silently wrong behavior in `when/is` (flipped inclusivity)
- Check applies to `for` loops and `when/is` cases

## Changes
- Add `E9005` (range-invalid-bounds) error code
- Add `checkRangeExpression` function in typechecker
- Call checkExpression for range in `checkForStatement` and `checkWhenStatement`
- Remove descending range tests (replaced with comments explaining the change)
- Updated ez-errors.md documentation

## Test plan
- [x] `for i in range(10, 5)` → E9005 error
- [x] `when x { is range(10, 5) {...} }` → E9005 error
- [x] `range(5, 10)` still works correctly
- [x] All 223 integration tests pass
- [x] All Go unit tests pass