### PR TITLE
feat: global builtins, @std expansion, and bug fixes (#525, #526, #522, #523, #524, #527)

### DIFF
--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -595,6 +595,12 @@ func printRuntimeError(errObj *interpreter.Error, source, filename string) {
 			code = errors.E4006
 		case "E4007":
 			code = errors.E4007
+		case "E5021":
+			// Panic - special display
+			code = errors.ErrorCode{Code: "PANIC", Name: "panic", Description: "panicked here"}
+		case "E5022":
+			// Assertion failure - special display
+			code = errors.ErrorCode{Code: "ASSERT", Name: "assertion-failed", Description: "assertion failed here"}
 		default:
 			// Unknown code, use generic
 			code = errors.ErrorCode{Code: errObj.Code, Name: "error", Description: "error occurred here"}

--- a/integration-tests/fail/errors/E5021_panic.ez
+++ b/integration-tests/fail/errors/E5021_panic.ez
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E5021 - panic
+ * Expected: "panic"
+ * Note: panic() is a global builtin, no import needed
+ */
+
+do main() {
+    panic("intentional panic for testing")
+}

--- a/integration-tests/fail/errors/E5022_assertion_failed.ez
+++ b/integration-tests/fail/errors/E5022_assertion_failed.ez
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E5022 - assertion-failed
+ * Expected: "assertion" or "failed"
+ * Note: assert() is a global builtin, no import needed
+ */
+
+do main() {
+    assert(false, "expected failure")
+}

--- a/integration-tests/fail/errors/E7032_sleep_negative.ez
+++ b/integration-tests/fail/errors/E7032_sleep_negative.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E7032 - sleep-negative
+ * Expected: "negative" or "sleep"
+ */
+
+import @std
+using std
+
+do main() {
+    sleep_seconds(-5)  // negative duration
+}

--- a/integration-tests/fail/errors/E7033_conversion_overflow.ez
+++ b/integration-tests/fail/errors/E7033_conversion_overflow.ez
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E7033 - conversion-overflow
+ * Expected: "overflow" or "exceeds"
+ */
+
+do main() {
+    temp f float = 9999999999999999999.9
+    temp i int = int(f)
+}

--- a/integration-tests/fail/errors/E9005_range_invalid_bounds.ez
+++ b/integration-tests/fail/errors/E9005_range_invalid_bounds.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E9005 - range-invalid-bounds
+ * Expected: "invalid range" or "start" or "less than"
+ */
+
+do main() {
+    for i in range(10, 5) {
+        // This should error - start > end
+    }
+}

--- a/integration-tests/pass/core/control-flow.ez
+++ b/integration-tests/pass/core/control-flow.ez
@@ -77,20 +77,10 @@ do main() {
         failed += 1
     }
 
-    // Test 5: for descending range
-    temp desc_list string = ""
-    for i in range(5, 0) {
-        desc_list = "${desc_list}${i}"
-    }
-    if desc_list == "54321" {
-        println("  [PASS] for descending range(5, 0)")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] descending range: expected '54321', got '${desc_list}'")
-        failed += 1
-    }
+    // Note: Descending range like range(5, 0) is now a compile-time error (E9005)
+    // Use a for loop with decrement if you need to count backwards
 
-    // Test 6: for with type annotation
+    // Test 5: for with type annotation
     temp sum3 int = 0
     for i int in range(0, 3) {
         sum3 += i

--- a/integration-tests/pass/core/range-expressions.ez
+++ b/integration-tests/pass/core/range-expressions.ez
@@ -39,18 +39,8 @@ do main() {
         failed += 1
     }
 
-    // Test 3: Descending range
-    temp desc_list string = ""
-    for i in range(5, 0) {
-        desc_list = "${desc_list}${i}"
-    }
-    if desc_list == "54321" {
-        println("  [PASS] range(5, 0) descending")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] range(5, 0): expected '54321', got '${desc_list}'")
-        failed += 1
-    }
+    // Note: Descending range like range(5, 0) is now a compile-time error (E9005)
+    // Use a for loop with decrement if you need to count backwards
 
     // ==================== RANGE IN 'IN' OPERATOR ====================
     println("  -- range in 'in' operator --")

--- a/integration-tests/pass/stdlib/std.ez
+++ b/integration-tests/pass/stdlib/std.ez
@@ -1,0 +1,114 @@
+/*
+ * std.ez - Test @std standard library expanded functions
+ *
+ * Global builtins (no import needed): exit, EXIT_SUCCESS, EXIT_FAILURE, panic, assert
+ * @std module functions (require import): println, printf, sleep_*, eprintln, eprintf
+ */
+
+import @std
+using std
+
+do main() {
+    println("=== @std Standard Library Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // ==================== EXIT_SUCCESS (global builtin) ====================
+    println("  -- EXIT_SUCCESS --")
+
+    if EXIT_SUCCESS == 0 {
+        println("  [PASS] EXIT_SUCCESS = 0")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] EXIT_SUCCESS: expected 0, got ${EXIT_SUCCESS}")
+        failed += 1
+    }
+
+    // ==================== EXIT_FAILURE (global builtin) ====================
+    println("  -- EXIT_FAILURE --")
+
+    if EXIT_FAILURE == 1 {
+        println("  [PASS] EXIT_FAILURE = 1")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] EXIT_FAILURE: expected 1, got ${EXIT_FAILURE}")
+        failed += 1
+    }
+
+    // ==================== sleep_milliseconds (@std) ====================
+    println("  -- sleep_milliseconds --")
+
+    // Test: sleep 0 milliseconds (should succeed immediately)
+    sleep_milliseconds(0)
+    println("  [PASS] sleep_milliseconds(0) completed")
+    passed += 1
+
+    // Test: sleep 1 millisecond (quick test)
+    sleep_milliseconds(1)
+    println("  [PASS] sleep_milliseconds(1) completed")
+    passed += 1
+
+    // ==================== sleep_nanoseconds (@std) ====================
+    println("  -- sleep_nanoseconds --")
+
+    // Test: sleep 0 nanoseconds
+    sleep_nanoseconds(0)
+    println("  [PASS] sleep_nanoseconds(0) completed")
+    passed += 1
+
+    // Test: sleep 1000 nanoseconds (1 microsecond)
+    sleep_nanoseconds(1000)
+    println("  [PASS] sleep_nanoseconds(1000) completed")
+    passed += 1
+
+    // ==================== eprintln (@std) ====================
+    println("  -- eprintln --")
+
+    // Test: eprintln outputs to stderr (we can only verify it doesn't crash)
+    eprintln("This goes to stderr")
+    println("  [PASS] eprintln() executed without error")
+    passed += 1
+
+    // Test: eprintln with multiple args
+    eprintln("stderr:", 42, true)
+    println("  [PASS] eprintln() with multiple args executed")
+    passed += 1
+
+    // ==================== eprintf (@std) ====================
+    println("  -- eprintf --")
+
+    // Test: eprintf outputs to stderr without newline
+    eprintf("stderr without newline")
+    eprintln()  // add newline after
+    println("  [PASS] eprintf() executed without error")
+    passed += 1
+
+    // ==================== assert (global builtin) ====================
+    println("  -- assert --")
+
+    // Test: assert with true condition (should pass)
+    assert(true, "this should not fail")
+    println("  [PASS] assert(true, msg) passed")
+    passed += 1
+
+    // Test: assert with expression
+    assert(1 + 1 == 2, "math works")
+    println("  [PASS] assert(1+1==2, msg) passed")
+    passed += 1
+
+    // Test: assert with comparison
+    temp x int = 42
+    assert(x == 42, "variable check")
+    println("  [PASS] assert(x==42, msg) passed")
+    passed += 1
+
+    // ==================== Summary ====================
+    println("")
+    println("=== Summary ===")
+    println("Passed: ${passed}")
+    println("Failed: ${failed}")
+
+    if failed > 0 {
+        exit(EXIT_FAILURE)
+    }
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -235,6 +235,7 @@ var (
 	E7030 = ErrorCode{"E7030", "command-not-found", "command or executable not found"}
 	E7031 = ErrorCode{"E7031", "command-failed", "command execution failed"}
 	E7032 = ErrorCode{"E7032", "sleep-negative", "sleep duration cannot be negative"}
+	E7033 = ErrorCode{"E7033", "conversion-overflow", "value exceeds target type range"}
 
 	// Path validation errors
 	E7040 = ErrorCode{"E7040", "empty-path", "path cannot be empty"}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -275,6 +275,7 @@ var (
 	E9002 = ErrorCode{"E9002", "array-non-numeric", "operation requires numeric array"}
 	E9003 = ErrorCode{"E9003", "range-step-zero", "range step cannot be zero"}
 	E9004 = ErrorCode{"E9004", "chunk-size-invalid", "chunk size must be greater than zero"}
+	E9005 = ErrorCode{"E9005", "range-invalid-bounds", "range start must be less than or equal to end"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -166,6 +166,8 @@ var (
 	E5018 = ErrorCode{"E5018", "max-recursion-depth", "maximum recursion depth exceeded"}
 	E5019 = ErrorCode{"E5019", "range-step-not-integer", "range step must be integer"}
 	E5020 = ErrorCode{"E5020", "range-in-operand-not-integer", "value checked against range must be integer"}
+	E5021 = ErrorCode{"E5021", "panic", "explicit panic called"}
+	E5022 = ErrorCode{"E5022", "assertion-failed", "assertion condition was false"}
 )
 
 // =============================================================================
@@ -232,6 +234,7 @@ var (
 	E7029 = ErrorCode{"E7029", "get-homedir-failed", "failed to get home directory"}
 	E7030 = ErrorCode{"E7030", "command-not-found", "command or executable not found"}
 	E7031 = ErrorCode{"E7031", "command-failed", "command execution failed"}
+	E7032 = ErrorCode{"E7032", "sleep-negative", "sleep duration cannot be negative"}
 
 	// Path validation errors
 	E7040 = ErrorCode{"E7040", "empty-path", "path cannot be empty"}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -167,18 +167,18 @@ func isValidModule(moduleName string) bool {
 func suggestModule(invalidName string) string {
 	// Check for common typos/variations
 	suggestions := map[string]string{
-		"string":  "strings",
-		"array":   "arrays",
-		"map":     "maps",
-		"rand":    "random",
-		"file":    "io",
-		"files":   "io",
-		"fs":      "io",
-		"env":     "os",
-		"system":  "os",
-		"byte":    "bytes",
+		"string":   "strings",
+		"array":    "arrays",
+		"map":      "maps",
+		"rand":     "random",
+		"file":     "io",
+		"files":    "io",
+		"fs":       "io",
+		"env":      "os",
+		"system":   "os",
+		"byte":     "bytes",
 		"datetime": "time",
-		"date":    "time",
+		"date":     "time",
 	}
 
 	if suggestion, ok := suggestions[invalidName]; ok {
@@ -1735,6 +1735,10 @@ func evalIdentifier(node *ast.Label, env *Environment) Object {
 	// Found in exactly one module
 	if len(foundModules) == 1 {
 		if foundBuiltin != nil {
+			// For constants (IsConstant=true), call immediately to get the value
+			if foundBuiltin.IsConstant {
+				return foundBuiltin.Fn()
+			}
 			return foundBuiltin
 		}
 		return foundUserObj
@@ -1742,6 +1746,10 @@ func evalIdentifier(node *ast.Label, env *Environment) Object {
 
 	// Check global builtins (like len, typeof, etc.)
 	if builtin, ok := builtins[node.Value]; ok {
+		// For constants (IsConstant=true), call immediately to get the value
+		if builtin.IsConstant {
+			return builtin.Fn()
+		}
 		return builtin
 	}
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2820,10 +2820,13 @@ func evalStructValue(node *ast.StructValue, env *Environment) Object {
 		}
 	}
 
-	// Create a new struct with the given fields
+	// Create a new struct with default values for all fields first
 	fields := make(map[string]Object)
+	for fieldName, fieldType := range structDef.Fields {
+		fields[fieldName] = getDefaultValue(fieldType)
+	}
 
-	// Evaluate each field expression
+	// Override with explicitly provided field values
 	for fieldName, fieldExpr := range node.Fields {
 		val := Eval(fieldExpr, env)
 		if isError(val) {

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -267,7 +267,8 @@ type BuiltinFunction func(args ...Object) Object
 
 // Builtin represents a built-in function
 type Builtin struct {
-	Fn BuiltinFunction
+	Fn         BuiltinFunction
+	IsConstant bool // If true, this is a constant (zero-arg function that returns a value)
 }
 
 func (b *Builtin) Type() ObjectType { return BUILTIN_OBJ }

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -582,7 +582,7 @@ var StdBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7004", Message: fmt.Sprintf("exit() argument must be an integer, got %s", getEZTypeName(args[0]))}
 			}
 			os.Exit(int(code.Value.Int64()))
-			return object.NIL // Never reached
+			return nil // Unreachable, but required by Go's type system
 		},
 	},
 

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -2838,3 +2838,240 @@ func TestMathPowOverflow(t *testing.T) {
 	result = powFn(&object.Integer{Value: big.NewInt(2)}, &object.Integer{Value: big.NewInt(10)})
 	testIntegerObject(t, result, 1024)
 }
+
+// ============================================================================
+// Issue #526: @std Module Expansion Tests
+// ============================================================================
+
+// Test EXIT_SUCCESS constant (global builtin)
+func TestExitSuccess(t *testing.T) {
+	exitSuccessFn := StdBuiltins["EXIT_SUCCESS"].Fn
+	result := exitSuccessFn()
+	testIntegerObject(t, result, 0)
+}
+
+// Test EXIT_FAILURE constant (global builtin)
+func TestExitFailure(t *testing.T) {
+	exitFailureFn := StdBuiltins["EXIT_FAILURE"].Fn
+	result := exitFailureFn()
+	testIntegerObject(t, result, 1)
+}
+
+// Note: exit() is not tested as it calls os.Exit() which terminates the test process
+
+// Test sleep_seconds() with negative value (should error)
+func TestSleepSecondsNegativeError(t *testing.T) {
+	sleepFn := StdBuiltins["std.sleep_seconds"].Fn
+	result := sleepFn(&object.Integer{Value: big.NewInt(-1)})
+	if !isErrorObject(result) {
+		t.Error("sleep_seconds() with negative duration should return error")
+	}
+}
+
+// Test sleep_seconds() with wrong argument type
+func TestSleepSecondsWrongTypeError(t *testing.T) {
+	sleepFn := StdBuiltins["std.sleep_seconds"].Fn
+	result := sleepFn(&object.String{Value: "5"})
+	if !isErrorObject(result) {
+		t.Error("sleep_seconds() with string argument should return error")
+	}
+}
+
+// Test sleep_seconds() with wrong number of arguments
+func TestSleepSecondsWrongArgCountError(t *testing.T) {
+	sleepFn := StdBuiltins["std.sleep_seconds"].Fn
+	result := sleepFn()
+	if !isErrorObject(result) {
+		t.Error("sleep_seconds() with no arguments should return error")
+	}
+	result = sleepFn(&object.Integer{Value: big.NewInt(1)}, &object.Integer{Value: big.NewInt(2)})
+	if !isErrorObject(result) {
+		t.Error("sleep_seconds() with two arguments should return error")
+	}
+}
+
+// Test sleep_milliseconds() with negative value (should error)
+func TestSleepMillisecondsNegativeError(t *testing.T) {
+	sleepFn := StdBuiltins["std.sleep_milliseconds"].Fn
+	result := sleepFn(&object.Integer{Value: big.NewInt(-1)})
+	if !isErrorObject(result) {
+		t.Error("sleep_milliseconds() with negative duration should return error")
+	}
+}
+
+// Test sleep_nanoseconds() with negative value (should error)
+func TestSleepNanosecondsNegativeError(t *testing.T) {
+	sleepFn := StdBuiltins["std.sleep_nanoseconds"].Fn
+	result := sleepFn(&object.Integer{Value: big.NewInt(-1)})
+	if !isErrorObject(result) {
+		t.Error("sleep_nanoseconds() with negative duration should return error")
+	}
+}
+
+// Test sleep with zero (should succeed)
+func TestSleepZero(t *testing.T) {
+	sleepFn := StdBuiltins["std.sleep_seconds"].Fn
+	result := sleepFn(&object.Integer{Value: big.NewInt(0)})
+	if isErrorObject(result) {
+		t.Error("sleep_seconds(0) should succeed")
+	}
+	if result != object.NIL {
+		t.Errorf("sleep_seconds() should return nil, got %T", result)
+	}
+}
+
+// Test panic() returns an error with correct code (global builtin)
+func TestPanic(t *testing.T) {
+	panicFn := StdBuiltins["panic"].Fn
+	result := panicFn(&object.String{Value: "something went wrong"})
+
+	err, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("panic() should return Error, got %T", result)
+	}
+	if err.Code != "E5021" {
+		t.Errorf("panic() error code should be E5021, got %s", err.Code)
+	}
+	if err.Message != "panic: something went wrong" {
+		t.Errorf("panic() message wrong, got %s", err.Message)
+	}
+}
+
+// Test panic() with wrong argument type
+func TestPanicWrongTypeError(t *testing.T) {
+	panicFn := StdBuiltins["panic"].Fn
+	result := panicFn(&object.Integer{Value: big.NewInt(42)})
+
+	err, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("panic() with non-string should return Error, got %T", result)
+	}
+	if err.Code != "E7003" {
+		t.Errorf("panic() with non-string should return E7003 error, got %s", err.Code)
+	}
+}
+
+// Test panic() with wrong number of arguments
+func TestPanicWrongArgCountError(t *testing.T) {
+	panicFn := StdBuiltins["panic"].Fn
+	result := panicFn()
+	if !isErrorObject(result) {
+		t.Error("panic() with no arguments should return error")
+	}
+	result = panicFn(&object.String{Value: "a"}, &object.String{Value: "b"})
+	if !isErrorObject(result) {
+		t.Error("panic() with two arguments should return error")
+	}
+}
+
+// Test eprintln() returns nil (actual output is to stderr, hard to test)
+func TestEprintln(t *testing.T) {
+	eprintlnFn := StdBuiltins["std.eprintln"].Fn
+	result := eprintlnFn(&object.String{Value: "test output"})
+	if result != object.NIL {
+		t.Errorf("eprintln() should return nil, got %T", result)
+	}
+}
+
+// Test eprintf() returns nil
+func TestEprintf(t *testing.T) {
+	eprintfFn := StdBuiltins["std.eprintf"].Fn
+	result := eprintfFn(&object.String{Value: "test output"})
+	if result != object.NIL {
+		t.Errorf("eprintf() should return nil, got %T", result)
+	}
+}
+
+// Test eprintln() with multiple arguments
+func TestEprintlnMultipleArgs(t *testing.T) {
+	eprintlnFn := StdBuiltins["std.eprintln"].Fn
+	result := eprintlnFn(
+		&object.String{Value: "hello"},
+		&object.Integer{Value: big.NewInt(42)},
+		&object.Boolean{Value: true},
+	)
+	if result != object.NIL {
+		t.Errorf("eprintln() should return nil, got %T", result)
+	}
+}
+
+// ============================================================================
+// Issue #525: assert() Tests
+// ============================================================================
+
+// Test assert() with true condition (should pass)
+func TestAssertTrue(t *testing.T) {
+	assertFn := StdBuiltins["assert"].Fn
+	result := assertFn(&object.Boolean{Value: true}, &object.String{Value: "this should not fail"})
+	if result != object.NIL {
+		t.Errorf("assert(true, msg) should return nil, got %T", result)
+	}
+}
+
+// Test assert() with false condition (should error)
+func TestAssertFalse(t *testing.T) {
+	assertFn := StdBuiltins["assert"].Fn
+	result := assertFn(&object.Boolean{Value: false}, &object.String{Value: "expected failure"})
+
+	err, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("assert(false, msg) should return Error, got %T", result)
+	}
+	if err.Code != "E5022" {
+		t.Errorf("assert() error code should be E5022, got %s", err.Code)
+	}
+	if err.Message != "assertion failed: expected failure" {
+		t.Errorf("assert() message wrong, got %s", err.Message)
+	}
+}
+
+// Test assert() with wrong first argument type
+func TestAssertWrongFirstArgType(t *testing.T) {
+	assertFn := StdBuiltins["assert"].Fn
+	result := assertFn(&object.Integer{Value: big.NewInt(1)}, &object.String{Value: "msg"})
+
+	err, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("assert() with non-boolean should return Error, got %T", result)
+	}
+	if err.Code != "E7008" {
+		t.Errorf("assert() with non-boolean should return E7008 error, got %s", err.Code)
+	}
+}
+
+// Test assert() with wrong second argument type
+func TestAssertWrongSecondArgType(t *testing.T) {
+	assertFn := StdBuiltins["assert"].Fn
+	result := assertFn(&object.Boolean{Value: true}, &object.Integer{Value: big.NewInt(42)})
+
+	err, ok := result.(*object.Error)
+	if !ok {
+		t.Fatalf("assert() with non-string message should return Error, got %T", result)
+	}
+	if err.Code != "E7003" {
+		t.Errorf("assert() with non-string message should return E7003 error, got %s", err.Code)
+	}
+}
+
+// Test assert() with wrong number of arguments
+func TestAssertWrongArgCount(t *testing.T) {
+	assertFn := StdBuiltins["assert"].Fn
+
+	// No arguments
+	result := assertFn()
+	if !isErrorObject(result) {
+		t.Error("assert() with no arguments should return error")
+	}
+
+	// One argument
+	result = assertFn(&object.Boolean{Value: true})
+	if !isErrorObject(result) {
+		t.Error("assert() with one argument should return error")
+	}
+
+	// Three arguments
+	result = assertFn(&object.Boolean{Value: true}, &object.String{Value: "msg"}, &object.String{Value: "extra"})
+	if !isErrorObject(result) {
+		t.Error("assert() with three arguments should return error")
+	}
+}

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -212,6 +212,38 @@ func TestIntConversionErrors(t *testing.T) {
 	if !isErrorObject(result) {
 		t.Error("expected error for invalid string")
 	}
+
+	// Float overflow - value exceeds int64 max (#522)
+	result = intFn(&object.Float{Value: 9999999999999999999.9})
+	if err, ok := result.(*object.Error); !ok {
+		t.Error("expected error for float overflow")
+	} else if err.Code != "E7033" {
+		t.Errorf("expected E7033 error code, got %s", err.Code)
+	}
+
+	// Float overflow - negative value below int64 min
+	result = intFn(&object.Float{Value: -9999999999999999999.9})
+	if err, ok := result.(*object.Error); !ok {
+		t.Error("expected error for negative float overflow")
+	} else if err.Code != "E7033" {
+		t.Errorf("expected E7033 error code, got %s", err.Code)
+	}
+
+	// NaN conversion should fail
+	result = intFn(&object.Float{Value: math.NaN()})
+	if err, ok := result.(*object.Error); !ok {
+		t.Error("expected error for NaN conversion")
+	} else if err.Code != "E7033" {
+		t.Errorf("expected E7033 error code, got %s", err.Code)
+	}
+
+	// Inf conversion should fail
+	result = intFn(&object.Float{Value: math.Inf(1)})
+	if err, ok := result.(*object.Error); !ok {
+		t.Error("expected error for Inf conversion")
+	} else if err.Code != "E7033" {
+		t.Errorf("expected E7033 error code, got %s", err.Code)
+	}
 }
 
 func TestFloatConversion(t *testing.T) {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2438,6 +2438,8 @@ func (tc *TypeChecker) inferBuiltinCallType(name string, args []ast.Expression) 
 		return "bool", true
 	case "char":
 		return "char", true
+	case "byte":
+		return "byte", true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
## Summary

This PR adds new global builtins, expands the @std module, and fixes several bugs.

## Features

### Global Builtins (no import needed)
| Function | Description |
|----------|-------------|
| `exit(code)` | Exit program with status code |
| `EXIT_SUCCESS` | Constant `0` |
| `EXIT_FAILURE` | Constant `1` |
| `panic(message)` | Terminate with panic message (shows `[PANIC]`) |
| `assert(condition, message)` | Assertion check (shows `[ASSERT]` on failure) |

### @std Module Functions (require `import @std`)
| Function | Description |
|----------|-------------|
| `sleep_seconds(n)` | Sleep for n seconds |
| `sleep_milliseconds(n)` | Sleep for n milliseconds |
| `sleep_nanoseconds(n)` | Sleep for n nanoseconds |
| `eprintln(values...)` | Print to stderr with newline |
| `eprintf(values...)` | Print to stderr without newline |

## Bug Fixes

- **#522**: `int(large_float)` now throws E7033 instead of silently clamping to INT64_MAX
- **#523**: Partial struct init `Point{x: 5}` now zero-initializes missing fields
- **#524**: `range(10, 5)` where start > end is now E9005 compile-time error
- **#527**: W2006 byte overflow warning now applies to `byte()` literal conversions

## New Error Codes

| Code | Name | Description |
|------|------|-------------|
| E5021 | panic | Explicit panic called |
| E5022 | assertion-failed | Assertion condition was false |
| E7032 | sleep-negative | Sleep duration cannot be negative |
| E7033 | conversion-overflow | Float-to-int overflow |
| E9005 | range-invalid-bounds | Range start must be <= end |

## Other Changes

- W2001 unreachable code warning now detects code after `exit()` and `panic()` calls
- `byte` added to type inference for proper W2006 warning coverage

## Closes

Closes #522
Closes #523
Closes #524
Closes #525
Closes #526
Closes #527

## Test Plan

- [x] All 223 integration tests pass
- [x] All Go unit tests pass