### PR TITLE
fix: checkFile now type-checks imported modules (#535)

### DIFF
--- a/integration-tests/fail/multi-file/E5016_immutable_param_in_module/main.ez
+++ b/integration-tests/fail/multi-file/E5016_immutable_param_in_module/main.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E5016 - immutable-parameter in module file
+ * Expected: "cannot modify" (error in imported module should be caught)
+ * Regression test for bug #535
+ */
+
+import @std
+import lib"./mylib"
+
+using std
+
+do main() {
+    temp h = lib.Hero{name: "Test", hp: 50}
+    lib.update_hero(h)
+}

--- a/integration-tests/fail/multi-file/E5016_immutable_param_in_module/mylib/lib.ez
+++ b/integration-tests/fail/multi-file/E5016_immutable_param_in_module/mylib/lib.ez
@@ -1,0 +1,10 @@
+module mylib
+
+const Hero struct {
+    name string
+    hp int
+}
+
+do update_hero(hero Hero) {
+    hero = Hero{name: "Modified", hp: 999}
+}


### PR DESCRIPTION
## Summary
- Fixes #535: Immutability errors in imported modules were only caught at runtime instead of compile-time
- Root cause: `checkFile()` only type-checked the single file, not following imports
- Fix: Added import-following logic to `checkFile()` matching `checkProject()` behavior

## Changes
- `cmd/ez/main.go`: Extended `checkFile()` to follow imports and type-check module files
- Added regression test: `integration-tests/fail/multi-file/E5016_immutable_param_in_module/`

## Test plan
- [x] `./ez check main.ez` now catches errors in imported modules
- [x] `./ez check dir/` still works as before
- [x] All 225 integration tests pass