### PR TITLE
fix: December 14, 2025 bug fixes

### DIFF
--- a/integration-tests/fail/errors/E5016_postfix_immutable_param.ez
+++ b/integration-tests/fail/errors/E5016_postfix_immutable_param.ez
@@ -1,0 +1,17 @@
+/*
+ * Error Test: E5016 - postfix on immutable parameter
+ * Expected: "cannot modify"
+ * Regression test for bug #539
+ */
+
+do test_increment(x int) {
+    x++  // ERROR: cannot modify immutable param with postfix
+}
+
+do test_decrement(y int) {
+    y--  // ERROR: cannot modify immutable param with postfix
+}
+
+do main() {
+    test_increment(5)
+}

--- a/integration-tests/fail/multi-file/E5016_immutable_param_in_module/main.ez
+++ b/integration-tests/fail/multi-file/E5016_immutable_param_in_module/main.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E5016 - immutable-parameter in module file
+ * Expected: "cannot modify" (error in imported module should be caught)
+ * Regression test for bug #535
+ */
+
+import @std
+import lib"./mylib"
+
+using std
+
+do main() {
+    temp h = lib.Hero{name: "Test", hp: 50}
+    lib.update_hero(h)
+}

--- a/integration-tests/fail/multi-file/E5016_immutable_param_in_module/mylib/lib.ez
+++ b/integration-tests/fail/multi-file/E5016_immutable_param_in_module/mylib/lib.ez
@@ -1,0 +1,10 @@
+module mylib
+
+const Hero struct {
+    name string
+    hp int
+}
+
+do update_hero(hero Hero) {
+    hero = Hero{name: "Modified", hp: 999}
+}

--- a/integration-tests/pass/multi-file/foreach-namespaced-collection/main.ez
+++ b/integration-tests/pass/multi-file/foreach-namespaced-collection/main.ez
@@ -1,0 +1,55 @@
+/*
+ * Test for_each with namespaced identifier as collection
+ * Regression test for bug #534
+ *
+ * This tests that for_each correctly parses lib.Items as a collection
+ * when an import uses namespace prefix (import lib"..." without & use).
+ */
+import @std
+import lib"./testlib"
+
+using std
+
+do main() {
+    println("=== For_each Namespaced Collection Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: for_each over namespaced string array
+    println("Items from lib.Items:")
+    temp item_count int = 0
+    for_each item in lib.Items {
+        println("  ${item}")
+        item_count += 1
+    }
+    if item_count == 3 {
+        println("  [PASS] for_each over namespaced string array")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] expected 3 items, got ${item_count}")
+        failed += 1
+    }
+
+    // Test 2: for_each over namespaced int array with accumulation
+    temp sum int = 0
+    for_each n in lib.Numbers {
+        sum += n
+    }
+    if sum == 100 {
+        println("  [PASS] for_each over namespaced int array (sum=${sum})")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] for_each over namespaced int array: expected 100, got ${sum}")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/multi-file/foreach-namespaced-collection/testlib/lib.ez
+++ b/integration-tests/pass/multi-file/foreach-namespaced-collection/testlib/lib.ez
@@ -1,0 +1,4 @@
+module testlib
+
+const Items [string, 3] = {"apple", "banana", "cherry"}
+const Numbers [int, 4] = {10, 20, 30, 40}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -168,6 +168,7 @@ var (
 	E5020 = ErrorCode{"E5020", "range-in-operand-not-integer", "value checked against range must be integer"}
 	E5021 = ErrorCode{"E5021", "panic", "explicit panic called"}
 	E5022 = ErrorCode{"E5022", "assertion-failed", "assertion condition was false"}
+	E5023 = ErrorCode{"E5023", "postfix-requires-integer", "postfix operator needs integer operand"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2189,7 +2189,8 @@ func elementsEqual(a, b Object) bool {
 func evalPostfixExpression(node *ast.PostfixExpression, env *Environment) Object {
 	ident, ok := node.Left.(*ast.Label)
 	if !ok {
-		return newError("postfix operator requires identifier")
+		return newErrorWithLocation("E5015", node.Token.Line, node.Token.Column,
+			"postfix operator %s requires a variable identifier", node.Operator)
 	}
 
 	val, ok := env.Get(ident.Value)
@@ -2199,7 +2200,8 @@ func evalPostfixExpression(node *ast.PostfixExpression, env *Environment) Object
 
 	intVal, ok := val.(*Integer)
 	if !ok {
-		return newError("postfix operator requires integer")
+		return newErrorWithLocation("E5023", node.Token.Line, node.Token.Column,
+			"postfix operator %s requires integer operand, got %s", node.Operator, val.Type())
 	}
 
 	var newVal *big.Int


### PR DESCRIPTION
## Summary

This PR contains bug fixes from the December 14, 2025 bugfix session.

### Fixes included:

**#534 - for_each loop fails to parse namespaced identifiers**
- Fixed `parseMemberExpression()` to use `looksLikeStructLiteral()` check before treating `lib.Items {` as a struct literal
- Now correctly distinguishes between struct literals and block statements in for_each loops

**#535 - Immutability errors caught at runtime instead of compile-time for module files**
- Extended `checkFile()` to follow imports and type-check all imported module files
- Ensures E5016 errors are caught at compile-time even when the violation is in an imported module

**#536 - continue in as_long_as loop causes infinite loop when stdin exhausted**
- Added `stdinEOFReached` flag in stdlib builtins
- First EOF read returns error (user can handle), subsequent reads exit gracefully with code 0
- Prevents infinite loops when using `continue` with stdin-reading functions

**#537 - ez version does not check for or display available updates**
- Modified `printVersion()` to check for updates AFTER printing version info
- Update notice now appears below version info for cleaner output

**#539 - Postfix ++/-- on immutable params not caught at compile-time**
- Added `checkPostfixExpression()` mutability check in typechecker
- Added E5023 error code for "postfix-requires-integer"
- Fixed runtime error formatting to use proper error codes (E5015, E5023)

## Test plan
- [x] All 226 integration tests pass
- [x] Each fix has been individually tested and merged via separate PRs

Closes #534, #535, #536, #537, #539