### PR TITLE
fix: validate multi-return type declarations (#581)

### DIFF
--- a/integration-tests/fail/errors/E3001_multi_return_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_multi_return_type_mismatch.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E3001 - multi-return-type-mismatch
+ * Expected: "type mismatch" or "multi-return"
+ */
+
+do get_pair() -> (int, string) {
+    return 42, "hello"
+}
+
+do main() {
+    // Types reversed - should fail
+    temp x string, y int = get_pair()
+}


### PR DESCRIPTION
## Summary
- Add compile-time type checking for typed multi-return assignments
- When variables have explicit type declarations like `temp x int, y string = func()`, the type checker now validates that each declared type matches the corresponding return type from the function

## Test plan
- [x] Added integration test `E3001_multi_return_type_mismatch.ez`
- [x] Verified correct multi-return still works
- [x] Verified untyped multi-return still works
- [x] All typechecker tests pass

Fixes #581