### PR TITLE
fix: validate default parameter types at compile time (#582)

### DIFF
--- a/integration-tests/fail/errors/E3001_default_param_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_default_param_type_mismatch.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3001 - default-param-type-mismatch
+ * Expected: "type mismatch" or "default"
+ */
+
+do bad_default(x int = "hello") -> int {
+    return x
+}
+
+do main() {
+    println("should not compile")
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -799,6 +799,22 @@ func (tc *TypeChecker) checkFunctionDeclaration(node *ast.FunctionDeclaration) {
 				param.Name.Token.Column,
 			)
 		}
+
+		// Check default value type matches parameter type (#582)
+		if param.DefaultValue != nil {
+			defaultType, ok := tc.inferExpressionType(param.DefaultValue)
+			if ok && !tc.typesCompatible(param.TypeName, defaultType) {
+				line, col := tc.getExpressionPosition(param.DefaultValue)
+				tc.addError(
+					errors.E3001,
+					fmt.Sprintf("default value type mismatch: parameter '%s' expects %s, got %s",
+						param.Name.Value, param.TypeName, defaultType),
+					line,
+					col,
+				)
+			}
+		}
+
 		sig.Parameters = append(sig.Parameters, &Parameter{
 			Name:       param.Name.Value,
 			Type:       param.TypeName,


### PR DESCRIPTION
## Summary
- Add compile-time type checking for function parameter default values
- When a parameter has a default value, the type checker now validates that the default value type matches the declared parameter type

## Test plan
- [x] Added integration test `E3001_default_param_type_mismatch.ez`
- [x] Verified correct default params still work
- [x] All typechecker tests pass

Fixes #582