### PR TITLE
fix: validate array element types in stdlib array functions (#589, #590, #591)

### DIFF
--- a/integration-tests/fail/errors/E3001_array_append_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_array_append_type_mismatch.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E3001 - array-append-type-mismatch
+ * Expected: "type mismatch" or "element type"
+ */
+
+import @arrays
+
+do main() {
+    temp nums [int] = {1, 2, 3}
+    arrays.append(nums, "hello")  // Should fail: string into int array
+}

--- a/integration-tests/fail/errors/E3001_array_concat_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_array_concat_type_mismatch.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3001 - array-concat-type-mismatch
+ * Expected: "type mismatch" or "element type"
+ */
+
+import @arrays
+
+do main() {
+    temp nums [int] = {1, 2, 3}
+    temp strs [string] = {"a", "b"}
+    temp result = arrays.concat(nums, strs)  // Should fail: incompatible element types
+}

--- a/integration-tests/fail/errors/E3001_array_insert_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_array_insert_type_mismatch.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E3001 - array-insert-type-mismatch
+ * Expected: "type mismatch" or "element type"
+ */
+
+import @arrays
+
+do main() {
+    temp nums [int] = {1, 2, 3}
+    arrays.insert(nums, 0, "hello")  // Should fail: string into int array
+}


### PR DESCRIPTION
## Summary
- Added `checkArrayElementTypeCompatibility` function to validate element types for array modification functions
- Covers `append`, `insert`, `concat`, `unshift`, `contains`, `index_of`, `last_index_of`, `count`, `remove`, `remove_all`, `fill`, `set`, and `zip`
- Produces E3001 error when element types don't match the array's declared element type

Fixes #589, #590, #591

## Test plan
- Added integration tests for append, insert, and concat type mismatches
- Verified valid array operations still compile correctly
- All existing type checker tests pass