### PR TITLE
fix: validate map key/value types in stdlib maps functions (#593)

### DIFF
--- a/integration-tests/fail/errors/E3001_map_key_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_map_key_type_mismatch.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E3001 - map-key-type-mismatch
+ * Expected: "type mismatch" or "key type"
+ */
+
+import @maps
+
+do main() {
+    temp m map[string:int] = {"a": 1, "b": 2}
+    maps.get(m, 123)  // Should fail: int key for string key map
+}

--- a/integration-tests/fail/errors/E3001_map_set_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_map_set_type_mismatch.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E3001 - map-set-type-mismatch
+ * Expected: "type mismatch" or "value type"
+ */
+
+import @maps
+
+do main() {
+    temp m map[string:int] = {"a": 1, "b": 2}
+    maps.set(m, "c", "wrong")  // Should fail: string value into int map
+}


### PR DESCRIPTION
## Summary
- Added `extractMapValueType` helper function
- Added `checkMapKeyValueTypeCompatibility` function to validate key/value types for map functions
- Covers `set`, `get`, `has`, `has_key`, `has_value`, `delete`, `remove`, `get_or_set`, `merge`, `update`, `equals`
- Produces E3001 error when key/value types don't match the map's declared types

Fixes #593

## Test plan
- Added integration tests for map set value mismatch and key type mismatch
- Verified valid map operations still compile correctly
- All existing type checker tests pass