### PR TITLE
fix: validate for_each collection type at compile time (#595)

### DIFF
--- a/integration-tests/fail/errors/E3017_for_each_non_iterable.ez
+++ b/integration-tests/fail/errors/E3017_for_each_non_iterable.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E3017 - for_each-non-iterable
+ * Expected: "for_each requires" or "array or string"
+ */
+
+import @std
+using std
+
+do main() {
+    temp m map[string:int] = {"a": 1}
+    for_each item in m {  // Should fail: map is not iterable
+        println(item)
+    }
+}

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1365,7 +1365,7 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestForEachStatementMap(t *testing.T) {
+func TestForEachStatementMapError(t *testing.T) {
 	input := `
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
@@ -1374,7 +1374,7 @@ do main() {
 }
 `
 	tc := typecheck(t, input)
-	assertNoErrors(t, tc)
+	assertHasError(t, tc, errors.E3017) // for_each on map should be an error (#595)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Added type validation in `checkForEachStatement` to ensure collection is array or string
- Non-iterable types (maps, ints, structs, etc.) now produce E3017 at compile time
- Updated existing test that expected for_each on map to pass

Fixes #595

## Test plan
- Added integration test for for_each on non-iterable type
- Verified for_each on arrays and strings still works
- All type checker tests pass