### PR TITLE
fix: validate range() argument types at compile time (#597)

### DIFF
--- a/integration-tests/fail/errors/E3001_range_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_range_type_mismatch.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E3001 - range-type-mismatch
+ * Expected: "range()" and "integer"
+ */
+
+import @std
+using std
+
+do main() {
+    for i in range("a", "z") {  // Should fail: strings to range()
+        println(i)
+    }
+}


### PR DESCRIPTION
## Summary
- Added type checking in `checkRangeExpression` to validate start, end, and step arguments
- All range arguments must be integers
- Non-integer types now produce E3001 at compile time

Fixes #597

## Test plan
- Added integration test for range with string arguments
- Verified valid range usage still works
- All type checker tests pass