### PR TITLE
fix: validate postfix ++/-- operand types at compile time (#598)

### DIFF
--- a/integration-tests/fail/errors/E3001_postfix_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_postfix_type_mismatch.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3001 - postfix-type-mismatch
+ * Expected: "postfix" and "integer"
+ */
+
+import @std
+using std
+
+do main() {
+    temp s string = "hello"
+    s++  // Should fail: increment on string
+}


### PR DESCRIPTION
## Summary
- Added type checking in `checkPostfixExpression` to validate operand type
- `++` and `--` operators now require integer operands
- Non-integer types produce E3001 at compile time

Fixes #598

## Test plan
- Added integration test for increment on string
- Verified valid integer increment/decrement still works
- All type checker tests pass