### PR TITLE
fix: validate modulo operator requires integer operands (#601)

### DIFF
--- a/integration-tests/fail/errors/E3002_modulo_float.ez
+++ b/integration-tests/fail/errors/E3002_modulo_float.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3002 - modulo-float
+ * Expected: "%" and "integer"
+ */
+
+import @std
+using std
+
+do main() {
+    temp f float = 3.14
+    temp x = f % 2  // Should fail: modulo on float
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1805,7 +1805,7 @@ func (tc *TypeChecker) checkInfixExpression(infix *ast.InfixExpression) {
 			column,
 		)
 
-	case "-", "*", "/", "%":
+	case "-", "*", "/":
 		// Only valid for numbers
 		if !tc.isNumericType(leftType) || !tc.isNumericType(rightType) {
 			tc.addError(
@@ -1834,6 +1834,17 @@ func (tc *TypeChecker) checkInfixExpression(infix *ast.InfixExpression) {
 					column,
 				)
 			}
+		}
+
+	case "%":
+		// Modulo only valid for integers (#601)
+		if !tc.isIntegerType(leftType) || !tc.isIntegerType(rightType) {
+			tc.addError(
+				errors.E3002,
+				fmt.Sprintf("invalid operands for '%%': %s and %s (expected integer)", leftType, rightType),
+				line,
+				column,
+			)
 		}
 
 	case "==", "!=":


### PR DESCRIPTION
## Summary
- Split `%` from other arithmetic operators in `checkInfixExpression`
- Modulo now requires integer operands (not just numeric)
- Float operands produce E3002 at compile time

Fixes #601

## Test plan
- Added integration test for modulo on float
- Verified valid integer modulo still works
- All type checker tests pass