### PR TITLE
fix: validate break/continue are inside loops at compile time (#603)

### DIFF
--- a/integration-tests/fail/errors/E5009_break_outside_loop.ez
+++ b/integration-tests/fail/errors/E5009_break_outside_loop.ez
@@ -1,8 +1,11 @@
 /*
  * Error Test: E5009 - break-outside-loop
- * Expected: "break statement outside loop"
+ * Expected: "break" and "outside loop"
  */
 
+import @std
+using std
+
 do main() {
-    break  // break outside of any loop
+    break  // Should fail: break outside loop
 }


### PR DESCRIPTION
## Summary
- Added `loopDepth` field to TypeChecker to track loop nesting
- Increment/decrement loopDepth in for, for_each, while, and loop statements
- Added validation for break/continue to check loopDepth > 0
- Break/continue outside loops now produce E5009 at compile time

Fixes #603

## Test plan
- Added integration test for break outside loop
- Verified valid break/continue inside loops still works
- All type checker tests pass