### PR TITLE
fix: validate enum member exists at compile time (#607)

### DIFF
--- a/integration-tests/fail/errors/E4004_enum_variant_not_found.ez
+++ b/integration-tests/fail/errors/E4004_enum_variant_not_found.ez
@@ -1,0 +1,17 @@
+/*
+ * Error Test: E4004 - enum-variant-not-found
+ * Expected: "not found" or "Yellow"
+ */
+
+import @std
+using std
+
+const Color enum {
+    Red
+    Green
+    Blue
+}
+
+do main() {
+    temp c = Color.Yellow  // Should fail: Yellow doesn't exist
+}


### PR DESCRIPTION
## Summary
- Non-existent enum variants now produce E4004 error during type checking instead of waiting for runtime

## Changes
- Added `EnumMembers` field to `Type` struct to track valid member names
- Populated `EnumMembers` in `registerEnumType` during enum registration
- Added validation in `inferMemberType` to check member exists

## Testing
- Added integration test `E4004_enum_variant_not_found.ez`
- All 251 integration tests pass

Fixes #607