### PR TITLE
fix: validate map key type matches at compile time (#608)

### DIFF
--- a/integration-tests/fail/errors/E3003_map_key_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3003_map_key_type_mismatch.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3003 - map-key-type-mismatch
+ * Expected: "key" and "type"
+ */
+
+import @std
+using std
+
+do main() {
+    temp m map[string:int] = {"a": 1, "b": 2}
+    temp val = m[123]  // Should fail: int key on string-keyed map
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1997,6 +1997,19 @@ func (tc *TypeChecker) checkIndexExpression(index *ast.IndexExpression) {
 				column,
 			)
 		}
+		// Validate that index type matches the map's declared key type (#608)
+		if indexOk {
+			mapKeyType := tc.extractMapKeyType(leftType)
+			if mapKeyType != "" && !tc.typesCompatible(mapKeyType, indexType) {
+				line, column := tc.getExpressionPosition(index.Index)
+				tc.addError(
+					errors.E3003,
+					fmt.Sprintf("map key type mismatch: expected %s, got %s", mapKeyType, indexType),
+					line,
+					column,
+				)
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Map access with wrong key type now produces E3003 error during type checking instead of waiting for runtime

## Changes
- Added key type validation in `checkIndexExpression` for map indexing

## Testing
- Added integration test `E3003_map_key_type_mismatch.ez`
- All 250 integration tests pass

Fixes #608