### PR TITLE
docs: update README, TESTING.md, add copyright notices, fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">Programming Made EZ</h3>
 
 <p align="center">
-  A simple, statically-typed programming language designed for clarity and ease of use.
+  A simple, interpreted, statically-typed programming language designed for clarity and ease of use.
 </p>
 
 <p align="center">
@@ -15,7 +15,7 @@
 
 ---
 
-## Quick Start (For Developers)
+## Developer Quick Start
 
 Want to contribute or build from source?
 
@@ -87,57 +87,15 @@ After this one-time manual update, `ez update` will work automatically for all f
 
 ## Running Tests
 
-EZ has two types of tests: **EZ language tests** (written in EZ) and **Go unit tests** (for the interpreter internals).
-
-### EZ Language Tests
-
 ```bash
-# Run passing tests
-./ez tests/comprehensive.ez
-./ez tests/multi-file/main.ez
-./ez tests/nested-test/main/main.ez
+# Run integration tests
+./integration-tests/run_tests.sh
 
-# Run error tests
-./tests/errors/run_error_tests.sh ./ez
-```
-
-### Go Unit Tests
-
-```bash
-# Run all unit tests
+# Run unit tests
 go test ./...
-
-# Run tests with verbose output
-go test -v ./...
-
-# Run tests for a specific package
-go test ./pkg/lexer/...
-go test ./pkg/parser/...
-go test ./pkg/ast/...
-go test ./pkg/object/...
-go test ./pkg/errors/...
-
-# Run with coverage report
-go test -cover ./...
-
-# Generate HTML coverage report
-go test -coverprofile=coverage.out ./...
-go tool cover -html=coverage.out
 ```
 
-### Unit Test Coverage
-
-| Package | Status |
-|---------|--------|
-| pkg/tokenizer | Implemented |
-| pkg/errors | Implemented |
-| pkg/lexer | Implemented |
-| pkg/ast | Implemented |
-| pkg/object | Implemented |
-| pkg/parser | Implemented |
-| pkg/typechecker | Implemented |
-| pkg/interpreter | Implemented |
-| pkg/stdlib | Implemented |
+For more details, see the [Testing Guide](TESTING.md).
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,32 +2,69 @@
 
 ## Unit Tests
 
-Unit tests are written in Go and test individual compiler/runtime components (lexer, parser, interpreter, typechecker, stdlib). Each package in `pkg/` has corresponding `*_test.go` files.
+Unit tests are written in Go and test individual compiler/runtime components. Each package in `pkg/` has corresponding `*_test.go` files.
+
+### Packages with Unit Tests
+
+- `pkg/ast` - Abstract syntax tree nodes
+- `pkg/errors` - Error handling and formatting
+- `pkg/interpreter` - Runtime evaluation
+- `pkg/lexer` - Tokenization
+- `pkg/lineeditor` - REPL line editing
+- `pkg/object` - Runtime object system
+- `pkg/parser` - Syntax parsing
+- `pkg/stdlib` - Standard library functions
+- `pkg/tokenizer` - Token definitions
+- `pkg/typechecker` - Static type checking
+
+### Running Unit Tests
 
 ```bash
 # Run all unit tests
 go test ./...
 
+# Run with verbose output
+go test -v ./...
+
 # Run with coverage summary
 go test ./pkg/... -cover
 
 # Run tests for a specific package
+go test ./pkg/lexer/...
+go test ./pkg/parser/...
+go test ./pkg/ast/...
+go test ./pkg/object/...
+go test ./pkg/errors/...
 go test ./pkg/interpreter/...
 go test ./pkg/typechecker/...
 go test ./pkg/stdlib/...
+go test ./pkg/lineeditor/...
+go test ./pkg/tokenizer/...
 ```
 
 ## Integration Tests
 
-Integration tests are `.ez` files that test the language end-to-end. Error tests verify the compiler catches errors correctly. Pass tests verify language features work correctly.
+Integration tests are `.ez` files that test the language end-to-end. They are located in the `integration-tests/` directory and organized into:
+
+- `integration-tests/pass/` - Tests that should execute successfully
+  - `core/` - Core language feature tests
+  - `stdlib/` - Standard library tests
+  - `multi-file/` - Multi-file project tests
+- `integration-tests/fail/` - Tests that should fail with expected errors
+  - `errors/` - Error detection tests
+  - `multi-file/` - Multi-file error tests
+
+### Running Integration Tests
 
 ```bash
-# Run error tests (files that should fail)
-./tests/errors/run_error_tests.sh ./ez
-
-# Run comprehensive language test (should pass)
-./ez run tests/comprehensive.ez
+# Run all integration tests
+./integration-tests/run_tests.sh
 ```
+
+The test runner will:
+- Execute all pass tests and verify they succeed
+- Execute all fail tests and verify they produce errors
+- Report a summary of passed/failed tests
 
 ## Test Coverage
 

--- a/examples/control_flow.ez
+++ b/examples/control_flow.ez
@@ -37,12 +37,15 @@ do main() {
         println("  ${i}")
     }
 
-    // Descending range (countdown)
+    // Note: Descending ranges like range(5, 0) are now compile-time errors (E9005)
+    // Use as_long_as with decrement if you need to count backwards:
     println("")
-    println("-- Descending range --")
+    println("-- Counting backwards --")
     println("Countdown from 5:")
-    for i in range(5, 0) {
-        println("  ${i}")
+    temp n int = 5
+    as_long_as n > 0 {
+        println("  ${n}")
+        n--
     }
 
     // for_each loop

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # EZ Language Installer
+#
+# Copyright (c) 2025-Present Marshall A Burns
+# Licensed under the MIT License. See LICENSE for details.
+
 set -e
 
 INSTALL_DIR="/usr/local/bin"

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -2,6 +2,9 @@
 #
 # EZ Integration Test Runner
 #
+# Copyright (c) 2025-Present Marshall A Burns
+# Licensed under the MIT License. See LICENSE for details.
+#
 # This script runs all integration tests and reports results.
 # - Tests in pass/ should execute successfully
 # - Tests in fail/ should fail with expected errors

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -1,5 +1,8 @@
 package ast
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"math/big"
 	"testing"

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,5 +1,8 @@
 package errors
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"strings"
 	"testing"

--- a/pkg/errors/format_test.go
+++ b/pkg/errors/format_test.go
@@ -1,5 +1,8 @@
 package errors
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"strings"
 	"testing"

--- a/pkg/errors/suggestions_test.go
+++ b/pkg/errors/suggestions_test.go
@@ -1,5 +1,8 @@
 package errors
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import "testing"
 
 // TestLevenshteinDistance verifies edit distance calculation

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -1,5 +1,8 @@
 package lexer
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"testing"
 

--- a/pkg/lineeditor/terminal_darwin.go
+++ b/pkg/lineeditor/terminal_darwin.go
@@ -2,6 +2,9 @@
 
 package lineeditor
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import "syscall"
 
 // Darwin/macOS ioctl constants for terminal control

--- a/pkg/lineeditor/terminal_linux.go
+++ b/pkg/lineeditor/terminal_linux.go
@@ -2,6 +2,9 @@
 
 package lineeditor
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import "syscall"
 
 // Linux ioctl constants for terminal control

--- a/pkg/lineeditor/terminal_windows.go
+++ b/pkg/lineeditor/terminal_windows.go
@@ -2,6 +2,9 @@
 
 package lineeditor
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"os"
 )

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -1,5 +1,8 @@
 package object
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"math/big"
 	"strings"

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,5 +1,8 @@
 package parser
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"math/big"
 	"strings"

--- a/pkg/stdlib/bytes_test.go
+++ b/pkg/stdlib/bytes_test.go
@@ -1,5 +1,8 @@
 package stdlib
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import (
 	"math/big"
 	"testing"

--- a/pkg/tokenizer/token_test.go
+++ b/pkg/tokenizer/token_test.go
@@ -1,5 +1,8 @@
 package tokenizer
 
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
 import "testing"
 
 // TestTokenTypeConstants verifies all token type constants are defined correctly


### PR DESCRIPTION
## Summary
- Update README integration tests section to reflect new `integration-tests/` directory structure
- Add `pkg/lineeditor` to unit test coverage list
- Add "interpreted" to language description
- Slim down README testing section, link to TESTING.md for details
- Expand TESTING.md with full package list and commands
- Add copyright notices to all Go source files and shell scripts missing them
- Fix `control_flow.ez` example (descending ranges are now compile-time errors)

## Test plan
- [x] All examples pass: `for f in examples/*.ez; do ./ez "$f"; done`
- [x] Integration tests pass: `./integration-tests/run_tests.sh`
- [x] Unit tests pass: `go test ./...`