### PR TITLE
fix: detect variable shadowing of functions from used modules

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -150,6 +150,7 @@ var (
 	E4012 = ErrorCode{"E4012", "shadows-type", "variable shadows a type definition"}
 	E4013 = ErrorCode{"E4013", "shadows-function", "variable shadows a function"}
 	E4014 = ErrorCode{"E4014", "shadows-module", "variable shadows an imported module"}
+	E4015 = ErrorCode{"E4015", "shadows-used-module-function", "variable shadows a function from a used module"}
 )
 
 // =============================================================================

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1442,8 +1442,8 @@ using arrays
 
 do main() {
 	temp nums [int] = {1, 2, 3}
-	temp first int = arrays.first(nums)
-	temp last int = arrays.last(nums)
+	temp first_item int = arrays.first(nums)
+	temp last_item int = arrays.last(nums)
 	temp rev [int] = arrays.reverse(nums)
 }
 `
@@ -1487,8 +1487,8 @@ using strings
 
 do main() {
 	temp s string = "hello"
-	temp upper string = strings.upper(s)
-	temp lower string = strings.lower(s)
+	temp upper_str string = strings.upper(s)
+	temp lower_str string = strings.lower(s)
 	temp trimmed string = strings.trim("  hello  ")
 }
 `
@@ -1502,9 +1502,9 @@ import @time
 using time
 
 do main() {
-	temp year int = time.year()
-	temp month int = time.month()
-	temp day int = time.day()
+	temp cur_year int = time.year()
+	temp cur_month int = time.month()
+	temp cur_day int = time.day()
 }
 `
 	tc := typecheck(t, input)
@@ -1518,9 +1518,53 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp keys [string] = maps.keys(m)
-	temp values [int] = maps.values(m)
-	temp has bool = maps.has(m, "a")
+	temp map_keys [string] = maps.keys(m)
+	temp map_values [int] = maps.values(m)
+	temp key_exists bool = maps.has(m, "a")
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestVariableShadowsUsedModuleFunction(t *testing.T) {
+	// Test that declaring a variable with the same name as a function from a 'used' module
+	// triggers an error - issue #616
+	input := `
+import & use @maps
+
+do main() {
+	temp m map[string:int] = {"a": 1}
+	temp values [int] = {1, 2, 3}
+}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E4015)
+}
+
+func TestVariableShadowsUsedModuleFunctionWithSeparateUsing(t *testing.T) {
+	// Test with separate 'using' statement instead of 'import & use'
+	input := `
+import @arrays
+using arrays
+
+do main() {
+	temp nums [int] = {1, 2, 3}
+	temp reverse [int] = {3, 2, 1}
+}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E4015)
+}
+
+func TestNoErrorWhenNotUsingModule(t *testing.T) {
+	// Test that variable names matching module functions are OK when not using the module
+	input := `
+import @maps
+
+do main() {
+	temp m map[string:int] = {"a": 1}
+	temp values [int] = {1, 2, 3}
 }
 `
 	tc := typecheck(t, input)


### PR DESCRIPTION
## Summary
- Adds compile-time error E4015 when a variable declaration shadows a function from a module imported via `import & use` or `using`
- Prevents confusing runtime errors when users accidentally name variables the same as module functions

Fixes #616

## Test plan
- [x] Added `TestVariableShadowsUsedModuleFunction` - verifies E4015 with `import & use`
- [x] Added `TestVariableShadowsUsedModuleFunctionWithSeparateUsing` - verifies E4015 with separate `using`
- [x] Added `TestNoErrorWhenNotUsingModule` - verifies no error when module not "used"
- [x] All existing typechecker tests pass