### PR TITLE
fix: recursively initialize nested struct fields (#621)

### DIFF
--- a/integration-tests/pass/core/nested_struct_init.ez
+++ b/integration-tests/pass/core/nested_struct_init.ez
@@ -1,0 +1,98 @@
+/*
+ * nested_struct_init.ez - Test nested struct initialization with new() and literals
+ * Regression test for bug #621
+ */
+
+import @std
+using std
+
+const Inner struct {
+    val int
+    name string
+}
+
+const Outer struct {
+    inner Inner
+    count int
+}
+
+const Deep struct {
+    outer Outer
+    label string
+}
+
+do main() {
+    println("=== Nested Struct Init Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: new() initializes nested struct
+    temp o = new(Outer)
+    if o.inner.val == 0 && o.inner.name == "" {
+        println("  [PASS] new() initializes nested struct with defaults")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] new() nested struct not initialized")
+        failed += 1
+    }
+
+    // Test 2: Can modify nested struct field
+    o.inner.val = 42
+    if o.inner.val == 42 {
+        println("  [PASS] can modify nested struct field")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] cannot modify nested struct field")
+        failed += 1
+    }
+
+    // Test 3: Deeply nested structs with new()
+    temp d = new(Deep)
+    if d.outer.inner.val == 0 {
+        println("  [PASS] deeply nested struct initialized with new()")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] deeply nested struct not initialized")
+        failed += 1
+    }
+
+    // Test 4: Can modify deeply nested field
+    d.outer.inner.name = "test"
+    if d.outer.inner.name == "test" {
+        println("  [PASS] can modify deeply nested field")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] cannot modify deeply nested field")
+        failed += 1
+    }
+
+    // Test 5: Empty struct literal initializes nested struct
+    temp o2 = Outer{}
+    if o2.inner.val == 0 && o2.inner.name == "" {
+        println("  [PASS] empty struct literal initializes nested struct")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] empty struct literal nested struct not initialized")
+        failed += 1
+    }
+
+    // Test 6: Partial struct literal initializes unspecified nested struct
+    temp o3 = Outer{count: 5}
+    if o3.inner.val == 0 && o3.count == 5 {
+        println("  [PASS] partial struct literal initializes nested struct")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] partial struct literal nested struct not initialized")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #621 - Nested struct fields are now properly initialized when creating structs with `new()` or struct literals.

**Before:** `hero.attributes.strength = 10` crashed with "member access not supported: NIL"
**After:** Nested struct is automatically initialized, assignment works

## Changes

- Add `getDefaultValueWithEnv()` helper that can look up struct definitions and recursively create nested struct instances
- Update `evalNewExpression()` and `evalStructValue()` to use the new helper
- Handle all integer/float type variants (i8, u32, f64, etc.)
- Add integration test covering:
  - `new()` with nested structs
  - Empty struct literals (`Outer{}`)
  - Partial struct literals (`Outer{count: 5}`)
  - Deeply nested structs (3 levels)

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass (253/254, 1 pre-existing failure)
- [x] EZ-TAG `hero.attributes.strength = 10` now works