### PR TITLE
ci: add docs repo sync trigger after `ERRORS.md` update

### DIFF
--- a/.github/workflows/sync-errors-doc.yml
+++ b/.github/workflows/sync-errors-doc.yml
@@ -43,3 +43,12 @@ jobs:
           git add ERRORS.md
           git commit -m "docs: regenerate ERRORS.md from codes.go"
           git push
+
+      - name: Trigger docs sync
+        if: github.ref == 'refs/heads/main'
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DOCS_REPO_TOKEN }}" \
+            https://api.github.com/repos/SchoolyB/language.ez/dispatches \
+            -d '{"event_type":"sync-errors"}'


### PR DESCRIPTION
## Summary

Adds a workflow step to trigger the docs site sync when ERRORS.md is regenerated.

When `codes.go` changes on main, this workflow:
1. Regenerates ERRORS.md
2. Commits and pushes if changed
3. **NEW:** Triggers the `language.ez` docs repo to sync the updated errors