### PR TITLE
test: add missing test coverage for struct bugs (#622)

### DIFF
--- a/integration-tests/fail/errors/E3001_struct_field_assignment_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_struct_field_assignment_type_mismatch.ez
@@ -1,0 +1,12 @@
+import @std
+using std
+
+const Person struct {
+    name string
+    age int
+}
+
+do main() {
+    temp p = Person{name: "John", age: 30}
+    p.name = 123
+}

--- a/integration-tests/pass/core/structs.ez
+++ b/integration-tests/pass/core/structs.ez
@@ -138,10 +138,40 @@ do main() {
         failed += 1
     }
 
+    // Test 9: new() initializes nested struct fields
+    temp newOuter = new(CopyOuter)
+    if newOuter.inner.val == 0 {
+        println("  [PASS] new() initializes nested struct with defaults")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] new() nested struct not initialized")
+        failed += 1
+    }
+
+    // Test 10: can modify nested struct field after new()
+    newOuter.inner.val = 42
+    if newOuter.inner.val == 42 {
+        println("  [PASS] can modify nested struct field after new()")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] cannot modify nested struct field")
+        failed += 1
+    }
+
+    // Test 11: empty struct literal initializes nested struct
+    temp emptyOuter = CopyOuter{}
+    if emptyOuter.inner.val == 0 {
+        println("  [PASS] empty struct literal initializes nested struct")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] empty struct literal nested struct not initialized")
+        failed += 1
+    }
+
     // ==================== COPY BUILTIN ====================
     println("  -- copy() Builtin --")
 
-    // Test 9: copy struct - verify deep copy
+    // Test 12: copy struct - verify deep copy
     temp a Person = Person{name: "Alice", age: 30, active: true}
     temp b Person = copy(a)
     b.age = 31
@@ -153,7 +183,7 @@ do main() {
         failed += 1
     }
 
-    // Test 10: copy nested struct - verify deep copy
+    // Test 13: copy nested struct - verify deep copy
     temp outer1 CopyOuter = CopyOuter{inner: CopyInner{val: 42}}
     temp outer2 CopyOuter = copy(outer1)
     outer2.inner.val = 99

--- a/pkg/interpreter/evaluator_test.go
+++ b/pkg/interpreter/evaluator_test.go
@@ -1238,6 +1238,43 @@ c.name
 	testStringObject(t, evaluated, "")
 }
 
+func TestNewExpressionNestedStruct(t *testing.T) {
+	// Regression test for issue #621/#622: new() should recursively initialize
+	// nested struct fields instead of leaving them as nil
+	input := `
+const Inner struct {
+	val int
+}
+const Outer struct {
+	inner Inner
+}
+temp o = new(Outer)
+o.inner.val = 42
+o.inner.val
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 42)
+}
+
+func TestStructLiteralNestedStruct(t *testing.T) {
+	// Regression test for issue #621/#622: struct literals should recursively
+	// initialize nested struct fields
+	input := `
+const Inner struct {
+	val int
+}
+const Outer struct {
+	inner Inner
+	name string
+}
+temp o = Outer{name: "test"}
+o.inner.val = 99
+o.inner.val
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 99)
+}
+
 // ============================================================================
 // Loop Statement Tests
 // ============================================================================

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -482,6 +482,24 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
+func TestStructFieldAssignmentTypeMismatch(t *testing.T) {
+	// Regression test for issue #622: struct field assignment type mismatch
+	// was not being caught after initialization
+	input := `
+const Person struct {
+	name string
+	age int
+}
+
+do main() {
+	temp p Person = Person{name: "", age: 0}
+	p.name = 123
+}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3001)
+}
+
 func TestStructWithArrayField(t *testing.T) {
 	// Regression test for issue #336: typechecker crashed when accessing
 	// struct fields with array types due to nil pointer dereference


### PR DESCRIPTION
## Summary
- Add unit test for struct field assignment type mismatch (typechecker)
- Add unit tests for `new()` and struct literal with nested structs (evaluator)
- Add integration test `E3001_struct_field_assignment_type_mismatch.ez`
- Update `structs.ez` with nested struct initialization tests

Closes #622

## Test plan
- [x] `go test ./pkg/typechecker/...` passes
- [x] `go test ./pkg/interpreter/...` passes
- [x] Integration test `structs.ez` passes (13/13 tests)
- [x] New integration test correctly fails with E3001