### PR TITLE
fix: @strict when rejects non-enum expressions (#628)

### DIFF
--- a/integration-tests/fail/errors/E2054_strict_when_non_enum_case.ez
+++ b/integration-tests/fail/errors/E2054_strict_when_non_enum_case.ez
@@ -1,0 +1,19 @@
+import @std
+using std
+
+const Color enum {
+    RED
+    GREEN
+    BLUE
+}
+
+do main() {
+    temp c Color = Color.RED
+
+    @strict
+    when c {
+        is range(0, 2) {
+            println("in range")
+        }
+    }
+}

--- a/integration-tests/fail/errors/E2055_strict_invalid_target.ez
+++ b/integration-tests/fail/errors/E2055_strict_invalid_target.ez
@@ -1,0 +1,7 @@
+import @std
+using std
+
+@strict
+do main() {
+    println("hello")
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -90,6 +90,8 @@ var (
 	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "@suppress can only be applied to function declarations"}
 	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}
 	E2053 = ErrorCode{"E2053", "type-definition-in-function", "type definitions must be at file level"}
+	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "@strict when requires explicit enum member values in cases"}
+	E2055 = ErrorCode{"E2055", "strict-invalid-target", "@strict can only be applied to when statements"}
 )
 
 // =============================================================================

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -106,6 +106,16 @@ func hasSuppressAttribute(attrs []*Attribute) *Attribute {
 	return nil
 }
 
+// hasStrictAttribute checks if attributes contain a @strict attribute
+func hasStrictAttribute(attrs []*Attribute) *Attribute {
+	for _, attr := range attrs {
+		if attr.Name == "strict" {
+			return attr
+		}
+	}
+	return nil
+}
+
 // Operator precedence levels
 const (
 	_ int = iota
@@ -581,6 +591,21 @@ func (p *Parser) parseStatement() Statement {
 			newAttrs := []*Attribute{}
 			for _, attr := range attrs {
 				if attr.Name != "suppress" {
+					newAttrs = append(newAttrs, attr)
+				}
+			}
+			attrs = newAttrs
+		}
+	}
+
+	// Validate @strict is only used on when statements
+	if strictAttr := hasStrictAttribute(attrs); strictAttr != nil {
+		if !p.currentTokenMatches(WHEN) {
+			p.addEZError(errors.E2055, "@strict can only be applied to when statements", strictAttr.Token)
+			// Clear @strict attributes to prevent them from being applied
+			newAttrs := []*Attribute{}
+			for _, attr := range attrs {
+				if attr.Name != "strict" {
 					newAttrs = append(newAttrs, attr)
 				}
 			}

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2087,3 +2087,56 @@ func TestAnyTypeNotAllowedInMap(t *testing.T) {
 	tc := typecheck(t, input)
 	assertHasError(t, tc, errors.E3034)
 }
+
+// ============================================================================
+// @strict When Statement Tests (#628)
+// ============================================================================
+
+func TestStrictWhenRejectsRangeExpression(t *testing.T) {
+	input := `
+const Color enum { RED, GREEN, BLUE }
+do main() {
+	temp c Color = Color.RED
+	@strict
+	when c {
+		is range(0, 2) {
+		}
+	}
+}`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E2054)
+}
+
+func TestStrictWhenRejectsIntegerLiteral(t *testing.T) {
+	input := `
+const Color enum { RED, GREEN, BLUE }
+do main() {
+	temp c Color = Color.RED
+	@strict
+	when c {
+		is 0 {
+		}
+	}
+}`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E2054)
+}
+
+func TestStrictWhenAcceptsEnumMembers(t *testing.T) {
+	input := `
+const Color enum { RED, GREEN, BLUE }
+do main() {
+	temp c Color = Color.RED
+	@strict
+	when c {
+		is Color.RED {
+		}
+		is Color.GREEN {
+		}
+		is Color.BLUE {
+		}
+	}
+}`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}


### PR DESCRIPTION
## Summary
- Add E2054 error for non-enum case values in @strict when statements
- Add E2055 error for @strict applied to non-when statements  
- Only allow explicit enum member references (e.g., `Color.RED`) in @strict when cases
- Reject `range()`, integer literals, and other non-enum expressions

Closes #628

## Test plan
- [x] Unit tests for E2054 (range, integer literals rejected)
- [x] Unit test for valid enum members accepted
- [x] Integration test `E2054_strict_when_non_enum_case.ez`
- [x] Integration test `E2055_strict_invalid_target.ez`
- [x] All existing tests pass