### PR TITLE
fix: `@strict` when enforces enum exhaustiveness at compile time (#629)

### DIFF
--- a/integration-tests/fail/errors/E2046_strict_when_missing_cases.ez
+++ b/integration-tests/fail/errors/E2046_strict_when_missing_cases.ez
@@ -1,0 +1,20 @@
+import @std
+using std
+
+const Color enum {
+    RED
+    GREEN
+    BLUE
+}
+
+do main() {
+    temp c Color = Color.RED
+
+    @strict
+    when c {
+        is Color.RED {
+            println("red")
+        }
+        // Missing GREEN and BLUE
+    }
+}

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2140,3 +2140,35 @@ do main() {
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
+
+func TestStrictWhenMissingEnumCases(t *testing.T) {
+	input := `
+const Color enum { RED, GREEN, BLUE }
+do main() {
+	temp c Color = Color.RED
+	@strict
+	when c {
+		is Color.RED {
+		}
+	}
+}`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E2046)
+}
+
+func TestStrictWhenPartialEnumCases(t *testing.T) {
+	input := `
+const Color enum { RED, GREEN, BLUE }
+do main() {
+	temp c Color = Color.RED
+	@strict
+	when c {
+		is Color.RED {
+		}
+		is Color.GREEN {
+		}
+	}
+}`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E2046)
+}


### PR DESCRIPTION
## Summary
- Add compile-time exhaustiveness check for `@strict` enum when statements
- Track handled enum cases during type checking
- Report missing cases with E2046 error listing all unhandled variants
- Example error: `@strict when statement missing enum cases: BLUE, GREEN`

Closes #629

## Test plan
- [x] Unit test for missing all but one enum case
- [x] Unit test for missing one enum case (partial)
- [x] Unit test for all cases handled (passes)
- [x] Integration test `E2046_strict_when_missing_cases.ez`
- [x] All existing tests pass