### PR TITLE
fix: duplicate map keys in literal now produce compile-time error (#641)

### DIFF
--- a/integration-tests/fail/errors/E12006_map_duplicate_key.ez
+++ b/integration-tests/fail/errors/E12006_map_duplicate_key.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E12006 - map-duplicate-key
+ * Expected: "duplicate key" in map literal
+ */
+
+do main() {
+    temp m map[string:int] = {
+        "a": 1,
+        "b": 2,
+        "a": 3
+    }
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -321,6 +321,7 @@ var (
 	E12003 = ErrorCode{"E12003", "map-key-not-found", "key not found in map"}
 	E12004 = ErrorCode{"E12004", "map-invalid-pair", "map entry must be a [key, value] pair"}
 	E12005 = ErrorCode{"E12005", "map-value-not-hashable", "map value is not hashable and cannot become a key"}
+	E12006 = ErrorCode{"E12006", "map-duplicate-key", "map literal contains duplicate key"}
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Map literals with duplicate keys now generate error E12006 at compile time instead of silently accepting the duplicate (with the last value winning)
- Added E12006 error code for map-duplicate-key
- Added duplicate key detection in typechecker's MapValue case
- Added integration test for the new error

## Test plan
- [x] `go test ./...` passes
- [x] New integration test `E12006_map_duplicate_key.ez` correctly triggers error
- [x] Verified error message shows line number of first occurrence

Closes #641