### PR TITLE
fix: float display now shows actual precision for debugging (#640)

### DIFF
--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/marshallburns/ez/pkg/ast"
@@ -68,10 +69,13 @@ type Float struct {
 
 func (f *Float) Type() ObjectType { return FLOAT_OBJ }
 func (f *Float) Inspect() string {
-	s := fmt.Sprintf("%.10f", f.Value)
-	s = strings.TrimRight(s, "0")
-	if strings.HasSuffix(s, ".") {
-		s += "0"
+	// Use %g format which shows the shortest representation that
+	// accurately represents the value - important for debugging
+	// floating point precision issues (#640)
+	s := strconv.FormatFloat(f.Value, 'g', -1, 64)
+	// Ensure whole numbers still show as floats (e.g., "1" -> "1.0")
+	if !strings.Contains(s, ".") && !strings.Contains(s, "e") {
+		s += ".0"
 	}
 	return s
 }


### PR DESCRIPTION
## Summary
- Changed Float.Inspect() to use strconv.FormatFloat with 'g' format
- Shows shortest representation that accurately represents the value
- Reveals floating point precision issues that were previously hidden

## Before/After
```
Before: 0.1 + 0.2 displayed as "0.3" (misleading)
After:  0.1 + 0.2 displays as "0.30000000000000004" (accurate)
```

Clean values like 1.0, 3.14, 0.5 still display normally.

## Test plan
- [x] `go test ./...` passes
- [x] Verified 0.1 + 0.2 now shows actual value
- [x] Verified clean floats (1.0, 3.14, 0.5) display normally

Closes #640