### PR TITLE
fix: version update detection and error sync workflow

### DIFF
--- a/.github/workflows/sync-errors-doc.yml
+++ b/.github/workflows/sync-errors-doc.yml
@@ -1,22 +1,32 @@
 name: Sync ERRORS.md
 
 on:
-  push:
+  pull_request:
     branches:
       - main
     paths:
       - 'pkg/errors/codes.go'
+  push:
+    branches:
+      - main
+    paths:
+      - 'ERRORS.md'
 
 jobs:
   sync:
     name: Regenerate ERRORS.md
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -35,7 +45,7 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push
+      - name: Commit changes to PR
         if: steps.check.outputs.changed == 'true'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -44,8 +54,12 @@ jobs:
           git commit -m "docs: regenerate ERRORS.md from codes.go"
           git push
 
+  trigger-docs:
+    name: Trigger docs sync
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
       - name: Trigger docs sync
-        if: github.ref == 'refs/heads/main'
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/cmd/ez/update.go
+++ b/cmd/ez/update.go
@@ -128,15 +128,18 @@ func parseVersion(v string) (major, minor, patch int) {
 	return
 }
 
-// isNewerVersion returns true if remote version has higher major or minor than local
+// isNewerVersion returns true if remote version is higher than local
 func isNewerVersion(local, remote string) bool {
-	localMajor, localMinor, _ := parseVersion(local)
-	remoteMajor, remoteMinor, _ := parseVersion(remote)
+	localMajor, localMinor, localPatch := parseVersion(local)
+	remoteMajor, remoteMinor, remotePatch := parseVersion(remote)
 
 	if remoteMajor > localMajor {
 		return true
 	}
 	if remoteMajor == localMajor && remoteMinor > localMinor {
+		return true
+	}
+	if remoteMajor == localMajor && remoteMinor == localMinor && remotePatch > localPatch {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- Fix patch version comparison in update check (v0.22.1 → v0.22.2 now detected)
- Show latest available version in `ez version` output
- Run error sync workflow on PRs instead of push to main (fixes protected branch issue)
- Fix E3030 type-as-value error to trigger for most functions while still allowing type args for json.decode

## Test plan
- [x] All 259 integration tests pass
- [x] `ez version` shows latest version from GitHub
- [x] `ez update` correctly detects patch version updates
- [x] `json.decode` still accepts type arguments
- [x] `copy(EnumType)` now triggers E3030 error