### PR TITLE
test: improve unit test coverage across packages

### DIFF
--- a/.github/workflows/sync-errors-doc.yml
+++ b/.github/workflows/sync-errors-doc.yml
@@ -52,6 +52,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add ERRORS.md
           git commit -m "docs: regenerate ERRORS.md from codes.go"
+          git pull --rebase
           git push
 
   trigger-docs:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
   <a href="https://schoolyb.github.io/language.ez/docs">Documentation</a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/SchoolyB/EZ/actions/workflows/ci.yml"><img src="https://github.com/SchoolyB/EZ/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/SchoolyB/EZ/actions/workflows/codeql-analysis.yml"><img src="https://github.com/SchoolyB/EZ/actions/workflows/codeql-analysis.yml/badge.svg" alt="CodeQL Security Scan"></a>
+</p>
+
 ---
 
 ## Developer Quick Start

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -3212,3 +3212,131 @@ func TestGetTimeWithInvalidArg(t *testing.T) {
 		t.Error("getTime with invalid arg should return current time")
 	}
 }
+
+// ============================================================================
+// Arrays Helper Function Tests
+// ============================================================================
+
+func TestCompareObjectsIntegers(t *testing.T) {
+	tests := []struct {
+		a, b     int64
+		expected int
+	}{
+		{1, 2, -1},
+		{2, 1, 1},
+		{5, 5, 0},
+		{-10, 10, -1},
+		{0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		a := &object.Integer{Value: big.NewInt(tt.a)}
+		b := &object.Integer{Value: big.NewInt(tt.b)}
+		result := compareObjects(a, b)
+		if result != tt.expected {
+			t.Errorf("compareObjects(%d, %d) = %d, want %d", tt.a, tt.b, result, tt.expected)
+		}
+	}
+}
+
+func TestCompareObjectsFloats(t *testing.T) {
+	tests := []struct {
+		a, b     float64
+		expected int
+	}{
+		{1.0, 2.0, -1},
+		{2.0, 1.0, 1},
+		{3.14, 3.14, 0},
+		{-1.5, 1.5, -1},
+	}
+
+	for _, tt := range tests {
+		a := &object.Float{Value: tt.a}
+		b := &object.Float{Value: tt.b}
+		result := compareObjects(a, b)
+		if result != tt.expected {
+			t.Errorf("compareObjects(%f, %f) = %d, want %d", tt.a, tt.b, result, tt.expected)
+		}
+	}
+}
+
+func TestCompareObjectsStrings(t *testing.T) {
+	tests := []struct {
+		a, b     string
+		expected int
+	}{
+		{"apple", "banana", -1},
+		{"banana", "apple", 1},
+		{"hello", "hello", 0},
+		{"", "a", -1},
+		{"z", "a", 1},
+	}
+
+	for _, tt := range tests {
+		a := &object.String{Value: tt.a}
+		b := &object.String{Value: tt.b}
+		result := compareObjects(a, b)
+		if result != tt.expected {
+			t.Errorf("compareObjects(%q, %q) = %d, want %d", tt.a, tt.b, result, tt.expected)
+		}
+	}
+}
+
+func TestCompareObjectsFallback(t *testing.T) {
+	// Test with boolean (uses Inspect fallback)
+	a := &object.Boolean{Value: false}
+	b := &object.Boolean{Value: true}
+	result := compareObjects(a, b)
+	// "false" < "true" lexicographically
+	if result != -1 {
+		t.Errorf("compareObjects(false, true) = %d, want -1", result)
+	}
+}
+
+func TestObjectsEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     object.Object
+		expected bool
+	}{
+		{
+			"same integers",
+			&object.Integer{Value: big.NewInt(42)},
+			&object.Integer{Value: big.NewInt(42)},
+			true,
+		},
+		{
+			"different integers",
+			&object.Integer{Value: big.NewInt(1)},
+			&object.Integer{Value: big.NewInt(2)},
+			false,
+		},
+		{
+			"same strings",
+			&object.String{Value: "hello"},
+			&object.String{Value: "hello"},
+			true,
+		},
+		{
+			"different strings",
+			&object.String{Value: "hello"},
+			&object.String{Value: "world"},
+			false,
+		},
+		{
+			"different types",
+			&object.Integer{Value: big.NewInt(1)},
+			&object.String{Value: "1"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := objectsEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("objectsEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Improved test coverage across interpreter, stdlib, typechecker, lineeditor, and object packages
- Added tests for when statements with different types (strings, chars, booleans, enums)
- Added integer overflow/underflow detection tests for various integer types (i8, i16, u8, u16, i128, u128)
- Added assignment and mutation tests (array elements, map elements, struct fields)
- Added tests for JSON conversion functions (zeroValueForType, convertToTypedValue)
- Fixed workflow rebase issues and added README badges

## Coverage Improvements
- interpreter: 60.8% → 63.8%
- stdlib: 53.5% → 54.5%
- typechecker: improved
- object: improved

## Test plan
- [x] All existing tests pass
- [x] New tests pass
- [x] `go test ./pkg/...` succeeds