### PR TITLE
fix: cross-module nested struct initialization

### DIFF
--- a/integration-tests/pass/multi-file/cross-module-nested-struct/main/main.ez
+++ b/integration-tests/pass/multi-file/cross-module-nested-struct/main/main.ez
@@ -1,0 +1,54 @@
+/*
+ * main.ez - Test cross-module nested struct initialization
+ * Regression test for issue #621/#649
+ *
+ * Bug: When creating a struct from another module that has nested struct fields,
+ * the nested structs were not being initialized (left as NIL), causing
+ * "member access not supported: NIL" errors.
+ */
+
+module main
+
+import @std
+import lib"../src/lib"
+
+using std
+
+do main() {
+    println("=== Cross-Module Nested Struct Init Test ===")
+
+    // Test 1: new() with module-qualified type initializes nested struct
+    temp o = new(lib.Outer)
+    o.inner.value = 42
+    o.inner.name = "test"
+    println("  [PASS] new(lib.Outer) - set nested struct fields")
+    println("    inner.value = ${o.inner.value}")
+    println("    inner.name = ${o.inner.name}")
+
+    // Test 2: Deeply nested structs with new()
+    temp d = new(lib.Deep)
+    d.outer.inner.value = 99
+    d.outer.inner.name = "deep"
+    d.outer.count = 10
+    d.label = "test"
+    println("  [PASS] new(lib.Deep) - set deeply nested fields")
+    println("    outer.inner.value = ${d.outer.inner.value}")
+    println("    outer.inner.name = ${d.outer.inner.name}")
+    println("    outer.count = ${d.outer.count}")
+
+    // Test 3: Empty struct literal initializes nested struct
+    temp o2 = lib.Outer{}
+    o2.inner.value = 100
+    println("  [PASS] lib.Outer{} - set nested struct field")
+    println("    inner.value = ${o2.inner.value}")
+
+    // Test 4: Partial struct literal initializes unspecified nested struct
+    temp o3 = lib.Outer{count: 5}
+    o3.inner.value = 200
+    println("  [PASS] lib.Outer{count: 5} - set nested struct field")
+    println("    count = ${o3.count}")
+    println("    inner.value = ${o3.inner.value}")
+
+    println("")
+    println("ALL TESTS PASSED")
+}

--- a/integration-tests/pass/multi-file/cross-module-nested-struct/src/lib/types.ez
+++ b/integration-tests/pass/multi-file/cross-module-nested-struct/src/lib/types.ez
@@ -1,0 +1,21 @@
+/*
+ * types.ez - Nested struct definitions for cross-module test
+ * Regression test for issue #621/#649 - cross-module nested struct init
+ */
+
+module lib
+
+const Inner struct {
+    value int
+    name string
+}
+
+const Outer struct {
+    inner Inner
+    count int
+}
+
+const Deep struct {
+    outer Outer
+    label string
+}


### PR DESCRIPTION
## Summary

Fixes the regression where nested struct fields in cross-module structs were not being initialized, causing "member access not supported: NIL" errors.

**Before:** `hero.attributes.strength = 10` crashed with "member access not supported: NIL" when `Hero` was imported from another module
**After:** Nested structs are automatically initialized from the source module

## Root Cause

When creating a struct from another module (e.g., `new(lib.Hero)`), `getDefaultValueWithEnv()` only looked up nested struct types in:
1. The current environment (main module)
2. Modules from "using" directives

It did **not** look in the source module where the parent struct was defined. So when `Hero` has a field `attributes HeroAttributes`, the lookup for `HeroAttributes` failed because it's only defined in the `library` module.

## Changes

- Add `sourceModule` parameter to `getDefaultValueWithEnv()` to track module context
- Update `evalNewExpression()` and `evalStructValue()` to pass the source module
- Check source module first when looking up nested struct types
- Add integration test for cross-module nested struct initialization

## Test plan

- [x] All 260 integration tests pass
- [x] All unit tests pass
- [x] EZ-TAG `hero.attributes.strength = x` now works
- [x] New regression test added