### PR TITLE
fix(stdlib): `arrays.set()` now modifies array in place

### DIFF
--- a/integration-tests/pass/stdlib/arrays.ez
+++ b/integration-tests/pass/stdlib/arrays.ez
@@ -209,6 +209,42 @@ do main() {
         failed += 1
     }
 
+    // ==================== arrays.set ====================
+    println("  -- arrays.set --")
+
+    // Test: set element at index
+    temp set_arr [int] = {1, 2, 3}
+    arrays.set(set_arr, 1, 99)
+    if set_arr[0] == 1 && set_arr[1] == 99 && set_arr[2] == 3 {
+        println("  [PASS] arrays.set({1,2,3}, 1, 99) = {1,99,3}")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] arrays.set: expected {1,99,3}, got ${set_arr}")
+        failed += 1
+    }
+
+    // Test: set first element
+    temp set_first [int] = {10, 20, 30}
+    arrays.set(set_first, 0, 99)
+    if set_first[0] == 99 && set_first[1] == 20 {
+        println("  [PASS] arrays.set at index 0")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] arrays.set at index 0: got ${set_first}")
+        failed += 1
+    }
+
+    // Test: set last element
+    temp set_last [int] = {10, 20, 30}
+    arrays.set(set_last, 2, 99)
+    if set_last[2] == 99 && set_last[1] == 20 {
+        println("  [PASS] arrays.set at last index")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] arrays.set at last index: got ${set_last}")
+        failed += 1
+    }
+
     // ==================== arrays.shift ====================
     println("  -- arrays.shift --")
 

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -340,6 +340,12 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7002", Message: "arrays.set() requires an array"}
 			}
+			if !arr.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable array (declared as const)",
+					Code:    "E4005",
+				}
+			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.set() requires an integer index"}
@@ -348,10 +354,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if index < 0 || index >= len(arr.Elements) {
 				return &object.Error{Code: "E5003", Message: "arrays.set() index out of bounds"}
 			}
-			newElements := make([]object.Object, len(arr.Elements))
-			copy(newElements, arr.Elements)
-			newElements[index] = args[2]
-			return &object.Array{Elements: newElements}
+			arr.Elements[index] = args[2]
+			return object.NIL
 		},
 	},
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4267,9 +4267,9 @@ func (tc *TypeChecker) checkArraysModuleCall(funcName string, call *ast.CallExpr
 		"take":      {2, 2, []string{"array", "int"}, "array"},
 		"drop":      {2, 2, []string{"array", "int"}, "array"},
 
-		// Array + int + value
-		"set":    {3, 3, []string{"array", "int", "any"}, "array"},
-		"insert": {3, 3, []string{"array", "int", "any"}, "array"},
+		// Array + int + value (modify in-place, return void)
+		"set":    {3, 3, []string{"array", "int", "any"}, "void"},
+		"insert": {3, 3, []string{"array", "int", "any"}, "void"},
 
 		// Array + int + int (optional)
 		"slice": {2, 3, []string{"array", "int", "int"}, "array"},


### PR DESCRIPTION
## Summary
- Fixed `arrays.set()` to modify array in-place and return `void` instead of returning a new array
- Added mutability check to prevent modifying const arrays
- Fixed typechecker to correctly declare `set`/`insert` return `void`, not `array`

## Test plan
- [x] Unit tests added for `arrays.set()` (5 tests)
- [x] Integration tests added for `arrays.set()` (3 tests)
- [x] All 260 integration tests pass
- [x] All Go unit tests pass

Fixes #652