### PR TITLE
fix: allow nil return for error type in user-defined functions

### DIFF
--- a/integration-tests/pass/core/error_handling.ez
+++ b/integration-tests/pass/core/error_handling.ez
@@ -1,0 +1,81 @@
+/*
+ * error_handling.ez - Test error type with nil returns
+ */
+
+import @std
+using std
+
+// Function that can fail - uses error type (lowercase)
+do parse_int(s string) -> (int, error) {
+    if s == "" {
+        return 0, error("empty string")
+    }
+    if s == "bad" {
+        return 0, error("invalid input")
+    }
+    return 42, nil
+}
+
+// Function using Error type (capitalized) - should also work
+do parse_float(s string) -> (float, Error) {
+    if s == "" {
+        return 0.0, error("empty string")
+    }
+    return 3.14, nil
+}
+
+do main() {
+    println("=== Error Handling Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: successful parse with error type
+    temp val1, err1 = parse_int("42")
+    if err1 == nil && val1 == 42 {
+        println("  [PASS] parse_int success returns nil error")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] parse_int success case")
+        failed += 1
+    }
+
+    // Test 2: failed parse with error type  
+    temp val2, err2 = parse_int("bad")
+    if err2 != nil && val2 == 0 {
+        println("  [PASS] parse_int failure returns error")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] parse_int failure case")
+        failed += 1
+    }
+
+    // Test 3: successful parse with Error type (capitalized)
+    temp val3, err3 = parse_float("3.14")
+    if err3 == nil && val3 == 3.14 {
+        println("  [PASS] parse_float success returns nil error")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] parse_float success case")
+        failed += 1
+    }
+
+    // Test 4: failed parse with Error type (capitalized)
+    temp val4, err4 = parse_float("")
+    if err4 != nil {
+        println("  [PASS] parse_float failure returns error")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] parse_float failure case")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2554,13 +2554,18 @@ func typeMatches(obj Object, ezType string) bool {
 		// nil matches nil, or any non-primitive type
 		// For now, we'll accept nil for any type except explicit primitives
 		// This allows: return nil as Error
-		return ezType == "nil" || ezType == "Error" || ezType == "array" ||
+		return ezType == "nil" || ezType == "Error" || ezType == "error" || ezType == "array" ||
 			(ezType != "int" && ezType != "float" && ezType != "string" &&
 				ezType != "bool" && ezType != "char" && !isIntegerType(ezType))
 	}
 
 	// Exact match
 	if actualType == ezType {
+		return true
+	}
+
+	// error/Error are interchangeable (error is alias for Error struct)
+	if (actualType == "error" && ezType == "Error") || (actualType == "Error" && ezType == "error") {
 		return true
 	}
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2876,9 +2876,13 @@ func (tc *TypeChecker) extractMapValueType(mapType string) string {
 }
 
 // isNullableType checks if a type can accept nil values
-// Only user-defined struct types can be nil in EZ
+// error type and user-defined struct types can be nil in EZ
 // Arrays, maps, and primitives cannot be nil
 func (tc *TypeChecker) isNullableType(typeName string) bool {
+	// error type can be nil (for error handling pattern)
+	if typeName == "error" {
+		return true
+	}
 	// User-defined struct types can be nil
 	if t, exists := tc.types[typeName]; exists && t.Kind == StructType {
 		return true
@@ -3691,6 +3695,11 @@ func (tc *TypeChecker) promoteNumericTypes(left, right string) string {
 func (tc *TypeChecker) typesCompatible(declared, actual string) bool {
 	// Exact match
 	if declared == actual {
+		return true
+	}
+
+	// error/Error are interchangeable (error is alias for Error struct)
+	if (declared == "error" && actual == "Error") || (declared == "Error" && actual == "error") {
 		return true
 	}
 


### PR DESCRIPTION
## Summary
- `error` type can now accept `nil` values in return statements
- `error` and `Error` are now interchangeable (error is alias for Error struct)
- Enables the standard error handling pattern:

```ez
do parse(s string) -> (int, error) {
    if bad {
        return 0, error("failed")
    }
    return 42, nil  // nil = no error
}

temp val, err = parse(input)
if err != nil {
    // handle error
}
```

## Test plan
- [x] Integration test added for error handling pattern
- [x] All 261 integration tests pass
- [x] All Go unit tests pass

Fixes #657