### PR TITLE
fix: detect missing return on all code paths at check time

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -130,6 +130,7 @@ Type system errors
 | E3032 | enum-type-mismatch | cannot compare values from different enum types |
 | E3033 | duplicate-enum-value | enum contains duplicate values |
 | E3034 | any-type-not-allowed | 'any' type is reserved for internal use |
+| E3035 | not-all-paths-return | not all code paths return a value |
 
 ## Reference Errors (E4xxx)
 

--- a/integration-tests/fail/errors/E3035_not_all_paths_return.ez
+++ b/integration-tests/fail/errors/E3035_not_all_paths_return.ez
@@ -1,0 +1,20 @@
+/*
+ * Error Test: E3035 - not-all-paths-return
+ *
+ * Functions with return types must return a value on ALL code paths.
+ * This function only returns in the if branch, not the fallthrough.
+ */
+import @std
+using std
+
+do maybe_return(x int) -> int {
+    if x > 0 {
+        return x
+    }
+    // Missing return when x <= 0
+}
+
+do main() {
+    temp result int = maybe_return(5)
+    println(result)
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -132,6 +132,7 @@ var (
 	E3032 = ErrorCode{"E3032", "enum-type-mismatch", "cannot compare values from different enum types"}
 	E3033 = ErrorCode{"E3033", "duplicate-enum-value", "enum contains duplicate values"}
 	E3034 = ErrorCode{"E3034", "any-type-not-allowed", "'any' type is reserved for internal use"}
+	E3035 = ErrorCode{"E3035", "not-all-paths-return", "not all code paths return a value"}
 )
 
 // =============================================================================

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -687,6 +687,115 @@ do main() {}
 }
 
 // ============================================================================
+// All Paths Return Tests (E3035)
+// ============================================================================
+
+func TestNotAllPathsReturn_IfWithoutOtherwise(t *testing.T) {
+	input := `
+do maybe_return(x int) -> int {
+	if x > 0 {
+		return x
+	}
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3035)
+}
+
+func TestNotAllPathsReturn_IfOrWithoutOtherwise(t *testing.T) {
+	input := `
+do classify(x int) -> string {
+	if x > 0 {
+		return "positive"
+	} or x < 0 {
+		return "negative"
+	}
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3035)
+}
+
+func TestNotAllPathsReturn_ReturnOnlyInLoop(t *testing.T) {
+	input := `
+do find_first(arr [int]) -> int {
+	for_each i in arr {
+		return i
+	}
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3035)
+}
+
+func TestAllPathsReturn_IfOtherwise(t *testing.T) {
+	input := `
+do get_sign(x int) -> string {
+	if x > 0 {
+		return "positive"
+	} otherwise {
+		return "non-positive"
+	}
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestAllPathsReturn_IfOrOtherwise(t *testing.T) {
+	input := `
+do classify(x int) -> string {
+	if x > 0 {
+		return "positive"
+	} or x < 0 {
+		return "negative"
+	} otherwise {
+		return "zero"
+	}
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestAllPathsReturn_DirectReturn(t *testing.T) {
+	input := `
+do double(x int) -> int {
+	return x * 2
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestAllPathsReturn_ReturnAfterIf(t *testing.T) {
+	input := `
+do abs_value(x int) -> int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+// ============================================================================
 // Operator Type Checking Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Adds control flow analysis to the typechecker to verify that functions with return types return a value on ALL code paths
- Previously, code would pass check but crash at runtime when a non-returning path was executed
- Now correctly produces error E3035 at check time

## Example

```ez
do maybe_return(x int) -> int {
    if x > 0 {
        return x
    }
    // No return when x <= 0 - now caught at check time!
}
```

## Changes

- Add `allPathsReturn()` and `ifAllPathsReturn()` for control flow analysis
- Add error code E3035 (not-all-paths-return)
- Add 7 unit tests covering various scenarios
- Add integration test for E3035

## Test plan

- [x] All existing tests pass (262 integration tests, all unit tests)
- [x] New unit tests cover: if without otherwise, if/or without otherwise, return only in loop, if/otherwise, if/or/otherwise, direct return, return after if

Closes #660