### PR TITLE
chore: cleanup `ez.bin` references and fix CI sync workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Build interpreter
-        run: go build -o ez.bin ./cmd/ez
+        run: go build -o ez ./cmd/ez
         if: runner.os != 'Windows'
 
       - name: Build interpreter (Windows)
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run interpreter tests
         if: runner.os != 'Windows'
-        run: ./ez.bin run tests/comprehensive.ez
+        run: ./ez run tests/comprehensive.ez
 
       - name: Run interpreter tests (Windows)
         if: runner.os == 'Windows'
@@ -48,7 +48,7 @@ jobs:
         run: |
           for file in examples/*.ez; do
             echo "Validating $file..."
-            ./ez.bin build "$file" || exit 1
+            ./ez build "$file" || exit 1
           done
 
       - name: Validate example files (Windows)
@@ -65,14 +65,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           echo "Testing REPL..."
-          echo -e "temp x int = 5\nx + 10\nexit" | timeout 5 ./ez.bin repl | grep -q "15"
+          echo -e "temp x int = 5\nx + 10\nexit" | timeout 5 ./ez repl | grep -q "15"
 
       - name: Test REPL basic functionality (macOS)
         if: runner.os == 'macOS'
         run: |
           echo "Testing REPL..."
           # macOS doesn't have timeout, use a subshell with background process
-          (echo -e "temp x int = 5\nx + 10\nexit" | ./ez.bin repl > /tmp/repl_output.txt) &
+          (echo -e "temp x int = 5\nx + 10\nexit" | ./ez repl > /tmp/repl_output.txt) &
           pid=$!
           sleep 5
           kill $pid 2>/dev/null || true

--- a/.github/workflows/sync-errors-doc.yml
+++ b/.github/workflows/sync-errors-doc.yml
@@ -52,8 +52,9 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add ERRORS.md
           git commit -m "docs: regenerate ERRORS.md from codes.go"
-          git pull --rebase
-          git push
+          # Pull latest changes and rebase, then push to current branch
+          git pull --rebase origin ${{ github.head_ref }}
+          git push origin HEAD:${{ github.head_ref }}
 
   trigger-docs:
     name: Trigger docs sync

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ uninstall:
 clean:
 	@echo "Cleaning build artifacts..."
 	@rm -f $(BINARY_NAME)
-	@rm -f ez.bin
 	@rm -rf dist/
 	@echo "Clean complete"
 


### PR DESCRIPTION
## Summary

Quick cleanup:
- Replace all `ez.bin` references with `ez` in CI workflow
- Remove `ez.bin` from Makefile clean target
- Fix `sync-errors-doc.yml` to push to the correct PR branch instead of main

## Changes

1. **CI workflow**: `go build -o ez.bin` → `go build -o ez`
2. **Makefile**: Remove `@rm -f ez.bin` from clean target
3. **sync-errors-doc.yml**: Explicitly push to `HEAD:${{ github.head_ref }}` instead of defaulting to main