### PR TITLE
feat(typechecker): reject executable statements at file scope

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -89,6 +89,9 @@ Syntax and parsing errors
 | E2051 | suppress-invalid-target | @suppress can only be applied to function declarations |
 | E2052 | suppress-invalid-code | warning code cannot be suppressed |
 | E2053 | type-definition-in-function | type definitions must be at file level |
+| E2054 | when-strict-non-enum-case | @strict when requires explicit enum member values in cases |
+| E2055 | strict-invalid-target | @strict can only be applied to when statements |
+| E2056 | executable-at-file-scope | executable statement not allowed at file scope |
 
 ## Type Errors (E3xxx)
 
@@ -302,6 +305,7 @@ Map-specific errors
 | E12003 | map-key-not-found | key not found in map |
 | E12004 | map-invalid-pair | map entry must be a [key, value] pair |
 | E12005 | map-value-not-hashable | map value is not hashable and cannot become a key |
+| E12006 | map-duplicate-key | map literal contains duplicate key |
 
 ## JSON Errors (E13xxx)
 
@@ -360,4 +364,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 230 error/warning codes
+**Total:** 235 error/warning codes

--- a/integration-tests/fail/errors/E2056_assignment_at_file_scope.ez
+++ b/integration-tests/fail/errors/E2056_assignment_at_file_scope.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E2056 - executable-at-file-scope
+ * Expected: "file scope" or "not allowed"
+ */
+
+import @std
+using std
+
+temp x = 5
+x += 1  // assignment at file scope
+
+do main() {
+    println("main")
+}

--- a/integration-tests/fail/errors/E2056_for_at_file_scope.ez
+++ b/integration-tests/fail/errors/E2056_for_at_file_scope.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E2056 - executable-at-file-scope
+ * Expected: "file scope" or "not allowed"
+ */
+
+import @std
+using std
+
+for i in range(0, 3) {
+    println(i)
+}
+
+do main() {
+    println("main")
+}

--- a/integration-tests/fail/errors/E2056_function_call_at_file_scope.ez
+++ b/integration-tests/fail/errors/E2056_function_call_at_file_scope.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E2056 - executable-at-file-scope
+ * Expected: "file scope" or "not allowed"
+ */
+
+import @std
+using std
+
+println("function call at file scope")
+
+do main() {
+    println("main")
+}

--- a/integration-tests/fail/errors/E2056_if_at_file_scope.ez
+++ b/integration-tests/fail/errors/E2056_if_at_file_scope.ez
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E2056 - executable-at-file-scope
+ * Expected: "file scope" or "not allowed"
+ */
+
+import @std
+using std
+
+if true {
+    println("if at file scope")
+}
+
+do main() {
+    println("main")
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -92,6 +92,7 @@ var (
 	E2053 = ErrorCode{"E2053", "type-definition-in-function", "type definitions must be at file level"}
 	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "@strict when requires explicit enum member values in cases"}
 	E2055 = ErrorCode{"E2055", "strict-invalid-target", "@strict can only be applied to when statements"}
+	E2056 = ErrorCode{"E2056", "executable-at-file-scope", "executable statement not allowed at file scope"}
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds file scope validation to prevent control flow and executable statements outside functions
- Only declarations (import, using, functions, types, variables) allowed at file scope
- Added error code E2056 "executable-at-file-scope"

## Changes
- Added `checkFileScopeStatements()` function to typechecker
- Rejects: `if`, `for`, `for_each`, `when`, `as_long_as`, `loop`, function calls, assignments, `return`, `break`, `continue`, and block statements at file scope
- Added 4 integration tests for E2056

## Test plan
- [x] Run `./integration-tests/run_tests.sh` - 263 passing, 3 pre-existing failures (issue #671)
- [x] Verify E2056 errors are produced for invalid file-scope statements

Closes #662