### PR TITLE
fix(typechecker): detect undefined variables in assignment targets

### DIFF
--- a/integration-tests/fail/errors/E4001_use_before_declaration.ez
+++ b/integration-tests/fail/errors/E4001_use_before_declaration.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E4001 - undefined-variable (use before declaration)
+ * Expected: "undefined variable"
+ */
+
+import @std
+using std
+
+do main() {
+    y = 10          // assigning to y before declaration
+    temp y = 5
+    println(y)
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1477,8 +1477,22 @@ func (tc *TypeChecker) checkAssignment(assign *ast.AssignmentStatement) {
 	// Also validate the value expression
 	tc.checkExpression(assign.Value)
 
-	// Check mutability - error if trying to modify an immutable variable
+	// Check that the assignment target exists and is mutable
 	if rootVar := tc.extractRootVariable(assign.Name); rootVar != "" {
+		// First check if the variable exists (#665)
+		_, varExists := tc.lookupVariable(rootVar)
+		if !varExists {
+			line, column := tc.getExpressionPosition(assign.Name)
+			tc.addError(
+				errors.E4001,
+				fmt.Sprintf("undefined variable '%s'", rootVar),
+				line,
+				column,
+			)
+			return
+		}
+
+		// Check mutability - error if trying to modify an immutable variable
 		isMutable, found := tc.isVariableMutable(rootVar)
 		if found && !isMutable {
 			line, column := tc.getExpressionPosition(assign.Name)


### PR DESCRIPTION
## Summary
- Adds validation in `checkAssignment()` to verify the assignment target variable exists
- Catches use-before-declaration errors where a variable is assigned before being declared

## Example
```ez
// Before: passes check, crashes at runtime
// After: E4001 at check time
y = 10       // E4001: undefined variable 'y'
temp y = 5
```

## Changes
- Updated `checkAssignment()` to check if root variable exists via `lookupVariable()`
- Added integration test `E4001_use_before_declaration.ez`

## Test plan
- [x] Run `./integration-tests/run_tests.sh` - 262 passing, 0 failures
- [x] Verify E4001 error is produced for assigning to undeclared variables

Closes #665