### PR TITLE
feat(typechecker): validate integer literal ranges for sized types

### DIFF
--- a/integration-tests/fail/errors/E3036_i8_out_of_range.ez
+++ b/integration-tests/fail/errors/E3036_i8_out_of_range.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3036 - integer-out-of-range
+ * Expected: "out of range" or "i8"
+ */
+
+do main() {
+    temp x i8 = 200  // i8 range is -128 to 127
+}

--- a/integration-tests/fail/errors/E3036_u8_negative.ez
+++ b/integration-tests/fail/errors/E3036_u8_negative.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3036 - integer-out-of-range (negative for unsigned)
+ * Expected: "out of range" or "u8"
+ */
+
+do main() {
+    temp x u8 = -1  // u8 cannot be negative
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -134,6 +134,7 @@ var (
 	E3033 = ErrorCode{"E3033", "duplicate-enum-value", "enum contains duplicate values"}
 	E3034 = ErrorCode{"E3034", "any-type-not-allowed", "'any' type is reserved for internal use"}
 	E3035 = ErrorCode{"E3035", "not-all-paths-return", "not all code paths return a value"}
+	E3036 = ErrorCode{"E3036", "integer-out-of-range", "integer literal exceeds type range"}
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds range validation for integer literals assigned to sized integer types
- Prevents silent overflow at runtime by catching out-of-range values at check time
- Added error code E3036 "integer-out-of-range"

## Supported Types and Ranges
| Type | Min | Max |
|------|-----|-----|
| i8 | -128 | 127 |
| i16 | -32768 | 32767 |
| i32 | -2147483648 | 2147483647 |
| i64 | -9223372036854775808 | 9223372036854775807 |
| u8 | 0 | 255 |
| u16 | 0 | 65535 |
| u32 | 0 | 4294967295 |
| u64 | 0 | 18446744073709551615 |

## Example
```ez
// Before: passes check, silent overflow at runtime
// After: E3036 at check time
temp x i8 = 200   // E3036: value 200 out of range for type i8
temp y u8 = -1    // E3036: value -1 out of range for type u8
```

## Test plan
- [x] Run `./integration-tests/run_tests.sh` - 266 passing, 3 pre-existing failures
- [x] Verify E3036 errors are produced for out-of-range literals

Closes #666