### PR TITLE
feat(typechecker): detect literal division/modulo by zero

### DIFF
--- a/integration-tests/fail/errors/E5001_literal_division_by_zero.ez
+++ b/integration-tests/fail/errors/E5001_literal_division_by_zero.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E5001 - division-by-zero (literal at check time)
+ * Expected: "division by zero"
+ */
+
+do main() {
+    temp x = 10 / 0  // literal division by zero
+}

--- a/integration-tests/fail/errors/E5002_literal_modulo_by_zero.ez
+++ b/integration-tests/fail/errors/E5002_literal_modulo_by_zero.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E5002 - modulo-by-zero (literal at check time)
+ * Expected: "modulo by zero"
+ */
+
+do main() {
+    temp x = 10 % 0  // literal modulo by zero
+}


### PR DESCRIPTION
## Summary
- Adds compile-time detection of division and modulo by literal zero values
- Catches errors at check time that would otherwise only be found at runtime
- Reuses existing error codes E5001 (division-by-zero) and E5002 (modulo-by-zero)

## Examples
```ez
// Before: passes check, crashes at runtime
// After: errors at check time
temp a = 10 / 0      // E5001: division by zero
temp b = 10 % 0      // E5002: modulo by zero
temp c = 10.5 / 0.0  // E5001: division by zero (float)
```

Note: Non-literal divisors (variables, function results) are NOT checked since their values aren't known at check time.

## Test plan
- [x] Run `./integration-tests/run_tests.sh` - 266 passing, 3 pre-existing failures
- [x] Verify E5001/E5002 errors are produced for literal division/modulo by zero

Closes #667