### PR TITLE
fix(typechecker): validate expressions in string interpolations (#684)

### DIFF
--- a/integration-tests/fail/errors/E3002_type_mismatch_in_interpolation.ez
+++ b/integration-tests/fail/errors/E3002_type_mismatch_in_interpolation.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3002 - type mismatch in string interpolation expression
+ * Expected: "invalid operands"
+ */
+
+import @std
+using std
+
+do main() {
+    temp s = "${1 + true}"  // Cannot add int and bool
+    println(s)
+}

--- a/integration-tests/fail/errors/E4001_undefined_in_interpolation.ez
+++ b/integration-tests/fail/errors/E4001_undefined_in_interpolation.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E4001 - undefined variable in string interpolation
+ * Expected: "undefined variable"
+ */
+
+import @std
+using std
+
+do main() {
+    temp s = "${undefined_var}"  // Variable doesn't exist inside interpolation
+    println(s)
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2097,6 +2097,16 @@ func (tc *TypeChecker) checkExpression(expr ast.Expression) {
 		tc.checkExpression(e.Left)
 		tc.checkPostfixExpression(e)
 
+	case *ast.InterpolatedString:
+		// Check all embedded expressions in the interpolated string (#684)
+		for _, part := range e.Parts {
+			// Skip string literal parts - only check embedded expressions
+			if _, isString := part.(*ast.StringValue); !isString {
+				tc.checkValueExpression(part) // Catch type/function used as interpolation value
+				tc.checkExpression(part)
+			}
+		}
+
 	case *ast.Label:
 		// Check if the identifier is known (variable, function, type, enum, etc.)
 		if !tc.isKnownIdentifier(e.Value) {


### PR DESCRIPTION
## Summary
Fixes #684 - String interpolation expressions are now type-checked.

Previously, expressions inside `"${...}"` were not validated by the typechecker, allowing undefined variables, type mismatches, and other errors to slip through to runtime.

## Changes
- Added case for `InterpolatedString` in `checkExpression()`
- Iterates through `Parts` and validates each embedded expression
- Calls `checkValueExpression()` to catch types/functions used as values
- Calls `checkExpression()` recursively for full validation

## Examples Now Caught
```ez
temp s1 = "${undefined_var}"    // Error: undefined variable
temp s2 = "${1 + true}"         // Error: invalid operands for +
```

## Test Plan
- [x] Build passes
- [x] All 274 integration tests pass (272 + 2 new)
- [x] Added E4001_undefined_in_interpolation.ez
- [x] Added E3002_type_mismatch_in_interpolation.ez