### PR TITLE
fix(typechecker): add compile-time array bounds checking (#685)

### DIFF
--- a/integration-tests/fail/errors/E5003_array_bounds_fixed.ez
+++ b/integration-tests/fail/errors/E5003_array_bounds_fixed.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E5003 - array index out of bounds for fixed-size array
+ * Expected: "out of bounds"
+ */
+
+import @std
+using std
+
+do main() {
+    temp arr [int, 3] = {1, 2, 3}  // Fixed-size array of 3 elements
+    temp x = arr[5]  // Index 5 is out of bounds (valid: 0-2)
+    println(x)
+}

--- a/integration-tests/fail/errors/E5003_array_negative_index.ez
+++ b/integration-tests/fail/errors/E5003_array_negative_index.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E5003 - negative array index
+ * Expected: "negative"
+ */
+
+import @std
+using std
+
+do main() {
+    temp arr [int] = {1, 2, 3}
+    temp x = arr[-1]  // Negative index is always invalid
+    println(x)
+}


### PR DESCRIPTION
## Summary
Fixes #685 - Array bounds are now checked at compile time for literal indices.

## What This Catches

### Negative Indices (all arrays)
```ez
temp arr [int] = {1, 2, 3}
temp x = arr[-1]  // Error: array index -1 is negative
```

### Out-of-Bounds on Fixed-Size Arrays
```ez
temp arr [int, 3] = {1, 2, 3}
temp x = arr[10]  // Error: array index 10 out of bounds for array of size 3
```

## Changes
- Added bounds checking in `checkIndexExpression()`
- Added `getLiteralIntValue()` helper to extract literal int values (including negatives)
- Uses existing `extractArraySize()` for fixed-size arrays

## Limitations
- Dynamic arrays (`[int]`) only check for negative indices since size is not known at compile time
- Runtime bounds checking still applies for variable indices

## Test Plan
- [x] Build passes
- [x] All 276 integration tests pass (274 + 2 new)
- [x] Added E5003_array_negative_index.ez
- [x] Added E5003_array_bounds_fixed.ez