### PR TITLE
fix(typechecker): extend overflow detection to all integer types (#686)

### DIFF
--- a/integration-tests/fail/errors/E3036_computed_overflow_i8.ez
+++ b/integration-tests/fail/errors/E3036_computed_overflow_i8.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3036 - computed value overflow for i8
+ * Expected: "out of range"
+ */
+
+import @std
+using std
+
+do main() {
+    temp x i8 = 100 + 50  // 150 exceeds i8 max of 127
+    println(x)
+}

--- a/integration-tests/fail/errors/E3036_computed_overflow_multiply.ez
+++ b/integration-tests/fail/errors/E3036_computed_overflow_multiply.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3036 - computed value overflow from multiplication
+ * Expected: "out of range"
+ */
+
+import @std
+using std
+
+do main() {
+    temp x i8 = 20 * 10  // 200 exceeds i8 max of 127
+    println(x)
+}

--- a/integration-tests/fail/errors/E3036_computed_underflow_unsigned.ez
+++ b/integration-tests/fail/errors/E3036_computed_underflow_unsigned.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3036 - computed value underflow for unsigned type
+ * Expected: "out of range"
+ */
+
+import @std
+using std
+
+do main() {
+    temp x u8 = 10 - 20  // -10 is below u8 min of 0
+    println(x)
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -355,6 +355,7 @@ var (
 	W2005 = ErrorCode{"W2005", "deprecated-feature", "using deprecated feature"}
 	W2006 = ErrorCode{"W2006", "byte-overflow-potential", "byte arithmetic may overflow"}
 	W2007 = ErrorCode{"W2007", "shadows-global", "variable shadows global variable or constant"}
+	W2008 = ErrorCode{"W2008", "integer-overflow-potential", "integer arithmetic may overflow"}
 
 	// Code Quality Warnings (W3xxx)
 	W3001 = ErrorCode{"W3001", "empty-block", "block statement is empty"}


### PR DESCRIPTION
## Summary
Fixes #686 - Integer overflow detection now covers all sized integer types, not just byte.

## What This Catches

### Addition Overflow
```ez
temp x i8 = 100 + 50   // Error: 150 out of range for i8 (-128 to 127)
```

### Multiplication Overflow
```ez
temp x i8 = 20 * 10    // Error: 200 out of range for i8
```

### Unsigned Underflow
```ez
temp x u8 = 10 - 20    // Error: -10 out of range for u8 (0 to 255)
```

### Large Type Overflow
```ez
temp x i32 = 2000000000 + 2000000000  // Error: 4B out of range for i32
```

## Changes
- Added W2008 warning code for general integer overflow
- Added `getIntegerBounds()` helper returning min/max for each integer type
- Added `checkArithmeticOverflow()` for checking variable arithmetic with same types
- Extended `checkIntegerLiteralRange()` to evaluate computed expressions with literals

## Types Covered
- Signed: i8, i16, i32, i64, int
- Unsigned: u8/byte, u16, u32, u64, uint

## Test Plan
- [x] Build passes
- [x] All new integration tests pass
- [x] Added E3036_computed_overflow_i8.ez
- [x] Added E3036_computed_overflow_multiply.ez
- [x] Added E3036_computed_underflow_unsigned.ez

Note: 2 pre-existing test failures in stdlib/io and multi-file/cross-module-nested-struct (unrelated to this PR)