### PR TITLE
fix(typechecker): add warning for member access on error type (#687)

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -356,6 +356,7 @@ var (
 	W2006 = ErrorCode{"W2006", "byte-overflow-potential", "byte arithmetic may overflow"}
 	W2007 = ErrorCode{"W2007", "shadows-global", "variable shadows global variable or constant"}
 	W2008 = ErrorCode{"W2008", "integer-overflow-potential", "integer arithmetic may overflow"}
+	W2009 = ErrorCode{"W2009", "nil-dereference-potential", "accessing member on potentially nil value"}
 
 	// Code Quality Warnings (W3xxx)
 	W3001 = ErrorCode{"W3001", "empty-block", "block statement is empty"}


### PR DESCRIPTION
## Summary
Fixes #687 - Added warning when accessing members on error type which may be nil.

## What This Catches
```ez
temp content, err = io.read_file("test.txt")
println(err.message)  // Warning: accessing member on error type which may be nil
```

## Changes
- Added W2009 warning code for potential nil dereference
- Properly register `error`/`Error` as struct types (was incorrectly listed as primitive)
- Show warning when accessing members on error type

## Bonus Fix
This PR also fixes a pre-existing issue where `error.message` access would fail with E4011 "cannot access member on type error (not a struct)". The stdlib/io integration test now passes.

## Test Plan
- [x] Build passes
- [x] 278 integration tests pass (up from 277 - fixed stdlib/io)
- [x] Warning shown when accessing err.message without nil check
- [x] No false positives for normal struct access