### PR TITLE
fix(interpreter): display actual return type instead of RETURN_VALUE in E5012 errors

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2688,6 +2688,17 @@ func objectTypeToEZ(obj Object) string {
 		return "nil"
 	case *Function:
 		return "function"
+	case *ReturnValue:
+		// Handle return values - format as tuple if multiple values
+		if len(v.Values) == 1 {
+			return objectTypeToEZ(v.Values[0])
+		}
+		// Multiple return values - format as tuple
+		types := make([]string, len(v.Values))
+		for i, val := range v.Values {
+			types[i] = objectTypeToEZ(val)
+		}
+		return "(" + strings.Join(types, ", ") + ")"
 	default:
 		return string(obj.Type())
 	}


### PR DESCRIPTION
## Summary
- Add case for `*ReturnValue` in `objectTypeToEZ()` to properly format return types in error messages
- Single values are unwrapped, multiple values are formatted as tuples (e.g., `([byte], Error)`)

Fixes #696

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [x] Verified fix with EasyDB project - error now shows `got ([byte], nil)` instead of `got RETURN_VALUE`