### PR TITLE
feat(parser): support tuple unpacking in assignment statements

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -300,6 +300,7 @@ func (v *VariableDeclaration) TokenLiteral() string { return v.Token.Literal }
 type AssignmentStatement struct {
 	Token    Token
 	Name     Expression // can be Identifier, IndexExpression, or MemberExpression
+	Names    []*Label   // for tuple unpacking: a, b = func()
 	Operator string
 	Value    Expression
 }


### PR DESCRIPTION
## Summary
- Add `Names` field to `AssignmentStatement` AST node for multiple targets
- Add `parseTupleAssignment()` to handle `a, b = func()` syntax
- Update `evalAssignment()` to unpack `ReturnValue` into multiple variables
- Supports blank identifier (`_`) for discarding values
- Validates all target variables exist and are mutable

Closes #699

## Example

```ez
temp data [byte]
temp err Error
data, err = io.read_bytes(f)  // Now works!
```

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Verified tuple unpacking works in assignments
- [x] Verified EasyDB project works with new syntax
- [x] Verified blank identifier (_) support
- [x] Verified error on undefined variable
- [x] Verified error on const variable