### PR TITLE
feat(parser): support tuple unpacking in assignment statements

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -300,6 +300,7 @@ func (v *VariableDeclaration) TokenLiteral() string { return v.Token.Literal }
 type AssignmentStatement struct {
 	Token    Token
 	Name     Expression // can be Identifier, IndexExpression, or MemberExpression
+	Names    []*Label   // for tuple unpacking: a, b = func()
 	Operator string
 	Value    Expression
 }


### PR DESCRIPTION
## Summary
Support tuple unpacking in assignment statements: `a, b = func()`

- Add `Names` field to `AssignmentStatement` AST node
- Add `parseTupleAssignment()` parser function  
- Update `evalAssignment()` to handle tuple unpacking

Closes #699

## Example
```ez
temp data [byte]
temp err Error
data, err = io.read_bytes(f)  // Now works!
```