### PR TITLE
fix(typechecker): validate field names in imported struct literals (#708)

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -593,8 +593,10 @@ func (tc *TypeChecker) checkStructLiteral(structVal *ast.StructValue) {
 	}
 
 	structName := structVal.Name.Value
-	structType, exists := tc.types[structName]
-	if !exists || structType.Kind != StructType {
+	// Use getStructTypeIncludingModules to handle both local types and
+	// qualified imported types like "lib.Item"
+	structType, exists := tc.getStructTypeIncludingModules(structName)
+	if !exists {
 		// Struct type doesn't exist - will be caught elsewhere
 		return
 	}


### PR DESCRIPTION
## Summary
- Fixed struct literal field validation for imported types
- Changed `checkStructLiteral` to use `getStructTypeIncludingModules()` instead of directly accessing `tc.types`
- This allows validation of struct literals like `lib.Item{}` where the type is imported from another module

## Test plan
- [x] Verified invalid field names are now caught for imported struct types
- [x] Verified valid struct literals still pass
- [x] Verified local struct field validation still works
- [x] All typechecker tests pass
- [x] Integration tests pass (1 pre-existing failure unrelated to this fix)

Closes #708