### PR TITLE
fix(typechecker): comprehensive validation of imported types (#709)

### DIFF
--- a/integration-tests/fail/multi-file/typechecker_foreach_imported_type/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_foreach_imported_type/lib/types.ez
@@ -1,0 +1,6 @@
+module lib
+
+const Item struct {
+    name string
+    value u32
+}

--- a/integration-tests/fail/multi-file/typechecker_foreach_imported_type/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_foreach_imported_type/main.ez
@@ -1,0 +1,17 @@
+module main
+
+// Test: Invalid field access in for_each with imported type
+// Expected: E4003 - struct has no field 'valu'
+
+import & use @std, @arrays
+import lib"./lib"
+
+do main() {
+    temp items [lib.Item]
+    arrays.append(items, lib.Item{ name: "Test", value: 100 })
+
+    for_each item in items {
+        // ERROR: 'valu' is not a field of Item (typo)
+        println(item.valu)
+    }
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_enum_member/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_enum_member/lib/types.ez
@@ -1,0 +1,7 @@
+module lib
+
+const Status enum {
+    ACTIVE
+    INACTIVE
+    PENDING
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_enum_member/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_enum_member/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Invalid enum member access with imported enum
+// Expected: E4004 - enum has no member 'RUNNING'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    // ERROR: 'RUNNING' is not a member of Status enum
+    temp s = lib.Status.RUNNING
+    println(s)
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_field/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_field/lib/types.ez
@@ -1,0 +1,6 @@
+module lib
+
+const Item struct {
+    name string
+    value u32
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_field/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_field/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Invalid struct field access with imported type
+// Expected: E4003 - struct has no field 'valu'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    temp item = lib.Item{ name: "Test", value: 100 }
+    // ERROR: 'valu' is not a field of Item (typo)
+    println(item.valu)
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_literal/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_literal/lib/types.ez
@@ -1,0 +1,6 @@
+module lib
+
+const Item struct {
+    name string
+    value u32
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_literal/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_literal/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Invalid field name in imported struct literal
+// Expected: E4003 - struct has no field 'valu'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    // ERROR: 'valu' is not a valid field of Item (typo)
+    temp item = lib.Item{ name: "Test", valu: 100 }
+    println(item.name)
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_undefined_func/lib/funcs.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_undefined_func/lib/funcs.ez
@@ -1,0 +1,5 @@
+module lib
+
+do add(a i32, b i32) -> i32 {
+    return a + b
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_undefined_func/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_undefined_func/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Undefined function in imported module
+// Expected: E4002 - undefined function 'lib.ad'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    // ERROR: 'ad' is not defined in lib (should be 'add')
+    temp sum = lib.ad(10, 20)
+    println(sum)
+}


### PR DESCRIPTION
## Summary
- Add `checkExpression()` call to as_long_as condition validation
- Add `checkExpression()` call to when statement value validation
- Validate imported enum members (module.EnumType.MEMBER patterns)
- Report error for undefined functions in imported modules
- Exit with code 1 on lexer/parser/type checker errors

## Integration Tests Added
- `typechecker_imported_struct_field` - Invalid struct field access with imported types
- `typechecker_imported_struct_literal` - Invalid struct literal fields with imported types
- `typechecker_imported_enum_member` - Invalid enum member access with imported types
- `typechecker_imported_undefined_func` - Undefined function calls in imported modules
- `typechecker_foreach_imported_type` - for_each loop variable typing with imported types

## Test Results
- All 43 audit tests passing (100%)
- All 5 new integration tests passing
- 280/284 integration tests passing (4 pre-existing stdlib failures unrelated to this change)

Fixes #709