### PR TITLE
Type checker bugfixes and stdlib validation (12-18-2025)

### DIFF
--- a/integration-tests/fail/multi-file/typechecker_foreach_imported_type/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_foreach_imported_type/lib/types.ez
@@ -1,0 +1,6 @@
+module lib
+
+const Item struct {
+    name string
+    value u32
+}

--- a/integration-tests/fail/multi-file/typechecker_foreach_imported_type/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_foreach_imported_type/main.ez
@@ -1,0 +1,17 @@
+module main
+
+// Test: Invalid field access in for_each with imported type
+// Expected: E4003 - struct has no field 'valu'
+
+import & use @std, @arrays
+import lib"./lib"
+
+do main() {
+    temp items [lib.Item]
+    arrays.append(items, lib.Item{ name: "Test", value: 100 })
+
+    for_each item in items {
+        // ERROR: 'valu' is not a field of Item (typo)
+        println(item.valu)
+    }
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_enum_member/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_enum_member/lib/types.ez
@@ -1,0 +1,7 @@
+module lib
+
+const Status enum {
+    ACTIVE
+    INACTIVE
+    PENDING
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_enum_member/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_enum_member/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Invalid enum member access with imported enum
+// Expected: E4004 - enum has no member 'RUNNING'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    // ERROR: 'RUNNING' is not a member of Status enum
+    temp s = lib.Status.RUNNING
+    println(s)
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_field/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_field/lib/types.ez
@@ -1,0 +1,6 @@
+module lib
+
+const Item struct {
+    name string
+    value u32
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_field/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_field/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Invalid struct field access with imported type
+// Expected: E4003 - struct has no field 'valu'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    temp item = lib.Item{ name: "Test", value: 100 }
+    // ERROR: 'valu' is not a field of Item (typo)
+    println(item.valu)
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_literal/lib/types.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_literal/lib/types.ez
@@ -1,0 +1,6 @@
+module lib
+
+const Item struct {
+    name string
+    value u32
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_struct_literal/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_struct_literal/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Invalid field name in imported struct literal
+// Expected: E4003 - struct has no field 'valu'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    // ERROR: 'valu' is not a valid field of Item (typo)
+    temp item = lib.Item{ name: "Test", valu: 100 }
+    println(item.name)
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_undefined_func/lib/funcs.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_undefined_func/lib/funcs.ez
@@ -1,0 +1,5 @@
+module lib
+
+do add(a i32, b i32) -> i32 {
+    return a + b
+}

--- a/integration-tests/fail/multi-file/typechecker_imported_undefined_func/main.ez
+++ b/integration-tests/fail/multi-file/typechecker_imported_undefined_func/main.ez
@@ -1,0 +1,13 @@
+module main
+
+// Test: Undefined function in imported module
+// Expected: E4002 - undefined function 'lib.ad'
+
+import & use @std
+import lib"./lib"
+
+do main() {
+    // ERROR: 'ad' is not defined in lib (should be 'add')
+    temp sum = lib.ad(10, 20)
+    println(sum)
+}

--- a/integration-tests/pass/stdlib/bytes.ez
+++ b/integration-tests/pass/stdlib/bytes.ez
@@ -1,0 +1,326 @@
+/*
+ * bytes.ez - Test @bytes standard library with PROPER ASSERTIONS
+ */
+
+import @std, @bytes
+using std
+
+do main() {
+    println("=== @bytes Standard Library Test ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // ==================== bytes.from_string / bytes.to_string ====================
+    println("  -- Creation and Conversion --")
+
+    // Test 1: from_string and to_string roundtrip
+    temp data [byte] = bytes.from_string("hello")
+    temp back string = bytes.to_string(data)
+    if back == "hello" {
+        println("  [PASS] bytes.from_string/to_string roundtrip")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.from_string/to_string: expected 'hello', got '${back}'")
+        failed += 1
+    }
+
+    // Test 2: from_array
+    temp arr [int] = {72, 105}  // "Hi" in ASCII
+    temp from_arr [byte] = bytes.from_array(arr)
+    temp from_arr_str string = bytes.to_string(from_arr)
+    if from_arr_str == "Hi" {
+        println("  [PASS] bytes.from_array")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.from_array: expected 'Hi', got '${from_arr_str}'")
+        failed += 1
+    }
+
+    // Test 3: to_hex
+    temp hex_data [byte] = bytes.from_string("AB")
+    temp hex_str string = bytes.to_hex(hex_data)
+    if hex_str == "4142" {
+        println("  [PASS] bytes.to_hex")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.to_hex: expected '4142', got '${hex_str}'")
+        failed += 1
+    }
+
+    // Test 4: to_hex_upper
+    temp hex_upper string = bytes.to_hex_upper(hex_data)
+    if hex_upper == "4142" {
+        println("  [PASS] bytes.to_hex_upper")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.to_hex_upper: expected '4142', got '${hex_upper}'")
+        failed += 1
+    }
+
+    // Test 5: from_hex
+    temp from_hex_result [byte], from_hex_err error = bytes.from_hex("4142")
+    if from_hex_err == nil {
+        temp from_hex_str string = bytes.to_string(from_hex_result)
+        if from_hex_str == "AB" {
+            println("  [PASS] bytes.from_hex")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] bytes.from_hex: expected 'AB', got '${from_hex_str}'")
+            failed += 1
+        }
+    } otherwise {
+        println("  [FAIL] bytes.from_hex: unexpected error")
+        failed += 1
+    }
+
+    // Test 6: to_base64
+    temp b64_data [byte] = bytes.from_string("Hello")
+    temp b64_str string = bytes.to_base64(b64_data)
+    if b64_str == "SGVsbG8=" {
+        println("  [PASS] bytes.to_base64")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.to_base64: expected 'SGVsbG8=', got '${b64_str}'")
+        failed += 1
+    }
+
+    // Test 7: from_base64
+    temp from_b64 [byte], from_b64_err error = bytes.from_base64("SGVsbG8=")
+    if from_b64_err == nil {
+        temp from_b64_str string = bytes.to_string(from_b64)
+        if from_b64_str == "Hello" {
+            println("  [PASS] bytes.from_base64")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] bytes.from_base64: expected 'Hello', got '${from_b64_str}'")
+            failed += 1
+        }
+    } otherwise {
+        println("  [FAIL] bytes.from_base64: unexpected error")
+        failed += 1
+    }
+
+    // ==================== Slicing and Combining ====================
+    println("  -- Slicing and Combining --")
+
+    // Test 8: slice
+    temp slice_data [byte] = bytes.from_string("Hello World")
+    temp sliced [byte] = bytes.slice(slice_data, 0, 5)
+    temp sliced_str string = bytes.to_string(sliced)
+    if sliced_str == "Hello" {
+        println("  [PASS] bytes.slice")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.slice: expected 'Hello', got '${sliced_str}'")
+        failed += 1
+    }
+
+    // Test 9: concat
+    temp a [byte] = bytes.from_string("Hello")
+    temp b [byte] = bytes.from_string(" World")
+    temp concat_result [byte] = bytes.concat(a, b)
+    temp concat_str string = bytes.to_string(concat_result)
+    if concat_str == "Hello World" {
+        println("  [PASS] bytes.concat")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.concat: expected 'Hello World', got '${concat_str}'")
+        failed += 1
+    }
+
+    // Test 10: copy
+    temp original [byte] = bytes.from_string("test")
+    temp copied [byte] = bytes.copy(original)
+    temp copied_str string = bytes.to_string(copied)
+    if copied_str == "test" {
+        println("  [PASS] bytes.copy")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.copy: expected 'test', got '${copied_str}'")
+        failed += 1
+    }
+
+    // ==================== Search Functions ====================
+    println("  -- Search Functions --")
+
+    // Test 11: contains
+    temp haystack [byte] = bytes.from_string("Hello World")
+    temp needle [byte] = bytes.from_string("World")
+    if bytes.contains(haystack, needle) {
+        println("  [PASS] bytes.contains (found)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.contains: expected true")
+        failed += 1
+    }
+
+    // Test 12: contains (not found)
+    temp not_needle [byte] = bytes.from_string("xyz")
+    if bytes.contains(haystack, not_needle) == false {
+        println("  [PASS] bytes.contains (not found)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.contains: expected false")
+        failed += 1
+    }
+
+    // Test 13: index
+    temp idx int = bytes.index(haystack, needle)
+    if idx == 6 {
+        println("  [PASS] bytes.index")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.index: expected 6, got ${idx}")
+        failed += 1
+    }
+
+    // Test 14: count
+    temp count_data [byte] = bytes.from_string("aaa")
+    temp count_pattern [byte] = bytes.from_string("a")
+    temp cnt int = bytes.count(count_data, count_pattern)
+    if cnt == 3 {
+        println("  [PASS] bytes.count")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.count: expected 3, got ${cnt}")
+        failed += 1
+    }
+
+    // ==================== Comparison Functions ====================
+    println("  -- Comparison Functions --")
+
+    // Test 15: equals
+    temp eq1 [byte] = bytes.from_string("test")
+    temp eq2 [byte] = bytes.from_string("test")
+    if bytes.equals(eq1, eq2) {
+        println("  [PASS] bytes.equals (equal)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.equals: expected true")
+        failed += 1
+    }
+
+    // Test 16: equals (not equal)
+    temp eq3 [byte] = bytes.from_string("other")
+    if bytes.equals(eq1, eq3) == false {
+        println("  [PASS] bytes.equals (not equal)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.equals: expected false")
+        failed += 1
+    }
+
+    // Test 17: is_empty
+    temp empty [byte] = bytes.from_string("")
+    if bytes.is_empty(empty) {
+        println("  [PASS] bytes.is_empty (empty)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.is_empty: expected true")
+        failed += 1
+    }
+
+    // Test 18: is_empty (not empty)
+    if bytes.is_empty(eq1) == false {
+        println("  [PASS] bytes.is_empty (not empty)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.is_empty: expected false")
+        failed += 1
+    }
+
+    // Test 19: starts_with
+    temp sw_data [byte] = bytes.from_string("Hello World")
+    temp sw_prefix [byte] = bytes.from_string("Hello")
+    if bytes.starts_with(sw_data, sw_prefix) {
+        println("  [PASS] bytes.starts_with")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.starts_with: expected true")
+        failed += 1
+    }
+
+    // Test 20: ends_with
+    temp ew_suffix [byte] = bytes.from_string("World")
+    if bytes.ends_with(sw_data, ew_suffix) {
+        println("  [PASS] bytes.ends_with")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.ends_with: expected true")
+        failed += 1
+    }
+
+    // ==================== Transformation Functions ====================
+    println("  -- Transformation Functions --")
+
+    // Test 21: reverse
+    temp rev_data [byte] = bytes.from_string("abc")
+    temp reversed [byte] = bytes.reverse(rev_data)
+    temp reversed_str string = bytes.to_string(reversed)
+    if reversed_str == "cba" {
+        println("  [PASS] bytes.reverse")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.reverse: expected 'cba', got '${reversed_str}'")
+        failed += 1
+    }
+
+    // Test 22: repeat
+    temp rep_data [byte] = bytes.from_string("ab")
+    temp repeated [byte] = bytes.repeat(rep_data, 3)
+    temp repeated_str string = bytes.to_string(repeated)
+    if repeated_str == "ababab" {
+        println("  [PASS] bytes.repeat")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.repeat: expected 'ababab', got '${repeated_str}'")
+        failed += 1
+    }
+
+    // Test 23: replace
+    temp repl_data [byte] = bytes.from_string("hello")
+    temp repl_old [byte] = bytes.from_string("l")
+    temp repl_new [byte] = bytes.from_string("L")
+    temp replaced [byte] = bytes.replace(repl_data, repl_old, repl_new)
+    temp replaced_str string = bytes.to_string(replaced)
+    if replaced_str == "heLLo" {
+        println("  [PASS] bytes.replace")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.replace: expected 'heLLo', got '${replaced_str}'")
+        failed += 1
+    }
+
+    // ==================== Utility Functions ====================
+    println("  -- Utility Functions --")
+
+    // Test 24: zero (zeros out a byte array)
+    temp to_zero [byte] = bytes.from_string("hello")
+    temp zeroed [byte] = bytes.zero(to_zero)
+    temp all_zero bool = true
+    for_each z in zeroed {
+        if z != 0x00 {
+            all_zero = false
+        }
+    }
+    if all_zero && len(zeroed) == 5 {
+        println("  [PASS] bytes.zero")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] bytes.zero: expected 5 zero bytes")
+        failed += 1
+    }
+
+    // ==================== Summary ====================
+    println("")
+    println("=== Summary ===")
+    println("  Passed: ${passed}")
+    println("  Failed: ${failed}")
+    println("")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -373,6 +373,7 @@ func (tc *TypeChecker) GetType(name string) (*Type, bool) {
 
 // getStructTypeIncludingModules looks up a struct type by name, checking both local
 // and module types. For qualified names like "lib.Hero", it looks up in moduleTypes.
+// For unqualified names like "Item", it also searches through all registered modules.
 func (tc *TypeChecker) getStructTypeIncludingModules(typeName string) (*Type, bool) {
 	// First check local types
 	if t, exists := tc.types[typeName]; exists && t.Kind == StructType {
@@ -390,6 +391,15 @@ func (tc *TypeChecker) getStructTypeIncludingModules(typeName string) (*Type, bo
 					return t, true
 				}
 			}
+		}
+	}
+
+	// For unqualified names, search through all registered modules
+	// This handles cases where a struct field type like "[Item]" references
+	// a type from the same module without qualification
+	for _, moduleTypes := range tc.moduleTypes {
+		if t, exists := moduleTypes[typeName]; exists && t.Kind == StructType {
+			return t, true
 		}
 	}
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -593,8 +593,10 @@ func (tc *TypeChecker) checkStructLiteral(structVal *ast.StructValue) {
 	}
 
 	structName := structVal.Name.Value
-	structType, exists := tc.types[structName]
-	if !exists || structType.Kind != StructType {
+	// Use getStructTypeIncludingModules to handle both local types and
+	// qualified imported types like "lib.Item"
+	structType, exists := tc.getStructTypeIncludingModules(structName)
+	if !exists {
 		// Struct type doesn't exist - will be caught elsewhere
 		return
 	}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5182,6 +5182,98 @@ func (tc *TypeChecker) isStdFunction(name string) bool {
 	return stdFuncs[name]
 }
 
+// isIoFunction checks if a function name exists in the io module
+func (tc *TypeChecker) isIoFunction(name string) bool {
+	ioFuncs := map[string]bool{
+		// File reading
+		"read_file": true, "read_bytes": true, "read_lines": true,
+		// File writing
+		"write_file": true, "write_bytes": true, "append_file": true, "append_line": true,
+		// Path utilities
+		"expand_path": true, "path_join": true, "path_base": true, "path_dir": true,
+		"path_ext": true, "path_abs": true, "path_clean": true, "path_separator": true,
+		// File checks
+		"exists": true, "is_file": true, "is_dir": true, "is_symlink": true,
+		// File operations
+		"remove": true, "remove_dir": true, "remove_all": true, "rename": true, "copy": true,
+		// Directory operations
+		"mkdir": true, "mkdir_all": true, "read_dir": true,
+		// File metadata
+		"file_size": true, "file_mod_time": true,
+		// File handle operations
+		"open": true, "read": true, "read_all": true, "read_string": true,
+		"write": true, "seek": true, "tell": true, "flush": true, "close": true,
+		// Filesystem utilities
+		"glob": true, "walk": true,
+		// Constants (accessed as functions)
+		"READ_ONLY": true, "WRITE_ONLY": true, "READ_WRITE": true,
+		"APPEND": true, "CREATE": true, "TRUNCATE": true, "EXCLUSIVE": true,
+		"SEEK_START": true, "SEEK_CURRENT": true, "SEEK_END": true,
+	}
+	return ioFuncs[name]
+}
+
+// isOsFunction checks if a function name exists in the os module
+func (tc *TypeChecker) isOsFunction(name string) bool {
+	osFuncs := map[string]bool{
+		// Environment variables
+		"get_env": true, "set_env": true, "unset_env": true, "env": true, "args": true,
+		// Process / System
+		"exit": true, "cwd": true, "chdir": true, "hostname": true, "username": true,
+		"home_dir": true, "temp_dir": true, "pid": true, "ppid": true,
+		// Platform detection
+		"platform": true, "arch": true, "is_windows": true, "is_linux": true, "is_macos": true,
+		"num_cpu": true, "line_separator": true, "dev_null": true,
+		// Command execution
+		"exec": true, "exec_output": true,
+		// Constants
+		"MAC_OS": true, "LINUX": true, "WINDOWS": true, "CURRENT_OS": true,
+	}
+	return osFuncs[name]
+}
+
+// isRandomFunction checks if a function name exists in the random module
+func (tc *TypeChecker) isRandomFunction(name string) bool {
+	randomFuncs := map[string]bool{
+		"float": true, "int": true, "bool": true, "byte": true, "char": true,
+		"choice": true, "shuffle": true, "sample": true,
+	}
+	return randomFuncs[name]
+}
+
+// isJsonFunction checks if a function name exists in the json module
+func (tc *TypeChecker) isJsonFunction(name string) bool {
+	jsonFuncs := map[string]bool{
+		"encode": true, "decode": true, "pretty": true, "is_valid": true,
+	}
+	return jsonFuncs[name]
+}
+
+// isBytesFunction checks if a function name exists in the bytes module
+func (tc *TypeChecker) isBytesFunction(name string) bool {
+	bytesFuncs := map[string]bool{
+		// Creation
+		"from_array": true, "from_string": true, "from_hex": true, "from_base64": true,
+		// Conversion
+		"to_string": true, "to_array": true, "to_hex": true, "to_hex_upper": true, "to_base64": true,
+		// Slicing and combining
+		"slice": true, "concat": true, "join": true, "split": true,
+		// Search
+		"contains": true, "index": true, "last_index": true, "count": true,
+		// Comparison
+		"compare": true, "equals": true, "is_empty": true, "starts_with": true, "ends_with": true,
+		// Transformation
+		"reverse": true, "repeat": true, "replace": true, "replace_n": true,
+		"trim": true, "trim_left": true, "trim_right": true,
+		"pad_left": true, "pad_right": true,
+		// Bitwise
+		"and": true, "or": true, "xor": true, "not": true,
+		// Utilities
+		"fill": true, "copy": true, "zero": true,
+	}
+	return bytesFuncs[name]
+}
+
 // getUsedModuleShadowingFunction checks if a name shadows a function from a used module
 // Returns the module name if there's a shadow, empty string otherwise
 func (tc *TypeChecker) getUsedModuleShadowingFunction(name string) string {
@@ -5219,6 +5311,16 @@ func (tc *TypeChecker) isModuleFunction(moduleName, funcName string) bool {
 		return tc.isTimeFunction(funcName)
 	case "maps":
 		return tc.isMapsFunction(funcName)
+	case "io":
+		return tc.isIoFunction(funcName)
+	case "os":
+		return tc.isOsFunction(funcName)
+	case "random":
+		return tc.isRandomFunction(funcName)
+	case "json":
+		return tc.isJsonFunction(funcName)
+	case "bytes":
+		return tc.isBytesFunction(funcName)
 	default:
 		// Check user-defined modules
 		if funcs, ok := tc.moduleFunctions[moduleName]; ok {
@@ -5243,7 +5345,7 @@ func (tc *TypeChecker) checkStdlibCall(member *ast.MemberExpression, call *ast.C
 	line, column := tc.getExpressionPosition(member.Member)
 
 	// Check if the module was imported (for standard library modules)
-	stdModules := map[string]bool{"std": true, "math": true, "arrays": true, "strings": true, "time": true, "maps": true, "io": true, "os": true, "random": true}
+	stdModules := map[string]bool{"std": true, "math": true, "arrays": true, "strings": true, "time": true, "maps": true, "io": true, "os": true, "bytes": true, "random": true, "json": true}
 	if stdModules[moduleName] && !tc.modules[moduleName] {
 		tc.addError(errors.E4007, fmt.Sprintf("module '%s' not imported; add 'import @%s'", moduleName, moduleName), line, column)
 		return
@@ -5262,6 +5364,16 @@ func (tc *TypeChecker) checkStdlibCall(member *ast.MemberExpression, call *ast.C
 		tc.checkTimeModuleCall(funcName, call, line, column)
 	case "maps":
 		tc.checkMapsModuleCall(funcName, call, line, column)
+	case "io":
+		tc.checkIoModuleCall(funcName, call, line, column)
+	case "os":
+		tc.checkOsModuleCall(funcName, call, line, column)
+	case "random":
+		tc.checkRandomModuleCall(funcName, call, line, column)
+	case "json":
+		tc.checkJsonModuleCall(funcName, call, line, column)
+	case "bytes":
+		tc.checkBytesModuleCall(funcName, call, line, column)
 	default:
 		// User-defined module - check if we have type info for it
 		tc.checkUserModuleCall(moduleName, funcName, call, line, column)
@@ -5888,6 +6000,254 @@ func (tc *TypeChecker) checkTimeModuleCall(funcName string, call *ast.CallExpres
 	}
 
 	tc.validateStdlibCall("time", funcName, call, sig, line, column)
+}
+
+// checkIoModuleCall validates io module function calls
+func (tc *TypeChecker) checkIoModuleCall(funcName string, call *ast.CallExpression, line, column int) {
+	signatures := map[string]StdlibFuncSig{
+		// File reading (1 path arg, returns tuple)
+		"read_file":  {1, 1, []string{"string"}, "tuple"},
+		"read_bytes": {1, 1, []string{"string"}, "tuple"},
+		"read_lines": {1, 1, []string{"string"}, "tuple"},
+
+		// File writing (2-3 args: path, content, optional perms)
+		"write_file":  {2, 3, []string{"string", "string", "int"}, "tuple"},
+		"write_bytes": {2, 3, []string{"string", "array", "int"}, "tuple"},
+		"append_file": {2, 3, []string{"string", "string", "int"}, "tuple"},
+		"append_line": {2, 3, []string{"string", "string", "int"}, "tuple"},
+
+		// Path utilities
+		"expand_path":    {1, 1, []string{"string"}, "string"},
+		"path_join":      {1, -1, []string{"string"}, "string"},
+		"path_base":      {1, 1, []string{"string"}, "string"},
+		"path_dir":       {1, 1, []string{"string"}, "string"},
+		"path_ext":       {1, 1, []string{"string"}, "string"},
+		"path_abs":       {1, 1, []string{"string"}, "tuple"},
+		"path_clean":     {1, 1, []string{"string"}, "string"},
+		"path_separator": {0, 0, []string{}, "string"},
+
+		// File checks (1 path arg, returns bool)
+		"exists":     {1, 1, []string{"string"}, "bool"},
+		"is_file":    {1, 1, []string{"string"}, "bool"},
+		"is_dir":     {1, 1, []string{"string"}, "bool"},
+		"is_symlink": {1, 1, []string{"string"}, "bool"},
+
+		// File operations
+		"remove":     {1, 1, []string{"string"}, "tuple"},
+		"remove_dir": {1, 1, []string{"string"}, "tuple"},
+		"remove_all": {1, 1, []string{"string"}, "tuple"},
+		"rename":     {2, 2, []string{"string", "string"}, "tuple"},
+		"copy":       {2, 3, []string{"string", "string", "int"}, "tuple"},
+
+		// Directory operations
+		"mkdir":     {1, 2, []string{"string", "int"}, "tuple"},
+		"mkdir_all": {1, 2, []string{"string", "int"}, "tuple"},
+		"read_dir":  {1, 1, []string{"string"}, "tuple"},
+
+		// File metadata
+		"file_size":     {1, 1, []string{"string"}, "tuple"},
+		"file_mod_time": {1, 1, []string{"string"}, "tuple"},
+
+		// File handle operations
+		"open":        {1, 3, []string{"string", "int", "int"}, "tuple"},
+		"read":        {2, 2, []string{"any", "int"}, "tuple"},
+		"read_all":    {1, 1, []string{"any"}, "tuple"},
+		"read_string": {2, 2, []string{"any", "int"}, "tuple"},
+		"write":       {2, 2, []string{"any", "any"}, "tuple"},
+		"seek":        {3, 3, []string{"any", "int", "int"}, "tuple"},
+		"tell":        {1, 1, []string{"any"}, "tuple"},
+		"flush":       {1, 1, []string{"any"}, "tuple"},
+		"close":       {1, 1, []string{"any"}, "tuple"},
+
+		// Filesystem utilities
+		"glob": {1, 1, []string{"string"}, "tuple"},
+		"walk": {1, 1, []string{"string"}, "tuple"},
+
+		// Constants (no args)
+		"READ_ONLY":    {0, 0, []string{}, "int"},
+		"WRITE_ONLY":   {0, 0, []string{}, "int"},
+		"READ_WRITE":   {0, 0, []string{}, "int"},
+		"APPEND":       {0, 0, []string{}, "int"},
+		"CREATE":       {0, 0, []string{}, "int"},
+		"TRUNCATE":     {0, 0, []string{}, "int"},
+		"EXCLUSIVE":    {0, 0, []string{}, "int"},
+		"SEEK_START":   {0, 0, []string{}, "int"},
+		"SEEK_CURRENT": {0, 0, []string{}, "int"},
+		"SEEK_END":     {0, 0, []string{}, "int"},
+	}
+
+	sig, exists := signatures[funcName]
+	if !exists {
+		return
+	}
+
+	tc.validateStdlibCall("io", funcName, call, sig, line, column)
+}
+
+// checkOsModuleCall validates os module function calls
+func (tc *TypeChecker) checkOsModuleCall(funcName string, call *ast.CallExpression, line, column int) {
+	signatures := map[string]StdlibFuncSig{
+		// Environment variables
+		"get_env":   {1, 1, []string{"string"}, "any"},
+		"set_env":   {2, 2, []string{"string", "string"}, "tuple"},
+		"unset_env": {1, 1, []string{"string"}, "tuple"},
+		"env":       {0, 0, []string{}, "map"},
+		"args":      {0, 0, []string{}, "array"},
+
+		// Process / System
+		"exit":     {0, 1, []string{"int"}, "void"},
+		"cwd":      {0, 0, []string{}, "tuple"},
+		"chdir":    {1, 1, []string{"string"}, "tuple"},
+		"hostname": {0, 0, []string{}, "tuple"},
+		"username": {0, 0, []string{}, "tuple"},
+		"home_dir": {0, 0, []string{}, "tuple"},
+		"temp_dir": {0, 0, []string{}, "string"},
+		"pid":      {0, 0, []string{}, "int"},
+		"ppid":     {0, 0, []string{}, "int"},
+
+		// Platform detection
+		"platform":       {0, 0, []string{}, "string"},
+		"arch":           {0, 0, []string{}, "string"},
+		"is_windows":     {0, 0, []string{}, "bool"},
+		"is_linux":       {0, 0, []string{}, "bool"},
+		"is_macos":       {0, 0, []string{}, "bool"},
+		"num_cpu":        {0, 0, []string{}, "int"},
+		"line_separator": {0, 0, []string{}, "string"},
+		"dev_null":       {0, 0, []string{}, "string"},
+
+		// Command execution
+		"exec":        {1, 1, []string{"string"}, "tuple"},
+		"exec_output": {1, 1, []string{"string"}, "tuple"},
+
+		// Constants
+		"MAC_OS":     {0, 0, []string{}, "int"},
+		"LINUX":      {0, 0, []string{}, "int"},
+		"WINDOWS":    {0, 0, []string{}, "int"},
+		"CURRENT_OS": {0, 0, []string{}, "int"},
+	}
+
+	sig, exists := signatures[funcName]
+	if !exists {
+		return
+	}
+
+	tc.validateStdlibCall("os", funcName, call, sig, line, column)
+}
+
+// checkRandomModuleCall validates random module function calls
+func (tc *TypeChecker) checkRandomModuleCall(funcName string, call *ast.CallExpression, line, column int) {
+	signatures := map[string]StdlibFuncSig{
+		// random.float() or random.float(min, max)
+		"float": {0, 2, []string{"numeric", "numeric"}, "float"},
+		// random.int(max) or random.int(min, max)
+		"int": {1, 2, []string{"numeric", "numeric"}, "int"},
+		// random.bool()
+		"bool": {0, 0, []string{}, "bool"},
+		// random.byte()
+		"byte": {0, 0, []string{}, "byte"},
+		// random.char() or random.char(min, max)
+		"char": {0, 2, []string{"any", "any"}, "char"},
+		// random.choice(array)
+		"choice": {1, 1, []string{"array"}, "any"},
+		// random.shuffle(array)
+		"shuffle": {1, 1, []string{"array"}, "array"},
+		// random.sample(array, n)
+		"sample": {2, 2, []string{"array", "int"}, "array"},
+	}
+
+	sig, exists := signatures[funcName]
+	if !exists {
+		return
+	}
+
+	tc.validateStdlibCall("random", funcName, call, sig, line, column)
+}
+
+// checkJsonModuleCall validates json module function calls
+func (tc *TypeChecker) checkJsonModuleCall(funcName string, call *ast.CallExpression, line, column int) {
+	signatures := map[string]StdlibFuncSig{
+		// json.encode(value)
+		"encode": {1, 1, []string{"any"}, "tuple"},
+		// json.decode(text) or json.decode(text, Type)
+		"decode": {1, 2, []string{"string", "any"}, "tuple"},
+		// json.pretty(value, indent)
+		"pretty": {2, 2, []string{"any", "string"}, "tuple"},
+		// json.is_valid(text)
+		"is_valid": {1, 1, []string{"string"}, "bool"},
+	}
+
+	sig, exists := signatures[funcName]
+	if !exists {
+		return
+	}
+
+	tc.validateStdlibCall("json", funcName, call, sig, line, column)
+}
+
+// checkBytesModuleCall validates bytes module function calls
+func (tc *TypeChecker) checkBytesModuleCall(funcName string, call *ast.CallExpression, line, column int) {
+	signatures := map[string]StdlibFuncSig{
+		// Creation functions
+		"from_array":  {1, 1, []string{"array"}, "array"},
+		"from_string": {1, 1, []string{"string"}, "array"},
+		"from_hex":    {1, 1, []string{"string"}, "tuple"},
+		"from_base64": {1, 1, []string{"string"}, "tuple"},
+
+		// Conversion functions
+		"to_string":    {1, 1, []string{"array"}, "string"},
+		"to_array":     {1, 1, []string{"array"}, "array"},
+		"to_hex":       {1, 1, []string{"array"}, "string"},
+		"to_hex_upper": {1, 1, []string{"array"}, "string"},
+		"to_base64":    {1, 1, []string{"array"}, "string"},
+
+		// Slicing and combining
+		"slice":  {2, 3, []string{"array", "int", "int"}, "array"},
+		"concat": {2, -1, []string{"array"}, "array"},
+		"join":   {2, 2, []string{"array", "array"}, "array"},
+		"split":  {2, 2, []string{"array", "array"}, "array"},
+
+		// Search functions
+		"contains":   {2, 2, []string{"array", "array"}, "bool"},
+		"index":      {2, 2, []string{"array", "array"}, "int"},
+		"last_index": {2, 2, []string{"array", "array"}, "int"},
+		"count":      {2, 2, []string{"array", "array"}, "int"},
+
+		// Comparison functions
+		"compare":     {2, 2, []string{"array", "array"}, "int"},
+		"equals":      {2, 2, []string{"array", "array"}, "bool"},
+		"is_empty":    {1, 1, []string{"array"}, "bool"},
+		"starts_with": {2, 2, []string{"array", "array"}, "bool"},
+		"ends_with":   {2, 2, []string{"array", "array"}, "bool"},
+
+		// Transformation functions
+		"reverse":    {1, 1, []string{"array"}, "array"},
+		"repeat":     {2, 2, []string{"array", "int"}, "array"},
+		"replace":    {3, 3, []string{"array", "array", "array"}, "array"},
+		"replace_n":  {4, 4, []string{"array", "array", "array", "int"}, "array"},
+		"trim":       {2, 2, []string{"array", "array"}, "array"},
+		"trim_left":  {2, 2, []string{"array", "array"}, "array"},
+		"trim_right": {2, 2, []string{"array", "array"}, "array"},
+		"pad_left":   {3, 3, []string{"array", "int", "int"}, "array"},
+		"pad_right":  {3, 3, []string{"array", "int", "int"}, "array"},
+
+		// Bitwise functions
+		"and": {2, 2, []string{"array", "array"}, "array"},
+		"or":  {2, 2, []string{"array", "array"}, "array"},
+		"xor": {2, 2, []string{"array", "array"}, "array"},
+		"not": {1, 1, []string{"array"}, "array"},
+
+		// Utility functions
+		"fill": {2, 2, []string{"array", "int"}, "array"},
+		"copy": {1, 1, []string{"array"}, "array"},
+		"zero": {1, 1, []string{"array"}, "array"},
+	}
+
+	sig, exists := signatures[funcName]
+	if !exists {
+		return
+	}
+
+	tc.validateStdlibCall("bytes", funcName, call, sig, line, column)
 }
 
 // validateStdlibCall performs the actual validation of a stdlib call


### PR DESCRIPTION
## Summary
Collection of type checker bugfixes and enhancements from 12-18-2025.

## Fixes Included

### #706 - for_each loop variable typing for imported structs
- Resolve unqualified imported types in member access validation
- Fix type checker to properly track loop variable types from imported arrays

### #708 - Struct literal field validation for imported types
- Validate field names in imported struct literals
- Report errors for undefined fields in struct literals from other modules

### #709 - Comprehensive type checker validation
- Add imported enum member validation (`lib.EnumType.MEMBER`)
- Add undefined function validation for imported modules
- Add `checkExpression()` to `as_long_as` and `when` statement validation
- Add proper exit codes for lexer/parser/type checker errors

### Stdlib type checking for all modules
- Add type checking for `@io` (40+ functions)
- Add type checking for `@os` (25+ functions)
- Add type checking for `@random` (8 functions)
- Add type checking for `@json` (4 functions)
- Add type checking for `@bytes` (37 functions)
- Add `bytes.ez` integration test (24 tests)

## Test plan
- [x] All 285 integration tests pass
- [x] All unit tests pass
- [x] All 43 audit tests pass