### PR TITLE
feat(stdlib): add @binary module and sized type conversions

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -149,6 +149,7 @@ var validModules = map[string]bool{
 	"bytes":   true, // Binary data operations
 	"random":  true, // Random number generation
 	"json":    true, // JSON encoding/decoding
+	"binary":  true, // Binary encoding/decoding for integers and floats
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/stdlib/binary.go
+++ b/pkg/stdlib/binary.go
@@ -1,0 +1,1297 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// createBinaryError creates an Error struct for recoverable errors in tuple returns
+func createBinaryError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}
+
+// Helper to convert EZ byte array to Go []byte with length validation
+func binaryBytesToSlice(arg object.Object, expected int, funcName string) ([]byte, *object.Struct) {
+	arr, ok := arg.(*object.Array)
+	if !ok {
+		return nil, createBinaryError("E7002", fmt.Sprintf("%s requires a byte array argument", funcName))
+	}
+	if len(arr.Elements) != expected {
+		return nil, createBinaryError("E7010", fmt.Sprintf("%s requires exactly %d bytes, got %d", funcName, expected, len(arr.Elements)))
+	}
+
+	data := make([]byte, expected)
+	for i, elem := range arr.Elements {
+		switch e := elem.(type) {
+		case *object.Byte:
+			data[i] = e.Value
+		case *object.Integer:
+			val := e.Value.Int64()
+			if val < 0 || val > 255 {
+				return nil, createBinaryError("E3022", fmt.Sprintf("%s byte at index %d out of range (0-255)", funcName, i))
+			}
+			data[i] = byte(val)
+		default:
+			return nil, createBinaryError("E7002", fmt.Sprintf("%s requires a byte array", funcName))
+		}
+	}
+	return data, nil
+}
+
+// Helper to convert Go []byte to EZ byte array
+func sliceToBinaryArray(data []byte) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, b := range data {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper to extract integer value for encoding
+func extractEncodingInt(arg object.Object, funcName string) (*big.Int, *object.Error) {
+	switch v := arg.(type) {
+	case *object.Integer:
+		return v.Value, nil
+	case *object.Float:
+		return big.NewInt(int64(v.Value)), nil
+	case *object.Byte:
+		return big.NewInt(int64(v.Value)), nil
+	default:
+		return nil, &object.Error{
+			Code:    "E7004",
+			Message: fmt.Sprintf("%s requires an integer argument", funcName),
+		}
+	}
+}
+
+// Helper to reverse byte slice (for endianness conversion with big.Int)
+func reverseBytes(data []byte) []byte {
+	n := len(data)
+	result := make([]byte, n)
+	for i := 0; i < n; i++ {
+		result[i] = data[n-1-i]
+	}
+	return result
+}
+
+// Helper to pad big.Int bytes to exact size (big-endian, for signed integers)
+// Converts negative numbers to two's complement representation
+func padBigIntBytesSigned(val *big.Int, size int) []byte {
+	if val.Sign() >= 0 {
+		// Positive: just pad with zeros
+		bytes := val.Bytes()
+		if len(bytes) > size {
+			return bytes[len(bytes)-size:]
+		}
+		result := make([]byte, size)
+		copy(result[size-len(bytes):], bytes)
+		return result
+	}
+
+	// Negative: convert to two's complement
+	// Two's complement = 2^(size*8) + val
+	modulus := new(big.Int).Lsh(big.NewInt(1), uint(size*8))
+	twosComp := new(big.Int).Add(modulus, val)
+	bytes := twosComp.Bytes()
+
+	if len(bytes) > size {
+		return bytes[len(bytes)-size:]
+	}
+	result := make([]byte, size)
+	copy(result[size-len(bytes):], bytes)
+	return result
+}
+
+// Helper to pad big.Int bytes to exact size (big-endian, for unsigned integers)
+func padBigIntBytesUnsigned(val *big.Int, size int) []byte {
+	bytes := val.Bytes()
+	if len(bytes) > size {
+		return bytes[len(bytes)-size:]
+	}
+	result := make([]byte, size)
+	copy(result[size-len(bytes):], bytes)
+	return result
+}
+
+// BinaryBuiltins contains the binary module functions for encoding/decoding
+var BinaryBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// 8-bit Encoding/Decoding (no endianness needed)
+	// ============================================================================
+
+	// Encodes an i8 to a single byte
+	"binary.encode_i8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i8() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i8()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -128 || intVal > 127 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i8 range (-128 to 127)", intVal)),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray([]byte{byte(int8(intVal))}),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Decodes a single byte to an i8
+	"binary.decode_i8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i8() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 1, "binary.decode_i8()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int8(data[0])
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i8"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Encodes a u8 to a single byte
+	"binary.encode_u8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u8() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u8()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < 0 || intVal > 255 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of u8 range (0 to 255)", intVal)),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray([]byte{byte(intVal)}),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Decodes a single byte to a u8
+	"binary.decode_u8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u8() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 1, "binary.decode_u8()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(data[0])), DeclaredType: "u8"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 16-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i16_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i16_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i16_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -32768 || intVal > 32767 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.LittleEndian.PutUint16(buf, uint16(int16(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i16_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i16_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_i16_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int16(binary.LittleEndian.Uint16(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u16_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u16_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u16_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < 0 || intVal > 65535 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of u16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.LittleEndian.PutUint16(buf, uint16(intVal))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u16_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u16_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_u16_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.LittleEndian.Uint16(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 16-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i16_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i16_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i16_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -32768 || intVal > 32767 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.BigEndian.PutUint16(buf, uint16(int16(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i16_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i16_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_i16_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int16(binary.BigEndian.Uint16(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u16_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u16_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u16_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < 0 || intVal > 65535 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of u16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.BigEndian.PutUint16(buf, uint16(intVal))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u16_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u16_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_u16_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.BigEndian.Uint16(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 32-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i32_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i32_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i32_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -2147483648 || intVal > 2147483647 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i32 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(buf, uint32(int32(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i32_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i32_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_i32_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int32(binary.LittleEndian.Uint32(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u32_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u32_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u32_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			if val.Sign() < 0 || val.Cmp(big.NewInt(4294967295)) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u32 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(buf, uint32(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u32_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u32_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_u32_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.LittleEndian.Uint32(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 32-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i32_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i32_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i32_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -2147483648 || intVal > 2147483647 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i32 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.BigEndian.PutUint32(buf, uint32(int32(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i32_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i32_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_i32_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int32(binary.BigEndian.Uint32(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u32_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u32_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u32_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			if val.Sign() < 0 || val.Cmp(big.NewInt(4294967295)) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u32 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.BigEndian.PutUint32(buf, uint32(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u32_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u32_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_u32_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.BigEndian.Uint32(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 64-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i64_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i64_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i64_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			minI64 := new(big.Int).SetInt64(-9223372036854775808)
+			maxI64 := new(big.Int).SetInt64(9223372036854775807)
+			if val.Cmp(minI64) < 0 || val.Cmp(maxI64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of i64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, uint64(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i64_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i64_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_i64_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int64(binary.LittleEndian.Uint64(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(val), DeclaredType: "i64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u64_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u64_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u64_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			maxU64 := new(big.Int).SetUint64(18446744073709551615)
+			if val.Sign() < 0 || val.Cmp(maxU64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, val.Uint64())
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u64_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u64_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_u64_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.LittleEndian.Uint64(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: new(big.Int).SetUint64(val), DeclaredType: "u64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 64-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i64_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i64_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i64_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			minI64 := new(big.Int).SetInt64(-9223372036854775808)
+			maxI64 := new(big.Int).SetInt64(9223372036854775807)
+			if val.Cmp(minI64) < 0 || val.Cmp(maxI64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of i64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, uint64(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i64_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i64_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_i64_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int64(binary.BigEndian.Uint64(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(val), DeclaredType: "i64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u64_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u64_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u64_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			maxU64 := new(big.Int).SetUint64(18446744073709551615)
+			if val.Sign() < 0 || val.Cmp(maxU64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, val.Uint64())
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u64_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u64_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_u64_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.BigEndian.Uint64(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: new(big.Int).SetUint64(val), DeclaredType: "u64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 128-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i128_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i128_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i128_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			minI128 := new(big.Int).Lsh(big.NewInt(-1), 127)
+			maxI128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+			if val.Cmp(minI128) < 0 || val.Cmp(maxI128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i128 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i128_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i128_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_i128_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			// Reverse for big-endian interpretation
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			// Check if negative (high bit set)
+			if beData[0]&0x80 != 0 {
+				// Two's complement: subtract 2^128
+				twoTo128 := new(big.Int).Lsh(big.NewInt(1), 128)
+				val.Sub(val, twoTo128)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u128_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u128_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u128_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			maxU128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u128 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u128_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u128_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_u128_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 128-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i128_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i128_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i128_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			minI128 := new(big.Int).Lsh(big.NewInt(-1), 127)
+			maxI128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+			if val.Cmp(minI128) < 0 || val.Cmp(maxI128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i128 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i128_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i128_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_i128_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			// Check if negative (high bit set)
+			if data[0]&0x80 != 0 {
+				twoTo128 := new(big.Int).Lsh(big.NewInt(1), 128)
+				val.Sub(val, twoTo128)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u128_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u128_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u128_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			maxU128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u128 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u128_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u128_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_u128_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 256-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i256_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i256_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i256_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			minI256 := new(big.Int).Lsh(big.NewInt(-1), 255)
+			maxI256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+			if val.Cmp(minI256) < 0 || val.Cmp(maxI256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i256 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i256_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i256_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_i256_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			if beData[0]&0x80 != 0 {
+				twoTo256 := new(big.Int).Lsh(big.NewInt(1), 256)
+				val.Sub(val, twoTo256)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u256_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u256_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u256_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			maxU256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u256 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u256_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u256_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_u256_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 256-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i256_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i256_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i256_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			minI256 := new(big.Int).Lsh(big.NewInt(-1), 255)
+			maxI256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+			if val.Cmp(minI256) < 0 || val.Cmp(maxI256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i256 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i256_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i256_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_i256_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			if data[0]&0x80 != 0 {
+				twoTo256 := new(big.Int).Lsh(big.NewInt(1), 256)
+				val.Sub(val, twoTo256)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u256_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u256_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u256_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			maxU256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u256 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u256_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u256_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_u256_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Float Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_f32_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f32_to_little_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f32_to_little_endian() requires a float or integer argument"}
+			}
+			bits := math.Float32bits(float32(floatVal))
+			buf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f32_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f32_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_f32_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.LittleEndian.Uint32(data)
+			val := math.Float32frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: float64(val)},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_f64_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f64_to_little_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f64_to_little_endian() requires a float or integer argument"}
+			}
+			bits := math.Float64bits(floatVal)
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f64_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f64_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_f64_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.LittleEndian.Uint64(data)
+			val := math.Float64frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: val},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Float Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_f32_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f32_to_big_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f32_to_big_endian() requires a float or integer argument"}
+			}
+			bits := math.Float32bits(float32(floatVal))
+			buf := make([]byte, 4)
+			binary.BigEndian.PutUint32(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f32_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f32_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_f32_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.BigEndian.Uint32(data)
+			val := math.Float32frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: float64(val)},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_f64_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f64_to_big_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f64_to_big_endian() requires a float or integer argument"}
+			}
+			bits := math.Float64bits(floatVal)
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f64_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f64_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_f64_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.BigEndian.Uint64(data)
+			val := math.Float64frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: val},
+				object.NIL,
+			}}
+		},
+	},
+}

--- a/pkg/stdlib/binary_test.go
+++ b/pkg/stdlib/binary_test.go
@@ -1,0 +1,352 @@
+package stdlib
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// Helper to create byte array from slice
+func makeBinaryByteArray(bytes []byte) *object.Array {
+	elements := make([]object.Object, len(bytes))
+	for i, b := range bytes {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper to extract bytes from return value
+func extractBytesFromReturn(t *testing.T, result object.Object) []byte {
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if len(rv.Values) != 2 {
+		t.Fatalf("expected 2 values in tuple, got %d", len(rv.Values))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Fatalf("expected nil error, got %v", rv.Values[1])
+	}
+	arr, ok := rv.Values[0].(*object.Array)
+	if !ok {
+		t.Fatalf("expected Array, got %T", rv.Values[0])
+	}
+	bytes := make([]byte, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		b, ok := elem.(*object.Byte)
+		if !ok {
+			t.Fatalf("expected Byte at index %d, got %T", i, elem)
+		}
+		bytes[i] = b.Value
+	}
+	return bytes
+}
+
+// Helper to extract integer from return value
+func extractIntFromReturn(t *testing.T, result object.Object) *big.Int {
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if len(rv.Values) != 2 {
+		t.Fatalf("expected 2 values in tuple, got %d", len(rv.Values))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Fatalf("expected nil error, got %v", rv.Values[1])
+	}
+	intVal, ok := rv.Values[0].(*object.Integer)
+	if !ok {
+		t.Fatalf("expected Integer, got %T", rv.Values[0])
+	}
+	return intVal.Value
+}
+
+// Helper to extract float from return value
+func extractFloatFromReturn(t *testing.T, result object.Object) float64 {
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if len(rv.Values) != 2 {
+		t.Fatalf("expected 2 values in tuple, got %d", len(rv.Values))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Fatalf("expected nil error, got %v", rv.Values[1])
+	}
+	floatVal, ok := rv.Values[0].(*object.Float)
+	if !ok {
+		t.Fatalf("expected Float, got %T", rv.Values[0])
+	}
+	return floatVal.Value
+}
+
+func TestBinaryEncodeDecodeI8(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected byte
+	}{
+		{0, 0x00},
+		{127, 0x7F},
+		{-128, 0x80},
+		{-1, 0xFF},
+	}
+
+	for _, tt := range tests {
+		// Encode
+		encodeResult := BinaryBuiltins["binary.encode_i8"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 1 || bytes[0] != tt.expected {
+			t.Errorf("encode_i8(%d): expected [0x%02X], got %v", tt.input, tt.expected, bytes)
+		}
+
+		// Decode
+		decodeResult := BinaryBuiltins["binary.decode_i8"].Fn(makeBinaryByteArray([]byte{tt.expected}))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_i8([0x%02X]): expected %d, got %d", tt.expected, tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeU8(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected byte
+	}{
+		{0, 0x00},
+		{127, 0x7F},
+		{255, 0xFF},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_u8"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 1 || bytes[0] != tt.expected {
+			t.Errorf("encode_u8(%d): expected [0x%02X], got %v", tt.input, tt.expected, bytes)
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_u8"].Fn(makeBinaryByteArray([]byte{tt.expected}))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_u8([0x%02X]): expected %d, got %d", tt.expected, tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeI32LE(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected []byte
+	}{
+		{0, []byte{0x00, 0x00, 0x00, 0x00}},
+		{1, []byte{0x01, 0x00, 0x00, 0x00}},
+		{256, []byte{0x00, 0x01, 0x00, 0x00}},
+		{12345, []byte{0x39, 0x30, 0x00, 0x00}},
+		{-1, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+		{2147483647, []byte{0xFF, 0xFF, 0xFF, 0x7F}},
+		{-2147483648, []byte{0x00, 0x00, 0x00, 0x80}},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_i32_to_little_endian"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 4 {
+			t.Errorf("encode_i32_to_little_endian(%d): expected 4 bytes, got %d", tt.input, len(bytes))
+			continue
+		}
+		for i, b := range tt.expected {
+			if bytes[i] != b {
+				t.Errorf("encode_i32_to_little_endian(%d): byte %d expected 0x%02X, got 0x%02X", tt.input, i, b, bytes[i])
+			}
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_i32_from_little_endian"].Fn(makeBinaryByteArray(tt.expected))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_i32_from_little_endian: expected %d, got %d", tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeI32BE(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected []byte
+	}{
+		{0, []byte{0x00, 0x00, 0x00, 0x00}},
+		{1, []byte{0x00, 0x00, 0x00, 0x01}},
+		{256, []byte{0x00, 0x00, 0x01, 0x00}},
+		{12345, []byte{0x00, 0x00, 0x30, 0x39}},
+		{-1, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_i32_to_big_endian"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		for i, b := range tt.expected {
+			if bytes[i] != b {
+				t.Errorf("encode_i32_to_big_endian(%d): byte %d expected 0x%02X, got 0x%02X", tt.input, i, b, bytes[i])
+			}
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_i32_from_big_endian"].Fn(makeBinaryByteArray(tt.expected))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_i32_from_big_endian: expected %d, got %d", tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeU64LE(t *testing.T) {
+	tests := []struct {
+		input    uint64
+		expected []byte
+	}{
+		{0, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{1, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{18446744073709551615, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_u64_to_little_endian"].Fn(&object.Integer{Value: new(big.Int).SetUint64(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		for i, b := range tt.expected {
+			if bytes[i] != b {
+				t.Errorf("encode_u64_to_little_endian(%d): byte %d expected 0x%02X, got 0x%02X", tt.input, i, b, bytes[i])
+			}
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_u64_from_little_endian"].Fn(makeBinaryByteArray(tt.expected))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Uint64() != tt.input {
+			t.Errorf("decode_u64_from_little_endian: expected %d, got %d", tt.input, val.Uint64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeF32LE(t *testing.T) {
+	tests := []float32{
+		0.0,
+		1.0,
+		-1.0,
+		3.14159,
+		float32(math.MaxFloat32),
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_f32_to_little_endian"].Fn(&object.Float{Value: float64(tt)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 4 {
+			t.Errorf("encode_f32_to_little_endian(%f): expected 4 bytes, got %d", tt, len(bytes))
+			continue
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_f32_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+		val := extractFloatFromReturn(t, decodeResult)
+		if float32(val) != tt {
+			t.Errorf("f32 round-trip: expected %f, got %f", tt, val)
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeF64LE(t *testing.T) {
+	tests := []float64{
+		0.0,
+		1.0,
+		-1.0,
+		3.141592653589793,
+		math.MaxFloat64,
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_f64_to_little_endian"].Fn(&object.Float{Value: tt})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 8 {
+			t.Errorf("encode_f64_to_little_endian(%f): expected 8 bytes, got %d", tt, len(bytes))
+			continue
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_f64_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+		val := extractFloatFromReturn(t, decodeResult)
+		if val != tt {
+			t.Errorf("f64 round-trip: expected %f, got %f", tt, val)
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeI128LE(t *testing.T) {
+	// Test zero
+	encodeResult := BinaryBuiltins["binary.encode_i128_to_little_endian"].Fn(&object.Integer{Value: big.NewInt(0)})
+	bytes := extractBytesFromReturn(t, encodeResult)
+	if len(bytes) != 16 {
+		t.Errorf("encode_i128_to_little_endian(0): expected 16 bytes, got %d", len(bytes))
+	}
+
+	decodeResult := BinaryBuiltins["binary.decode_i128_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+	val := extractIntFromReturn(t, decodeResult)
+	if val.Cmp(big.NewInt(0)) != 0 {
+		t.Errorf("decode_i128_from_little_endian(0): expected 0, got %s", val.String())
+	}
+
+	// Test positive value
+	testVal := big.NewInt(12345678901234567)
+	encodeResult = BinaryBuiltins["binary.encode_i128_to_little_endian"].Fn(&object.Integer{Value: testVal})
+	bytes = extractBytesFromReturn(t, encodeResult)
+	decodeResult = BinaryBuiltins["binary.decode_i128_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+	val = extractIntFromReturn(t, decodeResult)
+	if val.Cmp(testVal) != 0 {
+		t.Errorf("i128 round-trip: expected %s, got %s", testVal.String(), val.String())
+	}
+
+	// Test negative value
+	negVal := big.NewInt(-12345678901234567)
+	encodeResult = BinaryBuiltins["binary.encode_i128_to_little_endian"].Fn(&object.Integer{Value: negVal})
+	bytes = extractBytesFromReturn(t, encodeResult)
+	decodeResult = BinaryBuiltins["binary.decode_i128_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+	val = extractIntFromReturn(t, decodeResult)
+	if val.Cmp(negVal) != 0 {
+		t.Errorf("i128 round-trip (negative): expected %s, got %s", negVal.String(), val.String())
+	}
+}
+
+func TestBinaryRangeErrors(t *testing.T) {
+	// i8 out of range
+	result := BinaryBuiltins["binary.encode_i8"].Fn(&object.Integer{Value: big.NewInt(128)})
+	rv, ok := result.(*object.ReturnValue)
+	if !ok || rv.Values[1] == object.NIL {
+		t.Error("encode_i8(128) should return error")
+	}
+
+	// u8 negative
+	result = BinaryBuiltins["binary.encode_u8"].Fn(&object.Integer{Value: big.NewInt(-1)})
+	rv, ok = result.(*object.ReturnValue)
+	if !ok || rv.Values[1] == object.NIL {
+		t.Error("encode_u8(-1) should return error")
+	}
+
+	// Wrong byte array length
+	result = BinaryBuiltins["binary.decode_i32_from_little_endian"].Fn(makeBinaryByteArray([]byte{0x00, 0x00}))
+	rv, ok = result.(*object.ReturnValue)
+	if !ok || rv.Values[1] == object.NIL {
+		t.Error("decode_i32_from_little_endian with 2 bytes should return error")
+	}
+}
+
+func TestBinaryWrongArgCount(t *testing.T) {
+	// No args
+	result := BinaryBuiltins["binary.encode_i32_to_little_endian"].Fn()
+	if _, ok := result.(*object.Error); !ok {
+		t.Error("encode_i32_to_little_endian() with no args should return error")
+	}
+
+	// Too many args
+	result = BinaryBuiltins["binary.encode_i32_to_little_endian"].Fn(
+		&object.Integer{Value: big.NewInt(1)},
+		&object.Integer{Value: big.NewInt(2)},
+	)
+	if _, ok := result.(*object.Error); !ok {
+		t.Error("encode_i32_to_little_endian() with 2 args should return error")
+	}
+}

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -49,6 +49,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range JsonBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range BinaryBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }


### PR DESCRIPTION
## Summary

- Add `@binary` stdlib module for encoding/decoding integers and floats to/from byte arrays
- Add sized integer conversion builtins (i8-i256, u8-u256, f32, f64)

## Changes

### @binary Module (56 functions)

Encode/decode functions with explicit endianness:
- 8-bit: `encode_i8`, `encode_u8`, `decode_i8`, `decode_u8`
- 16/32/64-bit: `encode_i32_to_little_endian`, `decode_i32_from_little_endian`, etc.
- 128/256-bit: Same pattern for big integers
- Floats: `encode_f32_to_little_endian`, `encode_f64_to_big_endian`, etc.

### Sized Type Conversions (14 builtins)

Global conversion functions with range checking:
- Signed: `i8()`, `i16()`, `i32()`, `i64()`, `i128()`, `i256()`
- Unsigned: `u8()`, `u16()`, `u32()`, `u64()`, `u128()`, `u256()`
- Float: `f32()`, `f64()`

## Test plan

- [x] Unit tests for encode/decode round-trips
- [x] Boundary value tests (min/max for each type)
- [x] Error case tests (out of range, wrong length)
- [x] All tests pass: `go test ./pkg/stdlib/ -run Binary`

Closes #716