### PR TITLE
feat(lang): add `cast()` keyword for type conversion

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -256,6 +256,18 @@ type RangeExpression struct {
 func (r *RangeExpression) expressionNode()      {}
 func (r *RangeExpression) TokenLiteral() string { return r.Token.Literal }
 
+// CastExpression represents cast(value, type) for type conversion
+type CastExpression struct {
+	Token       Token      // The 'cast' token
+	Value       Expression // The expression to convert
+	TargetType  string     // The target type (e.g., "u8", "[u8]", "int")
+	IsArray     bool       // True if target is an array type like [u8]
+	ElementType string     // For arrays, the element type (e.g., "u8" from "[u8]")
+}
+
+func (c *CastExpression) expressionNode()      {}
+func (c *CastExpression) TokenLiteral() string { return c.Token.Literal }
+
 // ============================================================================
 // Statements
 // ============================================================================

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -121,6 +121,9 @@ const (
 	IS      TokenType = "IS"
 	DEFAULT TokenType = "DEFAULT"
 
+	// Type conversion
+	CAST TokenType = "CAST"
+
 	// Ampersand (for import & use syntax)
 	AMPERSAND TokenType = "&"
 )
@@ -157,6 +160,7 @@ var keywords = map[string]TokenType{
 	"when":       WHEN,
 	"is":         IS,
 	"default":    DEFAULT,
+	"cast":       CAST,
 }
 
 // Looks up the passed in identifier(i)
@@ -176,7 +180,7 @@ func IsKeyword(t TokenType) bool {
 		FOR, FOR_EACH, AS_LONG_AS, LOOP, BREAK, CONTINUE,
 		IN, NOT_IN, RANGE, IMPORT, USING, STRUCT, ENUM,
 		NIL, NEW, TRUE, FALSE, BLANK, MODULE, PRIVATE, USE,
-		WHEN, IS, DEFAULT:
+		WHEN, IS, DEFAULT, CAST:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- Add `cast(value, type)` keyword for explicit type conversion
- Supports single values: `cast(42, u8)`, `cast(3.14, int)`
- Supports element-wise array conversion: `cast(byte_array, [u8])`
- Includes 17 integration tests covering all conversion scenarios

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Manual testing with test file
- [x] Error handling for out-of-range values
- [x] Error handling for array conversion failures (with index info)

Closes #717