### PR TITLE
fix(modules): report type errors in single-file modules at compile time (#720)

### DIFF
--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -883,6 +883,22 @@ func runFile(filename string) {
 
 			fileTc.CheckProgram(fileProgram)
 
+			// Check for type errors in single-file modules (#720)
+			// For multi-file modules, we skip error checking here because each file
+			// is type-checked without context from other files in the same module.
+			// Multi-file module type errors will be caught at runtime.
+			if len(mod.Files) == 1 {
+				if fileTc.Errors().HasErrors() {
+					fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+					os.Exit(1)
+				}
+
+				// Display type checker warnings from single-file modules
+				if fileTc.Errors().HasWarnings() {
+					fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+				}
+			}
+
 			// Extract module name, function signatures, and types
 			if fileProgram.Module != nil && fileProgram.Module.Name != nil {
 				// Use the alias if one was provided, otherwise use the module's internal name


### PR DESCRIPTION
## Summary
- Adds compile-time error reporting for type errors in single-file modules
- Fixes misleading errors where calling a module function that internally uses an undefined function would report the caller as undefined instead of the actual missing function

## Limitation
Multi-file modules are excluded because each file is type-checked without context from other files in the same module. A follow-up issue will track improving multi-file module type checking.

## Test plan
- [x] All 285 integration tests pass
- [x] All 43 audit tests pass
- [x] All Go unit tests pass
- [x] Verified original bug scenario is fixed