### PR TITLE
feat: @binary module, cast keyword, and attribute syntax improvements

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -86,11 +86,11 @@ Syntax and parsing errors
 | E2048 | when-bool-condition | when condition cannot be a boolean. Use if/or/otherwise instead |
 | E2049 | when-nil-condition | when condition cannot be nil. Use if/otherwise to check for nil |
 | E2050 | when-collection-condition | when condition cannot be an array or map |
-| E2051 | suppress-invalid-target | @suppress can only be applied to function declarations |
+| E2051 | suppress-invalid-target | #suppress can only be applied to function declarations |
 | E2052 | suppress-invalid-code | warning code cannot be suppressed |
 | E2053 | type-definition-in-function | type definitions must be at file level |
-| E2054 | when-strict-non-enum-case | @strict when requires explicit enum member values in cases |
-| E2055 | strict-invalid-target | @strict can only be applied to when statements |
+| E2054 | when-strict-non-enum-case | #strict when requires explicit enum member values in cases |
+| E2055 | strict-invalid-target | #strict can only be applied to when statements |
 | E2056 | executable-at-file-scope | executable statement not allowed at file scope |
 
 ## Type Errors (E3xxx)

--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -883,6 +883,22 @@ func runFile(filename string) {
 
 			fileTc.CheckProgram(fileProgram)
 
+			// Check for type errors in single-file modules (#720)
+			// For multi-file modules, we skip error checking here because each file
+			// is type-checked without context from other files in the same module.
+			// Multi-file module type errors will be caught at runtime.
+			if len(mod.Files) == 1 {
+				if fileTc.Errors().HasErrors() {
+					fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+					os.Exit(1)
+				}
+
+				// Display type checker warnings from single-file modules
+				if fileTc.Errors().HasWarnings() {
+					fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+				}
+			}
+
 			// Extract module name, function signatures, and types
 			if fileProgram.Module != nil && fileProgram.Module.Name != nil {
 				// Use the alias if one was provided, otherwise use the module's internal name

--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -846,11 +846,26 @@ func runFile(filename string) {
 			continue // Module load errors will be caught at runtime
 		}
 
+		// For multi-file modules, use two-pass type checking (#722)
+		// Pass 1: Parse all files and extract declarations
+		// Pass 2: Full type check with complete module context
+		type parsedFile struct {
+			path    string
+			source  string
+			program *ast.Program
+		}
+		var parsedFiles []parsedFile
+
+		// Module-internal declarations (shared across files in the same module)
+		moduleInternalTypes := make(map[string]*typechecker.Type)
+		moduleInternalFuncs := make(map[string]*typechecker.FunctionSignature)
+		moduleInternalVars := make(map[string]string)
+
+		// Pass 1: Parse all files and extract declarations
 		for _, filePath := range mod.Files {
 			if checked[filePath] {
 				continue
 			}
-			checked[filePath] = true
 
 			fileData, err := os.ReadFile(filePath)
 			if err != nil {
@@ -866,7 +881,46 @@ func runFile(filename string) {
 				continue
 			}
 
-			fileTc := typechecker.NewTypeChecker(fileSource, filePath)
+			parsedFiles = append(parsedFiles, parsedFile{filePath, fileSource, fileProgram})
+
+			// Lightweight declaration extraction for multi-file modules
+			if len(mod.Files) > 1 {
+				declTc := typechecker.NewTypeChecker(fileSource, filePath)
+				declTc.SetSkipMainCheck(true)
+
+				// Register external module types/functions for type resolution
+				for modName, types := range moduleTypes {
+					for typeName, t := range types {
+						declTc.RegisterModuleType(modName, typeName, t)
+					}
+				}
+
+				declTc.RegisterDeclarations(fileProgram)
+
+				// Collect types, functions, and variables from this file
+				for typeName, t := range declTc.GetTypes() {
+					if t.Kind == typechecker.StructType || t.Kind == typechecker.EnumType {
+						moduleInternalTypes[typeName] = t
+					}
+				}
+				for funcName, sig := range declTc.GetFunctions() {
+					moduleInternalFuncs[funcName] = sig
+				}
+				for varName, varType := range declTc.GetVariables() {
+					moduleInternalVars[varName] = varType
+				}
+			}
+
+			// Collect imports from all files
+			newImports := collectImports(fileProgram, rootDir, filePath)
+			modulesToCheck = append(modulesToCheck, newImports...)
+		}
+
+		// Pass 2: Full type checking with complete module context
+		for _, pf := range parsedFiles {
+			checked[pf.path] = true
+
+			fileTc := typechecker.NewTypeChecker(pf.source, pf.path)
 			fileTc.SetSkipMainCheck(true)
 
 			// Register already-collected module types for cross-module checking (#709)
@@ -881,28 +935,46 @@ func runFile(filename string) {
 				}
 			}
 
-			fileTc.CheckProgram(fileProgram)
-
-			// Check for type errors in single-file modules (#720)
-			// For multi-file modules, we skip error checking here because each file
-			// is type-checked without context from other files in the same module.
-			// Multi-file module type errors will be caught at runtime.
-			if len(mod.Files) == 1 {
-				if fileTc.Errors().HasErrors() {
-					fmt.Print(errors.FormatErrorList(fileTc.Errors()))
-					os.Exit(1)
+			// For multi-file modules, register module-internal types/functions/variables (#722)
+			if len(mod.Files) > 1 {
+				// Get module name for self-referencing types (e.g., testmod.Hero within testmod)
+				var selfModuleName string
+				if pf.program.Module != nil && pf.program.Module.Name != nil {
+					selfModuleName = pf.program.Module.Name.Value
 				}
 
-				// Display type checker warnings from single-file modules
-				if fileTc.Errors().HasWarnings() {
-					fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+				for typeName, t := range moduleInternalTypes {
+					fileTc.RegisterType(typeName, t)
+					// Also register as module-prefixed type for self-referencing (bug #463)
+					if selfModuleName != "" {
+						fileTc.RegisterModuleType(selfModuleName, typeName, t)
+					}
+				}
+				for funcName, sig := range moduleInternalFuncs {
+					fileTc.RegisterFunction(funcName, sig)
+				}
+				for varName, varType := range moduleInternalVars {
+					fileTc.RegisterVariable(varName, varType)
 				}
 			}
 
+			fileTc.CheckProgram(pf.program)
+
+			// Check for type errors in module files (#720, #722)
+			if fileTc.Errors().HasErrors() {
+				fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+				os.Exit(1)
+			}
+
+			// Display type checker warnings from module files
+			if fileTc.Errors().HasWarnings() {
+				fmt.Print(errors.FormatErrorList(fileTc.Errors()))
+			}
+
 			// Extract module name, function signatures, and types
-			if fileProgram.Module != nil && fileProgram.Module.Name != nil {
+			if pf.program.Module != nil && pf.program.Module.Name != nil {
 				// Use the alias if one was provided, otherwise use the module's internal name
-				moduleName := fileProgram.Module.Name.Value
+				moduleName := pf.program.Module.Name.Value
 				if alias, hasAlias := pathToAlias[modPath]; hasAlias {
 					moduleName = alias
 				}
@@ -928,9 +1000,6 @@ func runFile(filename string) {
 					moduleVariables[moduleName][varName] = varType
 				}
 			}
-
-			newImports := collectImports(fileProgram, rootDir, filePath)
-			modulesToCheck = append(modulesToCheck, newImports...)
 		}
 	}
 

--- a/integration-tests/fail/errors/E2042_when_strict_has_default.ez
+++ b/integration-tests/fail/errors/E2042_when_strict_has_default.ez
@@ -1,4 +1,4 @@
-// E2042: @strict when statement cannot have a default case
+// E2042: #strict when statement cannot have a default case
 import @std
 using std
 
@@ -10,7 +10,7 @@ const Status enum {
 do main() {
     temp s = Status.PENDING
 
-    @strict
+    #strict
     when s {
         is Status.PENDING { println("pending") }
         is Status.ACTIVE { println("active") }

--- a/integration-tests/fail/errors/E2045_when_strict_non_enum.ez
+++ b/integration-tests/fail/errors/E2045_when_strict_non_enum.ez
@@ -1,10 +1,10 @@
-// E2045: @strict attribute only allowed on enum when statements
+// E2045: #strict attribute only allowed on enum when statements
 import @std
 using std
 
 do main() {
     temp x = 1
-    @strict
+    #strict
     when x {
         is 1 { println("one") }
         is 2 { println("two") }

--- a/integration-tests/fail/errors/E2046_strict_when_missing_cases.ez
+++ b/integration-tests/fail/errors/E2046_strict_when_missing_cases.ez
@@ -10,7 +10,7 @@ const Color enum {
 do main() {
     temp c Color = Color.RED
 
-    @strict
+    #strict
     when c {
         is Color.RED {
             println("red")

--- a/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
+++ b/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
@@ -1,12 +1,12 @@
 /*
  * Error Test: E2051 - suppress-invalid-target
- * Expected: "@suppress can only be applied to function declarations"
+ * Expected: "#suppress can only be applied to function declarations"
  */
 
 module main
 
-@suppress(W1001)
-const x = 5  // @suppress on variable declaration is not allowed
+#suppress(W1001)
+const x = 5  // #suppress on variable declaration is not allowed
 
 do main() {
     println(x)

--- a/integration-tests/fail/errors/E2052_suppress_invalid_code.ez
+++ b/integration-tests/fail/errors/E2052_suppress_invalid_code.ez
@@ -5,7 +5,7 @@
 
 module main
 
-@suppress(W9999)
+#suppress(W9999)
 do foo() {
     // W9999 does not exist
 }

--- a/integration-tests/fail/errors/E2052_suppress_non_suppressible.ez
+++ b/integration-tests/fail/errors/E2052_suppress_non_suppressible.ez
@@ -5,7 +5,7 @@
 
 module main
 
-@suppress(W1002)
+#suppress(W1002)
 do foo() {
     // W1002 (unused-import) is a valid code but cannot be suppressed
 }

--- a/integration-tests/fail/errors/E2054_strict_when_non_enum_case.ez
+++ b/integration-tests/fail/errors/E2054_strict_when_non_enum_case.ez
@@ -10,7 +10,7 @@ const Color enum {
 do main() {
     temp c Color = Color.RED
 
-    @strict
+    #strict
     when c {
         is range(0, 2) {
             println("in range")

--- a/integration-tests/fail/errors/E2055_strict_invalid_target.ez
+++ b/integration-tests/fail/errors/E2055_strict_invalid_target.ez
@@ -1,7 +1,7 @@
 import @std
 using std
 
-@strict
+#strict
 do main() {
     println("hello")
 }

--- a/integration-tests/pass/core/enums.ez
+++ b/integration-tests/pass/core/enums.ez
@@ -14,7 +14,7 @@ const Direction enum {
 }
 
 /* Flags enum with power-of-2 values (1, 2, 4, 8) */
-@flags
+#flags
 const Permissions enum {
     READ      // 1
     WRITE     // 2
@@ -30,7 +30,7 @@ const Status enum {
 }
 
 /* Explicit int enum (same as default) */
-@enum(int)
+#enum(int)
 const Priority enum {
     LOW       // 0
     MEDIUM    // 1
@@ -135,14 +135,14 @@ do main() {
     }
 
     // ==================== EXPLICIT INT ENUM ====================
-    println("  -- Explicit @enum(int) --")
+    println("  -- Explicit #enum(int) --")
 
-    // Test 10: @enum(int) works like default
+    // Test 10: #enum(int) works like default
     if Priority.LOW == 0 && Priority.MEDIUM == 1 && Priority.HIGH == 2 {
-        println("  [PASS] @enum(int) auto-increment (0, 1, 2)")
+        println("  [PASS] #enum(int) auto-increment (0, 1, 2)")
         passed += 1
     } otherwise {
-        println("  [FAIL] @enum(int): LOW=${Priority.LOW}, MEDIUM=${Priority.MEDIUM}, HIGH=${Priority.HIGH}")
+        println("  [FAIL] #enum(int): LOW=${Priority.LOW}, MEDIUM=${Priority.MEDIUM}, HIGH=${Priority.HIGH}")
         failed += 1
     }
 

--- a/integration-tests/pass/core/when-statements.ez
+++ b/integration-tests/pass/core/when-statements.ez
@@ -109,7 +109,7 @@ do test_strict_enum() {
     temp s = Status.DONE
     temp result = ""
 
-    @strict
+    #strict
     when s {
         is Status.PENDING { result = "pending" }
         is Status.ACTIVE { result = "active" }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -256,6 +256,18 @@ type RangeExpression struct {
 func (r *RangeExpression) expressionNode()      {}
 func (r *RangeExpression) TokenLiteral() string { return r.Token.Literal }
 
+// CastExpression represents cast(value, type) for type conversion
+type CastExpression struct {
+	Token       Token      // The 'cast' token
+	Value       Expression // The expression to convert
+	TargetType  string     // The target type (e.g., "u8", "[u8]", "int")
+	IsArray     bool       // True if target is an array type like [u8]
+	ElementType string     // For arrays, the element type (e.g., "u8" from "[u8]")
+}
+
+func (c *CastExpression) expressionNode()      {}
+func (c *CastExpression) TokenLiteral() string { return c.Token.Literal }
+
 // ============================================================================
 // Statements
 // ============================================================================

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -27,9 +27,10 @@ type Expression interface {
 
 // Program is the root node of every AST
 type Program struct {
-	Module     *ModuleDeclaration // Optional module declaration (first statement if present)
-	FileUsing  []*UsingStatement  // File-scoped using declarations
-	Statements []Statement
+	Module               *ModuleDeclaration // Optional module declaration (first statement if present)
+	FileUsing            []*UsingStatement  // File-scoped using declarations
+	Statements           []Statement
+	FileSuppressWarnings []string // File-level @suppress warnings (e.g., "W2009", "ALL")
 }
 
 // Visibility represents the access level of a declaration

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -30,7 +30,7 @@ type Program struct {
 	Module               *ModuleDeclaration // Optional module declaration (first statement if present)
 	FileUsing            []*UsingStatement  // File-scoped using declarations
 	Statements           []Statement
-	FileSuppressWarnings []string // File-level @suppress warnings (e.g., "W2009", "ALL")
+	FileSuppressWarnings []string // File-level #suppress warnings (e.g., "W2009", "ALL")
 }
 
 // Visibility represents the access level of a declaration
@@ -284,7 +284,7 @@ type VariableDeclaration struct {
 	TypeNames  []string // for typed tuple unpacking (int, string)
 	Value      Expression
 	Mutable    bool
-	Attributes []*Attribute // @suppress(...) attributes
+	Attributes []*Attribute // #suppress(...) attributes
 	Visibility Visibility   // Public (default), Private, or PrivateModule
 }
 
@@ -296,7 +296,7 @@ type BlankIdentifier struct {
 func (b *BlankIdentifier) expressionNode()      {}
 func (b *BlankIdentifier) TokenLiteral() string { return b.Token.Literal }
 
-// Attribute represents @suppress(warning_name, ...)
+// Attribute represents #suppress(warning_name, ...)
 type Attribute struct {
 	Token Token
 	Name  string   // "suppress"
@@ -373,8 +373,8 @@ type WhenStatement struct {
 	Value      Expression      // The value being matched
 	Cases      []*WhenCase     // All is cases
 	Default    *BlockStatement // Required default case
-	IsStrict   bool            // true if @strict attribute present
-	Attributes []*Attribute    // Any attributes like @strict
+	IsStrict   bool            // true if #strict attribute present
+	Attributes []*Attribute    // Any attributes like #strict
 }
 
 func (ws *WhenStatement) statementNode()       {}
@@ -445,7 +445,7 @@ type FunctionDeclaration struct {
 	Parameters  []*Parameter
 	ReturnTypes []string // can be multiple for multi-return
 	Body        *BlockStatement
-	Attributes  []*Attribute // @suppress(...) attributes
+	Attributes  []*Attribute // #suppress(...) attributes
 	Visibility  Visibility   // Public (default), Private, or PrivateModule
 }
 
@@ -529,8 +529,8 @@ type EnumValue struct {
 	Value Expression // optional explicit value
 }
 
-// EnumAttributes represents @enum(type) or @flags
+// EnumAttributes represents #enum(type) or #flags
 type EnumAttributes struct {
 	TypeName string // "int", "float", or "string"
-	IsFlags  bool   // true if @flags attribute present (power-of-2 values)
+	IsFlags  bool   // true if #flags attribute present (power-of-2 values)
 }

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -87,11 +87,11 @@ var (
 	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean. Use if/or/otherwise instead"}
 	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil. Use if/otherwise to check for nil"}
 	E2050 = ErrorCode{"E2050", "when-collection-condition", "when condition cannot be an array or map"}
-	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "@suppress can only be applied to function declarations"}
+	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "#suppress can only be applied to function declarations"}
 	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}
 	E2053 = ErrorCode{"E2053", "type-definition-in-function", "type definitions must be at file level"}
-	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "@strict when requires explicit enum member values in cases"}
-	E2055 = ErrorCode{"E2055", "strict-invalid-target", "@strict can only be applied to when statements"}
+	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "#strict when requires explicit enum member values in cases"}
+	E2055 = ErrorCode{"E2055", "strict-invalid-target", "#strict can only be applied to when statements"}
 	E2056 = ErrorCode{"E2056", "executable-at-file-scope", "executable statement not allowed at file scope"}
 )
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -149,6 +149,7 @@ var validModules = map[string]bool{
 	"bytes":   true, // Binary data operations
 	"random":  true, // Random number generation
 	"json":    true, // JSON encoding/decoding
+	"binary":  true, // Binary encoding/decoding for integers and floats
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -239,48 +239,44 @@ func (l *Lexer) NextToken() tokenizer.Token {
 	case '.':
 		tok = newToken(tokenizer.DOT, l.ch, l.line, l.column)
 	case '@':
-		// Peek ahead to check for @suppress
-		if l.peekAheadString(9) == "@suppress" {
-			// Found @suppress
-			tok = tokenizer.Token{Type: tokenizer.SUPPRESS, Literal: "@suppress", Line: l.line, Column: l.column}
-			// Consume the entire @suppress token
+		// @ is only used for stdlib imports like @std, @binary
+		tok = newToken(tokenizer.AT, l.ch, l.line, l.column)
+	case '#':
+		// # is used for attributes like #suppress, #strict, #flags, #enum
+		// Peek ahead to check for #suppress
+		if l.peekAheadString(9) == "#suppress" {
+			tok = tokenizer.Token{Type: tokenizer.SUPPRESS, Literal: "#suppress", Line: l.line, Column: l.column}
 			for i := 0; i < 9; i++ {
 				l.readChar()
 			}
 			return tok
 		}
-		// Peek ahead to check for @strict
-		if l.peekAheadString(7) == "@strict" {
-			// Found @strict
-			tok = tokenizer.Token{Type: tokenizer.STRICT, Literal: "@strict", Line: l.line, Column: l.column}
-			// Consume the entire @strict token
+		// Peek ahead to check for #strict
+		if l.peekAheadString(7) == "#strict" {
+			tok = tokenizer.Token{Type: tokenizer.STRICT, Literal: "#strict", Line: l.line, Column: l.column}
 			for i := 0; i < 7; i++ {
 				l.readChar()
 			}
 			return tok
 		}
-		// Peek ahead to check for @flags
-		if l.peekAheadString(6) == "@flags" {
-			// Found @flags
-			tok = tokenizer.Token{Type: tokenizer.FLAGS, Literal: "@flags", Line: l.line, Column: l.column}
-			// Consume the entire @flags token
+		// Peek ahead to check for #flags
+		if l.peekAheadString(6) == "#flags" {
+			tok = tokenizer.Token{Type: tokenizer.FLAGS, Literal: "#flags", Line: l.line, Column: l.column}
 			for i := 0; i < 6; i++ {
 				l.readChar()
 			}
 			return tok
 		}
-		// Peek ahead to check for @enum
-		if l.peekAheadString(5) == "@enum" {
-			// Found @enum
-			tok = tokenizer.Token{Type: tokenizer.ENUM_ATTR, Literal: "@enum", Line: l.line, Column: l.column}
-			// Consume the entire @enum token
+		// Peek ahead to check for #enum
+		if l.peekAheadString(5) == "#enum" {
+			tok = tokenizer.Token{Type: tokenizer.ENUM_ATTR, Literal: "#enum", Line: l.line, Column: l.column}
 			for i := 0; i < 5; i++ {
 				l.readChar()
 			}
 			return tok
 		}
-		// Just a regular @ symbol (e.g., for imports like @std)
-		tok = newToken(tokenizer.AT, l.ch, l.line, l.column)
+		// Unknown # usage - treat as illegal
+		tok = newToken(tokenizer.ILLEGAL, l.ch, l.line, l.column)
 	case '"':
 		tok.Line = l.line
 		tok.Column = l.column

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -374,14 +374,14 @@ func TestIdentifiers(t *testing.T) {
 	}
 }
 
-// TestSpecialTokens tests @suppress, !in, and blank identifier
+// TestSpecialTokens tests #suppress, !in, and blank identifier
 func TestSpecialTokens(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected tokenizer.TokenType
 		literal  string
 	}{
-		{"@suppress", tokenizer.SUPPRESS, "@suppress"},
+		{"#suppress", tokenizer.SUPPRESS, "#suppress"},
 		{"!in", tokenizer.NOT_IN, "!in"},
 		{"_", tokenizer.BLANK, "_"},
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -62,6 +62,7 @@ var allWarningCodes = map[string]bool{
 	"W2004": true, // implicit-type-conversion
 	"W2005": true, // deprecated-feature
 	"W2006": true, // byte-overflow-potential
+	"W2009": true, // nil-dereference-potential
 	// Code Quality Warnings (W3xxx)
 	"W3001": true, // empty-block
 	"W3002": true, // redundant-condition
@@ -81,6 +82,7 @@ var suppressibleWarnings = map[string]bool{
 	"W2004": true, // implicit-type-conversion
 	"W2005": true, // deprecated-feature
 	"W2006": true, // byte-overflow-potential
+	"W2009": true, // nil-dereference-potential
 	"W3001": true, // empty-block
 	"W3002": true, // redundant-condition
 	"W3003": true, // array-size-mismatch

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1371,7 +1371,7 @@ func TestPrivateModuleVisibility(t *testing.T) {
 // ============================================================================
 
 func TestSuppressAttribute(t *testing.T) {
-	input := `@suppress("W2001")
+	input := `#suppress("W2001")
 do test() {
 	return 1
 	x = 2
@@ -2614,7 +2614,7 @@ func TestWhenStatementStrict(t *testing.T) {
 	input := `const Status enum { ACTIVE, INACTIVE }
 	do main() {
 		temp s Status = Status.ACTIVE
-		@strict
+		#strict
 		when s {
 			is Status.ACTIVE { println("active") }
 			is Status.INACTIVE { println("inactive") }
@@ -2662,7 +2662,7 @@ func TestWhenStatementMissingDefault(t *testing.T) {
 func TestWhenStatementStrictWithDefault(t *testing.T) {
 	input := `do main() {
 		temp x int = 1
-		@strict
+		#strict
 		when x {
 			is 1 { println("one") }
 			default { println("other") }
@@ -2818,7 +2818,7 @@ do main() {
 // ============================================================================
 
 func TestEnumWithEnumTypeAttribute(t *testing.T) {
-	input := `@enum(string)
+	input := `#enum(string)
 	const Status enum { ACTIVE = "active", INACTIVE = "inactive" }`
 	program := parseProgram(t, input)
 
@@ -2828,30 +2828,30 @@ func TestEnumWithEnumTypeAttribute(t *testing.T) {
 	}
 
 	if enumDecl.Attributes == nil || enumDecl.Attributes.TypeName != "string" {
-		t.Error("expected @enum(string) attribute with TypeName='string'")
+		t.Error("expected #enum(string) attribute with TypeName='string'")
 	}
 }
 
 func TestEnumWithFlagsAttribute(t *testing.T) {
-	input := `@flags
+	input := `#flags
 	const Permissions enum { READ = 1, WRITE = 2, EXECUTE = 4 }`
 	program := parseProgram(t, input)
 
 	enumDecl := program.Statements[0].(*EnumDeclaration)
 
 	if enumDecl.Attributes == nil || !enumDecl.Attributes.IsFlags {
-		t.Error("expected @flags attribute with IsFlags=true")
+		t.Error("expected #flags attribute with IsFlags=true")
 	}
 }
 
 func TestEnumWithFloatAttribute(t *testing.T) {
-	input := `@enum(float)
+	input := `#enum(float)
 	const Values enum { PI = 3.14, E = 2.71 }`
 	program := parseProgram(t, input)
 
 	enumDecl := program.Statements[0].(*EnumDeclaration)
 
 	if enumDecl.Attributes == nil || enumDecl.Attributes.TypeName != "float" {
-		t.Error("expected @enum(float) attribute with TypeName='float'")
+		t.Error("expected #enum(float) attribute with TypeName='float'")
 	}
 }

--- a/pkg/stdlib/binary.go
+++ b/pkg/stdlib/binary.go
@@ -1,0 +1,1297 @@
+package stdlib
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// createBinaryError creates an Error struct for recoverable errors in tuple returns
+func createBinaryError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}
+
+// Helper to convert EZ byte array to Go []byte with length validation
+func binaryBytesToSlice(arg object.Object, expected int, funcName string) ([]byte, *object.Struct) {
+	arr, ok := arg.(*object.Array)
+	if !ok {
+		return nil, createBinaryError("E7002", fmt.Sprintf("%s requires a byte array argument", funcName))
+	}
+	if len(arr.Elements) != expected {
+		return nil, createBinaryError("E7010", fmt.Sprintf("%s requires exactly %d bytes, got %d", funcName, expected, len(arr.Elements)))
+	}
+
+	data := make([]byte, expected)
+	for i, elem := range arr.Elements {
+		switch e := elem.(type) {
+		case *object.Byte:
+			data[i] = e.Value
+		case *object.Integer:
+			val := e.Value.Int64()
+			if val < 0 || val > 255 {
+				return nil, createBinaryError("E3022", fmt.Sprintf("%s byte at index %d out of range (0-255)", funcName, i))
+			}
+			data[i] = byte(val)
+		default:
+			return nil, createBinaryError("E7002", fmt.Sprintf("%s requires a byte array", funcName))
+		}
+	}
+	return data, nil
+}
+
+// Helper to convert Go []byte to EZ byte array
+func sliceToBinaryArray(data []byte) *object.Array {
+	elements := make([]object.Object, len(data))
+	for i, b := range data {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper to extract integer value for encoding
+func extractEncodingInt(arg object.Object, funcName string) (*big.Int, *object.Error) {
+	switch v := arg.(type) {
+	case *object.Integer:
+		return v.Value, nil
+	case *object.Float:
+		return big.NewInt(int64(v.Value)), nil
+	case *object.Byte:
+		return big.NewInt(int64(v.Value)), nil
+	default:
+		return nil, &object.Error{
+			Code:    "E7004",
+			Message: fmt.Sprintf("%s requires an integer argument", funcName),
+		}
+	}
+}
+
+// Helper to reverse byte slice (for endianness conversion with big.Int)
+func reverseBytes(data []byte) []byte {
+	n := len(data)
+	result := make([]byte, n)
+	for i := 0; i < n; i++ {
+		result[i] = data[n-1-i]
+	}
+	return result
+}
+
+// Helper to pad big.Int bytes to exact size (big-endian, for signed integers)
+// Converts negative numbers to two's complement representation
+func padBigIntBytesSigned(val *big.Int, size int) []byte {
+	if val.Sign() >= 0 {
+		// Positive: just pad with zeros
+		bytes := val.Bytes()
+		if len(bytes) > size {
+			return bytes[len(bytes)-size:]
+		}
+		result := make([]byte, size)
+		copy(result[size-len(bytes):], bytes)
+		return result
+	}
+
+	// Negative: convert to two's complement
+	// Two's complement = 2^(size*8) + val
+	modulus := new(big.Int).Lsh(big.NewInt(1), uint(size*8))
+	twosComp := new(big.Int).Add(modulus, val)
+	bytes := twosComp.Bytes()
+
+	if len(bytes) > size {
+		return bytes[len(bytes)-size:]
+	}
+	result := make([]byte, size)
+	copy(result[size-len(bytes):], bytes)
+	return result
+}
+
+// Helper to pad big.Int bytes to exact size (big-endian, for unsigned integers)
+func padBigIntBytesUnsigned(val *big.Int, size int) []byte {
+	bytes := val.Bytes()
+	if len(bytes) > size {
+		return bytes[len(bytes)-size:]
+	}
+	result := make([]byte, size)
+	copy(result[size-len(bytes):], bytes)
+	return result
+}
+
+// BinaryBuiltins contains the binary module functions for encoding/decoding
+var BinaryBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// 8-bit Encoding/Decoding (no endianness needed)
+	// ============================================================================
+
+	// Encodes an i8 to a single byte
+	"binary.encode_i8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i8() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i8()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -128 || intVal > 127 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i8 range (-128 to 127)", intVal)),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray([]byte{byte(int8(intVal))}),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Decodes a single byte to an i8
+	"binary.decode_i8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i8() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 1, "binary.decode_i8()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int8(data[0])
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i8"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// Encodes a u8 to a single byte
+	"binary.encode_u8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u8() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u8()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < 0 || intVal > 255 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of u8 range (0 to 255)", intVal)),
+				}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray([]byte{byte(intVal)}),
+				object.NIL,
+			}}
+		},
+	},
+
+	// Decodes a single byte to a u8
+	"binary.decode_u8": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u8() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 1, "binary.decode_u8()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(data[0])), DeclaredType: "u8"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 16-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i16_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i16_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i16_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -32768 || intVal > 32767 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.LittleEndian.PutUint16(buf, uint16(int16(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i16_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i16_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_i16_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int16(binary.LittleEndian.Uint16(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u16_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u16_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u16_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < 0 || intVal > 65535 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of u16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.LittleEndian.PutUint16(buf, uint16(intVal))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u16_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u16_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_u16_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.LittleEndian.Uint16(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 16-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i16_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i16_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i16_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -32768 || intVal > 32767 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.BigEndian.PutUint16(buf, uint16(int16(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i16_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i16_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_i16_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int16(binary.BigEndian.Uint16(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u16_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u16_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u16_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < 0 || intVal > 65535 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of u16 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 2)
+			binary.BigEndian.PutUint16(buf, uint16(intVal))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u16_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u16_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 2, "binary.decode_u16_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.BigEndian.Uint16(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u16"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 32-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i32_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i32_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i32_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -2147483648 || intVal > 2147483647 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i32 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(buf, uint32(int32(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i32_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i32_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_i32_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int32(binary.LittleEndian.Uint32(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u32_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u32_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u32_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			if val.Sign() < 0 || val.Cmp(big.NewInt(4294967295)) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u32 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(buf, uint32(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u32_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u32_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_u32_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.LittleEndian.Uint32(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 32-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i32_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i32_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i32_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			intVal := val.Int64()
+			if intVal < -2147483648 || intVal > 2147483647 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %d out of i32 range", intVal)),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.BigEndian.PutUint32(buf, uint32(int32(intVal)))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i32_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i32_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_i32_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int32(binary.BigEndian.Uint32(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "i32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u32_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u32_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u32_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			if val.Sign() < 0 || val.Cmp(big.NewInt(4294967295)) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u32 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 4)
+			binary.BigEndian.PutUint32(buf, uint32(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u32_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u32_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_u32_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.BigEndian.Uint32(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(int64(val)), DeclaredType: "u32"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 64-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i64_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i64_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i64_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			minI64 := new(big.Int).SetInt64(-9223372036854775808)
+			maxI64 := new(big.Int).SetInt64(9223372036854775807)
+			if val.Cmp(minI64) < 0 || val.Cmp(maxI64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of i64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, uint64(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i64_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i64_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_i64_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int64(binary.LittleEndian.Uint64(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(val), DeclaredType: "i64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u64_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u64_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u64_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			maxU64 := new(big.Int).SetUint64(18446744073709551615)
+			if val.Sign() < 0 || val.Cmp(maxU64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, val.Uint64())
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u64_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u64_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_u64_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.LittleEndian.Uint64(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: new(big.Int).SetUint64(val), DeclaredType: "u64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 64-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i64_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i64_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i64_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			minI64 := new(big.Int).SetInt64(-9223372036854775808)
+			maxI64 := new(big.Int).SetInt64(9223372036854775807)
+			if val.Cmp(minI64) < 0 || val.Cmp(maxI64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of i64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, uint64(val.Int64()))
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i64_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i64_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_i64_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := int64(binary.BigEndian.Uint64(data))
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: big.NewInt(val), DeclaredType: "i64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u64_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u64_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u64_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			maxU64 := new(big.Int).SetUint64(18446744073709551615)
+			if val.Sign() < 0 || val.Cmp(maxU64) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", fmt.Sprintf("value %s out of u64 range", val.String())),
+				}}
+			}
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, val.Uint64())
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u64_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u64_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_u64_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := binary.BigEndian.Uint64(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: new(big.Int).SetUint64(val), DeclaredType: "u64"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 128-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i128_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i128_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i128_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			minI128 := new(big.Int).Lsh(big.NewInt(-1), 127)
+			maxI128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+			if val.Cmp(minI128) < 0 || val.Cmp(maxI128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i128 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i128_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i128_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_i128_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			// Reverse for big-endian interpretation
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			// Check if negative (high bit set)
+			if beData[0]&0x80 != 0 {
+				// Two's complement: subtract 2^128
+				twoTo128 := new(big.Int).Lsh(big.NewInt(1), 128)
+				val.Sub(val, twoTo128)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u128_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u128_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u128_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			maxU128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u128 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u128_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u128_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_u128_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 128-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i128_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i128_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i128_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			minI128 := new(big.Int).Lsh(big.NewInt(-1), 127)
+			maxI128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+			if val.Cmp(minI128) < 0 || val.Cmp(maxI128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i128 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i128_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i128_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_i128_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			// Check if negative (high bit set)
+			if data[0]&0x80 != 0 {
+				twoTo128 := new(big.Int).Lsh(big.NewInt(1), 128)
+				val.Sub(val, twoTo128)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u128_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u128_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u128_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			maxU128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU128) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u128 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 16)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u128_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u128_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 16, "binary.decode_u128_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u128"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 256-bit Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_i256_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i256_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i256_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			minI256 := new(big.Int).Lsh(big.NewInt(-1), 255)
+			maxI256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+			if val.Cmp(minI256) < 0 || val.Cmp(maxI256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i256 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i256_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i256_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_i256_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			if beData[0]&0x80 != 0 {
+				twoTo256 := new(big.Int).Lsh(big.NewInt(1), 256)
+				val.Sub(val, twoTo256)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u256_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u256_to_little_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u256_to_little_endian()")
+			if err != nil {
+				return err
+			}
+			maxU256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u256 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(reverseBytes(buf)),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u256_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u256_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_u256_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			beData := reverseBytes(data)
+			val := new(big.Int).SetBytes(beData)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// 256-bit Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_i256_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_i256_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_i256_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			minI256 := new(big.Int).Lsh(big.NewInt(-1), 255)
+			maxI256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+			if val.Cmp(minI256) < 0 || val.Cmp(maxI256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of i256 range"),
+				}}
+			}
+			buf := padBigIntBytesSigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_i256_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_i256_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_i256_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			if data[0]&0x80 != 0 {
+				twoTo256 := new(big.Int).Lsh(big.NewInt(1), 256)
+				val.Sub(val, twoTo256)
+			}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "i256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_u256_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_u256_to_big_endian() takes exactly 1 argument"}
+			}
+			val, err := extractEncodingInt(args[0], "binary.encode_u256_to_big_endian()")
+			if err != nil {
+				return err
+			}
+			maxU256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+			if val.Sign() < 0 || val.Cmp(maxU256) > 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					object.NIL,
+					createBinaryError("E3022", "value out of u256 range"),
+				}}
+			}
+			buf := padBigIntBytesUnsigned(val, 32)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_u256_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_u256_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 32, "binary.decode_u256_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			val := new(big.Int).SetBytes(data)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Integer{Value: val, DeclaredType: "u256"},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Float Encoding (Little Endian)
+	// ============================================================================
+
+	"binary.encode_f32_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f32_to_little_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f32_to_little_endian() requires a float or integer argument"}
+			}
+			bits := math.Float32bits(float32(floatVal))
+			buf := make([]byte, 4)
+			binary.LittleEndian.PutUint32(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f32_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f32_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_f32_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.LittleEndian.Uint32(data)
+			val := math.Float32frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: float64(val)},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_f64_to_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f64_to_little_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f64_to_little_endian() requires a float or integer argument"}
+			}
+			bits := math.Float64bits(floatVal)
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f64_from_little_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f64_from_little_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_f64_from_little_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.LittleEndian.Uint64(data)
+			val := math.Float64frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: val},
+				object.NIL,
+			}}
+		},
+	},
+
+	// ============================================================================
+	// Float Encoding (Big Endian)
+	// ============================================================================
+
+	"binary.encode_f32_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f32_to_big_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f32_to_big_endian() requires a float or integer argument"}
+			}
+			bits := math.Float32bits(float32(floatVal))
+			buf := make([]byte, 4)
+			binary.BigEndian.PutUint32(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f32_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f32_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 4, "binary.decode_f32_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.BigEndian.Uint32(data)
+			val := math.Float32frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: float64(val)},
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.encode_f64_to_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.encode_f64_to_big_endian() takes exactly 1 argument"}
+			}
+			var floatVal float64
+			switch v := args[0].(type) {
+			case *object.Float:
+				floatVal = v.Value
+			case *object.Integer:
+				f, _ := new(big.Float).SetInt(v.Value).Float64()
+				floatVal = f
+			default:
+				return &object.Error{Code: "E7004", Message: "binary.encode_f64_to_big_endian() requires a float or integer argument"}
+			}
+			bits := math.Float64bits(floatVal)
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, bits)
+			return &object.ReturnValue{Values: []object.Object{
+				sliceToBinaryArray(buf),
+				object.NIL,
+			}}
+		},
+	},
+
+	"binary.decode_f64_from_big_endian": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "binary.decode_f64_from_big_endian() takes exactly 1 argument"}
+			}
+			data, errStruct := binaryBytesToSlice(args[0], 8, "binary.decode_f64_from_big_endian()")
+			if errStruct != nil {
+				return &object.ReturnValue{Values: []object.Object{object.NIL, errStruct}}
+			}
+			bits := binary.BigEndian.Uint64(data)
+			val := math.Float64frombits(bits)
+			return &object.ReturnValue{Values: []object.Object{
+				&object.Float{Value: val},
+				object.NIL,
+			}}
+		},
+	},
+}

--- a/pkg/stdlib/binary_test.go
+++ b/pkg/stdlib/binary_test.go
@@ -1,0 +1,352 @@
+package stdlib
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// Helper to create byte array from slice
+func makeBinaryByteArray(bytes []byte) *object.Array {
+	elements := make([]object.Object, len(bytes))
+	for i, b := range bytes {
+		elements[i] = &object.Byte{Value: b}
+	}
+	return &object.Array{Elements: elements, ElementType: "byte"}
+}
+
+// Helper to extract bytes from return value
+func extractBytesFromReturn(t *testing.T, result object.Object) []byte {
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if len(rv.Values) != 2 {
+		t.Fatalf("expected 2 values in tuple, got %d", len(rv.Values))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Fatalf("expected nil error, got %v", rv.Values[1])
+	}
+	arr, ok := rv.Values[0].(*object.Array)
+	if !ok {
+		t.Fatalf("expected Array, got %T", rv.Values[0])
+	}
+	bytes := make([]byte, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		b, ok := elem.(*object.Byte)
+		if !ok {
+			t.Fatalf("expected Byte at index %d, got %T", i, elem)
+		}
+		bytes[i] = b.Value
+	}
+	return bytes
+}
+
+// Helper to extract integer from return value
+func extractIntFromReturn(t *testing.T, result object.Object) *big.Int {
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if len(rv.Values) != 2 {
+		t.Fatalf("expected 2 values in tuple, got %d", len(rv.Values))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Fatalf("expected nil error, got %v", rv.Values[1])
+	}
+	intVal, ok := rv.Values[0].(*object.Integer)
+	if !ok {
+		t.Fatalf("expected Integer, got %T", rv.Values[0])
+	}
+	return intVal.Value
+}
+
+// Helper to extract float from return value
+func extractFloatFromReturn(t *testing.T, result object.Object) float64 {
+	rv, ok := result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("expected ReturnValue, got %T", result)
+	}
+	if len(rv.Values) != 2 {
+		t.Fatalf("expected 2 values in tuple, got %d", len(rv.Values))
+	}
+	if rv.Values[1] != object.NIL {
+		t.Fatalf("expected nil error, got %v", rv.Values[1])
+	}
+	floatVal, ok := rv.Values[0].(*object.Float)
+	if !ok {
+		t.Fatalf("expected Float, got %T", rv.Values[0])
+	}
+	return floatVal.Value
+}
+
+func TestBinaryEncodeDecodeI8(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected byte
+	}{
+		{0, 0x00},
+		{127, 0x7F},
+		{-128, 0x80},
+		{-1, 0xFF},
+	}
+
+	for _, tt := range tests {
+		// Encode
+		encodeResult := BinaryBuiltins["binary.encode_i8"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 1 || bytes[0] != tt.expected {
+			t.Errorf("encode_i8(%d): expected [0x%02X], got %v", tt.input, tt.expected, bytes)
+		}
+
+		// Decode
+		decodeResult := BinaryBuiltins["binary.decode_i8"].Fn(makeBinaryByteArray([]byte{tt.expected}))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_i8([0x%02X]): expected %d, got %d", tt.expected, tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeU8(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected byte
+	}{
+		{0, 0x00},
+		{127, 0x7F},
+		{255, 0xFF},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_u8"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 1 || bytes[0] != tt.expected {
+			t.Errorf("encode_u8(%d): expected [0x%02X], got %v", tt.input, tt.expected, bytes)
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_u8"].Fn(makeBinaryByteArray([]byte{tt.expected}))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_u8([0x%02X]): expected %d, got %d", tt.expected, tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeI32LE(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected []byte
+	}{
+		{0, []byte{0x00, 0x00, 0x00, 0x00}},
+		{1, []byte{0x01, 0x00, 0x00, 0x00}},
+		{256, []byte{0x00, 0x01, 0x00, 0x00}},
+		{12345, []byte{0x39, 0x30, 0x00, 0x00}},
+		{-1, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+		{2147483647, []byte{0xFF, 0xFF, 0xFF, 0x7F}},
+		{-2147483648, []byte{0x00, 0x00, 0x00, 0x80}},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_i32_to_little_endian"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 4 {
+			t.Errorf("encode_i32_to_little_endian(%d): expected 4 bytes, got %d", tt.input, len(bytes))
+			continue
+		}
+		for i, b := range tt.expected {
+			if bytes[i] != b {
+				t.Errorf("encode_i32_to_little_endian(%d): byte %d expected 0x%02X, got 0x%02X", tt.input, i, b, bytes[i])
+			}
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_i32_from_little_endian"].Fn(makeBinaryByteArray(tt.expected))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_i32_from_little_endian: expected %d, got %d", tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeI32BE(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected []byte
+	}{
+		{0, []byte{0x00, 0x00, 0x00, 0x00}},
+		{1, []byte{0x00, 0x00, 0x00, 0x01}},
+		{256, []byte{0x00, 0x00, 0x01, 0x00}},
+		{12345, []byte{0x00, 0x00, 0x30, 0x39}},
+		{-1, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_i32_to_big_endian"].Fn(&object.Integer{Value: big.NewInt(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		for i, b := range tt.expected {
+			if bytes[i] != b {
+				t.Errorf("encode_i32_to_big_endian(%d): byte %d expected 0x%02X, got 0x%02X", tt.input, i, b, bytes[i])
+			}
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_i32_from_big_endian"].Fn(makeBinaryByteArray(tt.expected))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Int64() != tt.input {
+			t.Errorf("decode_i32_from_big_endian: expected %d, got %d", tt.input, val.Int64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeU64LE(t *testing.T) {
+	tests := []struct {
+		input    uint64
+		expected []byte
+	}{
+		{0, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{1, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{18446744073709551615, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_u64_to_little_endian"].Fn(&object.Integer{Value: new(big.Int).SetUint64(tt.input)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		for i, b := range tt.expected {
+			if bytes[i] != b {
+				t.Errorf("encode_u64_to_little_endian(%d): byte %d expected 0x%02X, got 0x%02X", tt.input, i, b, bytes[i])
+			}
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_u64_from_little_endian"].Fn(makeBinaryByteArray(tt.expected))
+		val := extractIntFromReturn(t, decodeResult)
+		if val.Uint64() != tt.input {
+			t.Errorf("decode_u64_from_little_endian: expected %d, got %d", tt.input, val.Uint64())
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeF32LE(t *testing.T) {
+	tests := []float32{
+		0.0,
+		1.0,
+		-1.0,
+		3.14159,
+		float32(math.MaxFloat32),
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_f32_to_little_endian"].Fn(&object.Float{Value: float64(tt)})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 4 {
+			t.Errorf("encode_f32_to_little_endian(%f): expected 4 bytes, got %d", tt, len(bytes))
+			continue
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_f32_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+		val := extractFloatFromReturn(t, decodeResult)
+		if float32(val) != tt {
+			t.Errorf("f32 round-trip: expected %f, got %f", tt, val)
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeF64LE(t *testing.T) {
+	tests := []float64{
+		0.0,
+		1.0,
+		-1.0,
+		3.141592653589793,
+		math.MaxFloat64,
+	}
+
+	for _, tt := range tests {
+		encodeResult := BinaryBuiltins["binary.encode_f64_to_little_endian"].Fn(&object.Float{Value: tt})
+		bytes := extractBytesFromReturn(t, encodeResult)
+		if len(bytes) != 8 {
+			t.Errorf("encode_f64_to_little_endian(%f): expected 8 bytes, got %d", tt, len(bytes))
+			continue
+		}
+
+		decodeResult := BinaryBuiltins["binary.decode_f64_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+		val := extractFloatFromReturn(t, decodeResult)
+		if val != tt {
+			t.Errorf("f64 round-trip: expected %f, got %f", tt, val)
+		}
+	}
+}
+
+func TestBinaryEncodeDecodeI128LE(t *testing.T) {
+	// Test zero
+	encodeResult := BinaryBuiltins["binary.encode_i128_to_little_endian"].Fn(&object.Integer{Value: big.NewInt(0)})
+	bytes := extractBytesFromReturn(t, encodeResult)
+	if len(bytes) != 16 {
+		t.Errorf("encode_i128_to_little_endian(0): expected 16 bytes, got %d", len(bytes))
+	}
+
+	decodeResult := BinaryBuiltins["binary.decode_i128_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+	val := extractIntFromReturn(t, decodeResult)
+	if val.Cmp(big.NewInt(0)) != 0 {
+		t.Errorf("decode_i128_from_little_endian(0): expected 0, got %s", val.String())
+	}
+
+	// Test positive value
+	testVal := big.NewInt(12345678901234567)
+	encodeResult = BinaryBuiltins["binary.encode_i128_to_little_endian"].Fn(&object.Integer{Value: testVal})
+	bytes = extractBytesFromReturn(t, encodeResult)
+	decodeResult = BinaryBuiltins["binary.decode_i128_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+	val = extractIntFromReturn(t, decodeResult)
+	if val.Cmp(testVal) != 0 {
+		t.Errorf("i128 round-trip: expected %s, got %s", testVal.String(), val.String())
+	}
+
+	// Test negative value
+	negVal := big.NewInt(-12345678901234567)
+	encodeResult = BinaryBuiltins["binary.encode_i128_to_little_endian"].Fn(&object.Integer{Value: negVal})
+	bytes = extractBytesFromReturn(t, encodeResult)
+	decodeResult = BinaryBuiltins["binary.decode_i128_from_little_endian"].Fn(makeBinaryByteArray(bytes))
+	val = extractIntFromReturn(t, decodeResult)
+	if val.Cmp(negVal) != 0 {
+		t.Errorf("i128 round-trip (negative): expected %s, got %s", negVal.String(), val.String())
+	}
+}
+
+func TestBinaryRangeErrors(t *testing.T) {
+	// i8 out of range
+	result := BinaryBuiltins["binary.encode_i8"].Fn(&object.Integer{Value: big.NewInt(128)})
+	rv, ok := result.(*object.ReturnValue)
+	if !ok || rv.Values[1] == object.NIL {
+		t.Error("encode_i8(128) should return error")
+	}
+
+	// u8 negative
+	result = BinaryBuiltins["binary.encode_u8"].Fn(&object.Integer{Value: big.NewInt(-1)})
+	rv, ok = result.(*object.ReturnValue)
+	if !ok || rv.Values[1] == object.NIL {
+		t.Error("encode_u8(-1) should return error")
+	}
+
+	// Wrong byte array length
+	result = BinaryBuiltins["binary.decode_i32_from_little_endian"].Fn(makeBinaryByteArray([]byte{0x00, 0x00}))
+	rv, ok = result.(*object.ReturnValue)
+	if !ok || rv.Values[1] == object.NIL {
+		t.Error("decode_i32_from_little_endian with 2 bytes should return error")
+	}
+}
+
+func TestBinaryWrongArgCount(t *testing.T) {
+	// No args
+	result := BinaryBuiltins["binary.encode_i32_to_little_endian"].Fn()
+	if _, ok := result.(*object.Error); !ok {
+		t.Error("encode_i32_to_little_endian() with no args should return error")
+	}
+
+	// Too many args
+	result = BinaryBuiltins["binary.encode_i32_to_little_endian"].Fn(
+		&object.Integer{Value: big.NewInt(1)},
+		&object.Integer{Value: big.NewInt(2)},
+	)
+	if _, ok := result.(*object.Error); !ok {
+		t.Error("encode_i32_to_little_endian() with 2 args should return error")
+	}
+}

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -49,6 +49,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range JsonBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range BinaryBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -121,6 +121,9 @@ const (
 	IS      TokenType = "IS"
 	DEFAULT TokenType = "DEFAULT"
 
+	// Type conversion
+	CAST TokenType = "CAST"
+
 	// Ampersand (for import & use syntax)
 	AMPERSAND TokenType = "&"
 )
@@ -157,6 +160,7 @@ var keywords = map[string]TokenType{
 	"when":       WHEN,
 	"is":         IS,
 	"default":    DEFAULT,
+	"cast":       CAST,
 }
 
 // Looks up the passed in identifier(i)
@@ -176,7 +180,7 @@ func IsKeyword(t TokenType) bool {
 		FOR, FOR_EACH, AS_LONG_AS, LOOP, BREAK, CONTINUE,
 		IN, NOT_IN, RANGE, IMPORT, USING, STRUCT, ENUM,
 		NIL, NEW, TRUE, FALSE, BLANK, MODULE, PRIVATE, USE,
-		WHEN, IS, DEFAULT:
+		WHEN, IS, DEFAULT, CAST:
 		return true
 	}
 	return false

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2380,7 +2380,7 @@ func (tc *TypeChecker) checkCastExpression(castExpr *ast.CastExpression) {
 
 	// Infer the source type and check if the conversion is valid
 	sourceType, ok := tc.inferExpressionType(castExpr.Value)
-	if !ok {
+	if !ok || sourceType == "" {
 		return // Can't validate without knowing source type
 	}
 
@@ -4500,6 +4500,40 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 		case "read_u64", "read_u64_be", "read_i64", "read_i64_be":
 			return []string{"int", "error"}
 		case "read_f32", "read_f32_be", "read_f64", "read_f64_be":
+			return []string{"float", "error"}
+		}
+	case "binary":
+		// All binary encode functions return ([byte], error)
+		// All binary decode functions return (typed_int_or_float, error)
+		switch funcName {
+		case "encode_i8", "encode_u8",
+			"encode_i16_to_little_endian", "encode_u16_to_little_endian",
+			"encode_i16_to_big_endian", "encode_u16_to_big_endian",
+			"encode_i32_to_little_endian", "encode_u32_to_little_endian",
+			"encode_i32_to_big_endian", "encode_u32_to_big_endian",
+			"encode_i64_to_little_endian", "encode_u64_to_little_endian",
+			"encode_i64_to_big_endian", "encode_u64_to_big_endian",
+			"encode_i128_to_little_endian", "encode_u128_to_little_endian",
+			"encode_i128_to_big_endian", "encode_u128_to_big_endian",
+			"encode_i256_to_little_endian", "encode_u256_to_little_endian",
+			"encode_i256_to_big_endian", "encode_u256_to_big_endian",
+			"encode_f32_to_little_endian", "encode_f32_to_big_endian",
+			"encode_f64_to_little_endian", "encode_f64_to_big_endian":
+			return []string{"[byte]", "error"}
+		case "decode_i8", "decode_u8",
+			"decode_i16_from_little_endian", "decode_u16_from_little_endian",
+			"decode_i16_from_big_endian", "decode_u16_from_big_endian",
+			"decode_i32_from_little_endian", "decode_u32_from_little_endian",
+			"decode_i32_from_big_endian", "decode_u32_from_big_endian",
+			"decode_i64_from_little_endian", "decode_u64_from_little_endian",
+			"decode_i64_from_big_endian", "decode_u64_from_big_endian",
+			"decode_i128_from_little_endian", "decode_u128_from_little_endian",
+			"decode_i128_from_big_endian", "decode_u128_from_big_endian",
+			"decode_i256_from_little_endian", "decode_u256_from_little_endian",
+			"decode_i256_from_big_endian", "decode_u256_from_big_endian":
+			return []string{"int", "error"}
+		case "decode_f32_from_little_endian", "decode_f32_from_big_endian",
+			"decode_f64_from_little_endian", "decode_f64_from_big_endian":
 			return []string{"float", "error"}
 		}
 	}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -318,9 +318,16 @@ func (tc *TypeChecker) TypeExists(typeName string) bool {
 		parts := strings.SplitN(typeName, ".", 2)
 		if len(parts) == 2 {
 			moduleName := parts[0]
+			typeNamePart := parts[1]
 			// Check if the module has been imported
 			if tc.modules[moduleName] {
 				return true
+			}
+			// Also check registered module types (#722 - self-referencing types)
+			if modTypes, ok := tc.moduleTypes[moduleName]; ok {
+				if _, exists := modTypes[typeNamePart]; exists {
+					return true
+				}
 			}
 		}
 	}
@@ -363,6 +370,11 @@ func (tc *TypeChecker) RegisterType(name string, t *Type) {
 // RegisterFunction adds a function signature to the registry
 func (tc *TypeChecker) RegisterFunction(name string, sig *FunctionSignature) {
 	tc.functions[name] = sig
+}
+
+// RegisterVariable adds a variable/constant to the global scope (#722)
+func (tc *TypeChecker) RegisterVariable(name, typeName string) {
+	tc.variables[name] = typeName
 }
 
 // GetType retrieves a type by name

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2200,7 +2200,7 @@ func TestAnyTypeNotAllowedInMap(t *testing.T) {
 }
 
 // ============================================================================
-// @strict When Statement Tests (#628)
+// #strict When Statement Tests (#628)
 // ============================================================================
 
 func TestStrictWhenRejectsRangeExpression(t *testing.T) {
@@ -2208,7 +2208,7 @@ func TestStrictWhenRejectsRangeExpression(t *testing.T) {
 const Color enum { RED, GREEN, BLUE }
 do main() {
 	temp c Color = Color.RED
-	@strict
+	#strict
 	when c {
 		is range(0, 2) {
 		}
@@ -2223,7 +2223,7 @@ func TestStrictWhenRejectsIntegerLiteral(t *testing.T) {
 const Color enum { RED, GREEN, BLUE }
 do main() {
 	temp c Color = Color.RED
-	@strict
+	#strict
 	when c {
 		is 0 {
 		}
@@ -2238,7 +2238,7 @@ func TestStrictWhenAcceptsEnumMembers(t *testing.T) {
 const Color enum { RED, GREEN, BLUE }
 do main() {
 	temp c Color = Color.RED
-	@strict
+	#strict
 	when c {
 		is Color.RED {
 		}
@@ -2257,7 +2257,7 @@ func TestStrictWhenMissingEnumCases(t *testing.T) {
 const Color enum { RED, GREEN, BLUE }
 do main() {
 	temp c Color = Color.RED
-	@strict
+	#strict
 	when c {
 		is Color.RED {
 		}
@@ -2272,7 +2272,7 @@ func TestStrictWhenPartialEnumCases(t *testing.T) {
 const Color enum { RED, GREEN, BLUE }
 do main() {
 	temp c Color = Color.RED
-	@strict
+	#strict
 	when c {
 		is Color.RED {
 		}


### PR DESCRIPTION
## Summary

- Add `@binary` module for binary encoding/decoding operations (little/big endian support for all integer and float types)
- Add `cast()` keyword for type conversion (single values and arrays)
- Change attribute prefix from `@` to `#` to avoid confusion with stdlib imports (`@std`, `@binary`)
- Add file-level `#suppress` for suppressing warnings across entire files
- Add `#suppress(ALL)` option to suppress all warnings
- Fix `#suppress("W2009")` for nil-dereference-potential warning
- Add `@binary` module return types to typechecker for proper type inference

## Changes

### New Features
- `@binary` module with encode/decode functions for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, f32, f64
- `cast(value, type)` for single value conversion
- `cast(array, [type])` for element-wise array conversion
- File-level `#suppress("W2009")` or `#suppress(ALL)` after imports

### Breaking Changes
- Attributes now use `#` prefix instead of `@`:
  - `@suppress` → `#suppress`
  - `@strict` → `#strict`
  - `@flags` → `#flags`
  - `@enum` → `#enum`

### Bug Fixes
- W2009 (nil-dereference-potential) can now be suppressed
- Binary module functions properly type-checked for multi-return values

## Test Plan
- [x] All existing integration tests pass
- [x] All unit tests pass
- [x] New binary module tests added
- [x] Cast keyword tests added