### PR TITLE
fix: module symbol sharing and using statement resolution

### DIFF
--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -377,6 +377,11 @@ func checkFile(filename string) {
 			fileTc := typechecker.NewTypeChecker(pf.source, pf.path)
 			fileTc.SetSkipMainCheck(true)
 
+			// Set current module name for same-module symbol lookup
+			if pf.program.Module != nil && pf.program.Module.Name != nil {
+				fileTc.SetCurrentModule(pf.program.Module.Name.Value)
+			}
+
 			// Register all collected module types for cross-module checking (#709)
 			for modName, types := range moduleTypes {
 				for typeName, t := range types {
@@ -386,6 +391,11 @@ func checkFile(filename string) {
 			for modName, funcs := range moduleSignatures {
 				for funcName, sig := range funcs {
 					fileTc.RegisterModuleFunction(modName, funcName, sig)
+				}
+			}
+			for modName, vars := range moduleVariables {
+				for varName, varType := range vars {
+					fileTc.RegisterModuleVariable(modName, varName, varType)
 				}
 			}
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3113,6 +3113,14 @@ func evalStructValue(node *ast.StructValue, env *Environment) Object {
 		if isError(val) {
 			return val
 		}
+		// If the value is an empty array but the field type is a map, create an empty map instead
+		if arr, ok := val.(*Array); ok && len(arr.Elements) == 0 {
+			if fieldType, hasField := structDef.Fields[fieldName]; hasField {
+				if strings.HasPrefix(fieldType, "map[") {
+					val = &Map{Pairs: []*MapPair{}, Index: make(map[string]int), Mutable: true}
+				}
+			}
+		}
 		fields[fieldName] = val
 	}
 


### PR DESCRIPTION
## Summary
- Fix same-module symbol sharing: files in the same module can now access each other's functions, types, and variables without imports
- Fix `using` module symbol lookup for user-defined modules
- Fix interpreter bug where empty `{}` in struct fields with map types created empty array instead of map

## Test plan
- [x] All 285 integration tests pass
- [x] Tested audit program on examples/ directory