### PR TITLE
Removed unused `GetAllBindings` method

### DIFF
--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -736,12 +736,6 @@ func (e *Environment) GetStructDef(name string) (*StructDef, bool) {
 	return nil, false
 }
 
-// GetAllBindings returns all bindings in this environment (not including outer scopes)
-// Used for debugging
-func (e *Environment) GetAllBindings() map[string]Object {
-	return e.store
-}
-
 // GetPublicBindings returns only public bindings (for module exports)
 func (e *Environment) GetPublicBindings() map[string]Object {
 	result := make(map[string]Object)


### PR DESCRIPTION
# Summary
- Removed unused `GetAllBindings` method from pkg/object package

# Test Plan
- [x]  All unit tests pass
- [x] All 285 integration tests pass 

CLOSES #734 