### PR TITLE
feat: Struct field tags JSON customization

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -508,6 +508,7 @@ func (sd *StructDeclaration) TokenLiteral() string { return sd.Token.Literal }
 type StructField struct {
 	Name       *Label
 	TypeName   string
+	Tag 			 string
 	Visibility Visibility // Public (default), Private, or PrivateModule
 }
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3432,6 +3432,7 @@ func copyByDefault(val Object) Object {
 		return &Struct{
 			TypeName: v.TypeName,
 			Fields:   newFields,
+			FieldTags: v.FieldTags,
 			Mutable:  v.Mutable,
 		}
 	case *Array:

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -417,18 +417,21 @@ func Eval(node ast.Node, env *Environment) Object {
 				optionString, _ := strings.CutPrefix(field.Tag, "json:\"")
 				optionString, _ = strings.CutSuffix(optionString, "\"")
 				options := strings.Split(optionString, ",")
-				for _, opt := range options {
-					switch opt {
-						case "-":
-							jsonTag.Ignore = true
-						case "omitempty":
-							jsonTag.OmitEmpty = true
-						case "string":
-							jsonTag.EncodeAsString = true
-						default:
-							jsonTag.Name = opt
+				switch options[0] {
+					case "-":
+						jsonTag.Ignore = true
+				default:
+					jsonTag.Name = options[0]
+					for _, opt := range options[1:] {
+							switch opt {
+								case "omitempty":
+									jsonTag.OmitEmpty = true
+								case "string":
+									jsonTag.EncodeAsString = true
+							}
 					}
 				}
+				tags[field.Name.Value] = jsonTag
 			} else if (field.Tag == "") {
 				tags[field.Name.Value] = &EmptyTag{}
 			}

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -30,6 +30,9 @@ type (
 	Map             = object.Map
 	MapPair         = object.MapPair
 	Struct          = object.Struct
+	StructFieldTags = object.StructFieldTags
+	EmptyTag 				= object.EmptyTag
+	JSONTag 				= object.JSONTag
 	Break           = object.Break
 	Continue        = object.Continue
 	StructDef       = object.StructDef

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -405,11 +405,44 @@ func NewMap() *Map {
 	}
 }
 
+type StructFieldTags interface {
+	Inspect() string
+}
+
+type EmptyTag struct {}
+
+func (et *EmptyTag) Inspect() string {
+	return "Tag: ``\n"
+}
+
+type JSONTag struct {
+	Name 					 string
+	Ignore 				 bool
+	OmitEmpty 		 bool
+	EncodeAsString bool
+}
+
+func (jt *JSONTag) Inspect() string {
+	if jt.Ignore {
+		return "Tag: `json:\"-\"`"
+	}
+	tag := fmt.Sprintf("Tag: `json:\"%s", jt.Name)
+	if jt.OmitEmpty {
+		tag += ",omitempty"
+	}
+	if jt.EncodeAsString {
+		tag += ",string"
+	}
+	tag += "\"`"
+	return tag
+}
+
 // Struct represents a struct instance
 type Struct struct {
-	TypeName string
-	Fields   map[string]Object
-	Mutable  bool
+	TypeName  string
+	Fields    map[string]Object
+	FieldTags map[string]StructFieldTags
+	Mutable   bool
 }
 
 func (s *Struct) Type() ObjectType { return STRUCT_OBJ }
@@ -437,6 +470,7 @@ func (c *Continue) Inspect() string  { return "continue" }
 type StructDef struct {
 	Name   string
 	Fields map[string]string
+	FieldTags   map[string]StructFieldTags
 }
 
 // TypeValue represents a type as a first-class value (for passing types to functions)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2353,8 +2353,17 @@ func (p *Parser) parseStructDeclaration() *StructDeclaration {
 			return nil
 		}
 
+		var tags []string
+		// Check for struct field tags
+		if (p.peekTokenMatches(RAW_STRING)) {
+			p.nextToken()
+			tags = append(tags, p.currentToken.Literal)
+		} else {
+			tags = append(tags, "")
+		}
+
 		// Create a field for each name with the same type
-		for _, name := range names {
+		for i, name := range names {
 			// Check for duplicate field names
 			if prevToken, exists := fieldNames[name.Value]; exists {
 				msg := fmt.Sprintf("duplicate field name '%s' in struct '%s'", name.Value, stmt.Name.Value)
@@ -2369,6 +2378,7 @@ func (p *Parser) parseStructDeclaration() *StructDeclaration {
 			field := &StructField{
 				Name:     name,
 				TypeName: typeName,
+				Tag: 			tags[i],
 			}
 			stmt.Fields = append(stmt.Fields, field)
 		}

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -257,7 +257,23 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 			if err != nil {
 				return nil, err
 			}
-			m[key] = goVal
+			switch tag := v.FieldTags[key].(type) {
+				case *object.JSONTag:
+					if tag.Ignore {
+						break
+					}
+					if tag.OmitEmpty && val.Type() == object.NIL_OBJ {
+						break
+					}
+					if tag.EncodeAsString && 
+					val.Type() == object.INTEGER_OBJ || 
+					val.Type() == object.FLOAT_OBJ {
+						// TODO
+					}
+					m[tag.Name] = goVal
+				default:
+					m[key] = goVal
+			}
 		}
 		return m, nil
 

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -265,8 +265,13 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 					if tag.OmitEmpty && val.Type() == object.NIL_OBJ {
 						break
 					}
-					// TODO: encode value object as string
 					if tag.EncodeAsString {
+					switch v := goVal.(type) {
+							case *object.Integer:
+								m[tag.Name] = v.Inspect()
+							case *object.Float:
+								m[tag.Name] = v.Inspect()
+						}
 					}
 					m[tag.Name] = goVal
 				default:

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -317,13 +317,13 @@ func decodeToStruct(jsonStr string, structDef *object.StructDef) (*object.Struct
 		switch tag := structDef.FieldTags[fieldName].(type) {
 			case *object.JSONTag:
 				if tag.Ignore {
+					fields[fieldName] = zeroValueForType(fieldType)
 					break
 				}
 			 
 				if jsonVal, exists := jsonMap[tag.Name]; exists {
 					fields[fieldName] = convertToTypedValue(jsonVal, fieldType)
-				} else if !exists && !tag.OmitEmpty {
-					// Set zero value if `omitempty` is not set
+				} else if !exists {
 					fields[fieldName] = zeroValueForType(fieldType)
 				}
 			default:


### PR DESCRIPTION
# Summary
- Added struct field tags to struct definitions
- Standard library json methods allows for following customization
    - `json:"customName"`
    - `json:"-"` 
    - `json:"name,omitempty"`
    - `json:"name,string"`
 
# Test Plan
- [x] All unit tests pass
- [x] All integration tests pass

CLOSES #613 