### PR TITLE
fix(interpreter): add bounds check for empty ReturnValue.Values

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -771,7 +771,10 @@ func evalProgram(program *ast.Program, env *Environment) Object {
 
 		switch result := result.(type) {
 		case *ReturnValue:
-			return result.Values[0]
+			if len(result.Values) > 0 {
+				return result.Values[0]
+			}
+			return NIL
 		case *Error:
 			return result
 		}


### PR DESCRIPTION
## Summary
- Add length check before accessing `Values[0]` in `evalProgram` to prevent panic when `ReturnValue` has an empty `Values` slice

## Test plan
- [x] All existing tests pass
- [x] Bug reproduction test confirms the fix

Fixes #740