### PR TITLE
fix(stdlib): make ignored file Close errors explicit in io.go

### DIFF
--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -60,19 +60,19 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 
 	// Set permissions before writing (for security)
 	if err := tmpFile.Chmod(perm); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close() // Error ignored; already returning an error
 		return fmt.Errorf("set permissions: %w", err)
 	}
 
 	// Write data
 	if _, err := tmpFile.Write(data); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close() // Error ignored; already returning an error
 		return fmt.Errorf("write data: %w", err)
 	}
 
 	// Sync to ensure data is on disk before rename
 	if err := tmpFile.Sync(); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close() // Error ignored; already returning an error
 		return fmt.Errorf("sync: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Add explicit blank identifier assignments for `tmpFile.Close()` calls in error paths
- Makes intentional error ignoring clear and silences linter warnings
- Code quality improvement, no functional change

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass (285 tests)

Fixes #742