### PR TITLE
fix(stdlib): remove redundant `arrays.range()` function

### DIFF
--- a/BUG_REPORT.md
+++ b/BUG_REPORT.md
@@ -1,0 +1,131 @@
+# EZ Language Bug Report
+
+**Date:** 2025-12-19
+**Branch:** `bugfixes/test-coverage-bug-fixes`
+
+---
+
+## Fixed Bugs
+
+### BUG #1: Unchecked Array Access in ReturnValue - **FIXED** (PR #743)
+- **File:** `pkg/interpreter/evaluator.go:774`
+- **Issue:** Accessed `result.Values[0]` without bounds check
+- **Fix:** Added length check before access
+
+### BUG #2: Ignored Deref() Error in Compound Assignment - **FIXED** (PR #744)
+- **File:** `pkg/interpreter/evaluator.go:1142`
+- **Issue:** Ignored error return from `ref.Deref()`
+- **Fix:** Added error check and proper error return
+
+### BUG #3: Missing Error Checks on File Close - **FIXED** (PR #745)
+- **File:** `pkg/stdlib/io.go:63,69,75`
+- **Issue:** Ignored `Close()` errors in error paths
+- **Fix:** Made ignored errors explicit with blank identifier
+
+---
+
+## Open Bugs
+
+### BUG #4: Unchecked Type Assertions in arrays.range()
+
+**File:** `pkg/stdlib/arrays.go`
+**Lines:** 923, 927-928, 931-933
+**Severity:** High
+
+**Code:**
+```go
+if len(args) == 1 {
+    end = args[0].(*object.Integer).Value.Int64()  // No type check!
+} else if len(args) == 2 {
+    start = args[0].(*object.Integer).Value.Int64()  // No type check!
+    end = args[1].(*object.Integer).Value.Int64()    // No type check!
+} else {
+    start = args[0].(*object.Integer).Value.Int64()  // No type check!
+    end = args[1].(*object.Integer).Value.Int64()    // No type check!
+    step = args[2].(*object.Integer).Value.Int64()   // No type check!
+}
+```
+
+**Description:**
+The function validates argument count but does NOT validate that arguments are Integers before casting. Passing a Float or String will cause a panic.
+
+**Impact:** Crash on `arrays.range(1.5)` or `arrays.range("a")`
+
+**Suggested Fix:**
+```go
+intArg, ok := args[0].(*object.Integer)
+if !ok {
+    return &object.Error{Code: "E7004", Message: "arrays.range() requires integer arguments"}
+}
+end = intArg.Value.Int64()
+```
+
+---
+
+### BUG #5: Integer-to-Byte Conversion Without Bounds Check
+
+**File:** `pkg/stdlib/bytes.go`
+**Lines:** 167, 1014
+**Severity:** Medium
+
+**Code:**
+```go
+// Line 167 (bytes.to_string)
+if intVal, ok := elem.(*object.Integer); ok {
+    data[i] = byte(intVal.Value.Int64())  // No bounds check!
+    continue
+}
+
+// Line 1014 (slice_data helper)
+case *object.Integer:
+    data[i] = byte(e.Value.Int64())  // No bounds check!
+```
+
+**Description:**
+When converting integers to bytes, there's no validation that the value is in the valid range (0-255). Go silently truncates out-of-range values.
+
+**Impact:** `bytes.to_string([256, 0])` silently converts 256 to 0 instead of erroring
+
+**Suggested Fix:**
+```go
+val := intVal.Value.Int64()
+if val < 0 || val > 255 {
+    return &object.Error{Code: "E7005", Message: "byte value must be 0-255"}
+}
+data[i] = byte(val)
+```
+
+---
+
+## Additional Patterns to Review
+
+| File | Line | Pattern |
+|------|------|---------|
+| `pkg/typechecker/typechecker.go` | 637 | `varType, _ = tc.inferExpressionType(node.Value)` |
+| `pkg/typechecker/typechecker.go` | 714 | `structType, _ := tc.GetType(node.Name.Value)` |
+| `pkg/stdlib/json.go` | 472 | `hash, _ := object.HashKey(keyObj)` |
+| `pkg/stdlib/json.go` | 498 | `bytes, _ := json.Marshal(v.Value)` |
+| `pkg/stdlib/json.go` | 511 | `bytes, _ := json.Marshal(string(v.Value))` |
+
+---
+
+## Verified Safe Patterns
+
+| Location | Pattern | Reason |
+|----------|---------|--------|
+| math.go:113,148 | `args[0].(*object.Integer)` | `getNumber()` validates type first |
+| evaluator.go:836 | `returnVal.Values[i]` | Bounds checked at lines 825-827 |
+| evaluator.go:2911-2912 | `v.Values[0]` | `len(v.Values) == 1` checked first |
+
+---
+
+## Summary
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| High | 1 | BUG #4 - arrays.range() |
+| Medium | 1 | BUG #5 - bytes.go bounds |
+| Fixed | 3 | PRs #743, #744, #745 |
+
+**Open bugs:** 2
+**Fixed bugs:** 3

--- a/ez-article-two.md
+++ b/ez-article-two.md
@@ -1,0 +1,129 @@
+# Building EZ: Part 2
+
+**Subtitle:** So What's Next?
+
+---
+
+## Introduction
+
+You shipped something. Congratulations. The GitHub stars trickle in, maybe someone files an issue, and reality sets in: you now have a codebase to maintain.
+
+Most "vibe coding" content focuses on the build. The initial rush of watching an AI spin up features faster than you can review them. Nobody talks about what happens after the honeymoon - when you're staring at code you half-understand, hunting bugs across a system that grew faster than your comprehension of it.
+
+This is that article.
+
+After shipping EZ and writing about the initial development process, I've spent months maintaining, debugging, and evolving the language. Here's what I've learned about the long game of AI-assisted development.
+
+---
+
+## Bug Hunting with AI
+
+Here's my actual bug hunting process: I write programs.
+
+Not toy examples. Real programs. A banking software simulator. A text adventure game. I use EZ like a user would, and when something breaks, I document it. This sounds obvious, but it's easy to fall into the trap of only testing what you *think* might break.
+
+The interesting bugs come from places you weren't looking.
+
+### The NaN Problem
+
+One bug that kept resurfacing involved `NaN` and `Inf`/`-Inf` comparisons. The issue wasn't that it was hard to fix - it's that it kept coming back in different forms. Why? Because different Claude Code sessions had different mental models for how these edge cases should be handled.
+
+Session one decides `NaN == NaN` should return `false` (mathematically correct). Session two, with no memory of that decision, implements comparison logic that assumes `NaN` values are equal. Now you have inconsistent behavior buried in your codebase, and it only surfaces when an integration test runs a specific comparison.
+
+This is the hidden cost of AI-assisted development: **consistency requires explicit documentation**. The AI doesn't remember last week's architectural decisions unless you tell it.
+
+---
+
+## Feature Planning - Vision vs. Scope Creep
+
+Claude is helpful. Sometimes too helpful.
+
+At one point during JSON implementation, Claude suggested adding generics to the language. Generics would make unmarshaling cleaner, more flexible, more "correct." It was a reasonable suggestion from a language design perspective.
+
+I said no.
+
+Here's my rule: **if I don't understand it, it doesn't belong in my language.** I don't fully understand generics. I can use them in other languages, but I couldn't explain the implementation to someone else. So they're not going in EZ.
+
+This came up repeatedly. Claude suggested `let`, `var`, and `mut` keywords at various points - patterns borrowed from Rust, Swift, JavaScript. Each suggestion made sense in isolation. Each one would have added complexity that contradicted EZ's core philosophy: clarity over cleverness.
+
+The AI doesn't know your vision unless you enforce it. Every session, every conversation, the AI is optimizing for "good code" by general standards. Your job is to optimize for *your* standards.
+
+---
+
+## Writing Tests - Your Safety Net
+
+Let me tell you about the tests that weren't actually testing anything.
+
+Up until around version 0.17.x, the integration tests that Claude had written weren't asserting anything meaningful. Tests were "passing" because they ran without crashing - not because they verified correct behavior. A function could return completely wrong output, and the test would pass.
+
+I didn't catch this for months.
+
+This is the uncomfortable truth about vibecoded projects: **you can't review every line**. You're trusting the AI to write correct code, and sometimes that trust is misplaced. Tests are supposed to be your safety net, but if the AI writes the tests too, who's testing the tests?
+
+My solution: I understand all the integration tests because they're written in EZ syntax - the language I designed. I know what those tests are doing because I can read them like English.
+
+The unit tests? Written in Go. I haven't looked at most of them. They pass, and I trust that, but I couldn't explain what half of them are verifying.
+
+This is a gap I live with. You'll have gaps too. The question is whether you're honest about where they are.
+
+---
+
+## Keeping AI On Track
+
+### The Runaway Problem
+
+I learned to include this in my prompts: "Report back to me the moment you find a bug."
+
+It doesn't work.
+
+Claude finds a bug, mentions it in passing - "I found an issue with string parsing" - and then keeps going. Writing more tests. Investigating related code. Refactoring nearby functions. By the time it stops, the original bug is buried under fifteen new findings, and I'm scrolling up through terminal history trying to find what actually mattered.
+
+The same thing happens with test writing. Ask Claude to write tests for a simple function, and you'll get fifteen test cases covering edge cases you didn't ask about. At some point you have to interrupt: "What are you doing? The first test passed. We're done."
+
+**The AI doesn't know when to stop.** That's your job.
+
+### Context Is Everything
+
+At the start of every session, I give Claude a master prompt that points to my context directory. Inside that directory is a `Language-Spec` folder containing files about every aspect of EZ's design: philosophy, syntax, error handling, type system, everything.
+
+This is the documentation-as-memory approach from my first article, in practice. Without it, every session starts from zero. With it, Claude at least has a chance of making decisions consistent with past decisions.
+
+It's not perfect. The AI still loses the plot mid-conversation. But I've never had to restart a session entirely - I just course-correct. "No, we're not adding that. Read the design philosophy doc again."
+
+---
+
+## Honesty Hour
+
+Let's be real.
+
+**What part of the EZ codebase do I understand the least?** The AST. Nodes. The abstract syntax tree that powers the entire parser. I know what it does conceptually. I could not write it from scratch, and I could not debug a complex issue in it without AI assistance.
+
+**Have I shipped code thinking "I hope this doesn't break"?** The whole thing. But specifically? The basics. Simple variable declarations. Functions. Return statements. Parameters.
+
+That's the stuff everyone touches first. If a new user writes `temp x int = 5` and it breaks, EZ is dead on arrival. Those foundational features were written early, when I understood the codebase least, and they've been stable enough that I haven't had to revisit them.
+
+Stable enough. Probably fine. I hope.
+
+This is the reality of vibecoded projects. You're shipping software built on foundations you didn't fully verify. The AI wrote it, the tests pass, users haven't complained - so you move forward and try not to think about it too hard.
+
+---
+
+## Conclusion
+
+Maintaining an AI-assisted project isn't harder than maintaining a traditional one. It's differently hard.
+
+You trade "I don't know how to implement this" for "I don't fully understand what was implemented." You trade slow development for fast development with gaps in comprehension. You trade complete control for velocity.
+
+The goal isn't a perfect codebase. It's a sustainable one. That means:
+
+- **Document decisions** so future sessions stay consistent
+- **Say no to features** that don't match your vision, even good ones
+- **Understand your tests** - at least enough to know what they're actually testing
+- **Know your gaps** and be honest about what you don't understand
+- **Write real programs** with your own tools - that's where the bugs hide
+
+The honeymoon ends. The real work begins. And if you're honest with yourself about what you've built, you might just keep it running.
+
+---
+
+*This is Part 2 of the Building EZ series. [Part 1 covers the initial development process and prompting framework.](https://marshallburns.me/blog/ez-article-one)*

--- a/integration-tests/fail/errors/E9003_range_step_zero.ez
+++ b/integration-tests/fail/errors/E9003_range_step_zero.ez
@@ -3,8 +3,8 @@
  * Expected: "step" or "zero"
  */
 
-import @arrays
-
 do main() {
-    temp arr = arrays.range(1, 10, 0)  // step cannot be zero
+    for i in range(1, 10, 0) {  // step cannot be zero
+        show(i)
+    }
 }

--- a/pkg/interpreter/bug_reproduction_test.go
+++ b/pkg/interpreter/bug_reproduction_test.go
@@ -1,0 +1,143 @@
+package interpreter
+
+// Bug reproduction tests - these tests verify bugs documented in BUG_REPORT.md
+
+import (
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/lexer"
+	"github.com/marshallburns/ez/pkg/parser"
+)
+
+// TestBug1_EmptyReturnValuePanic tests that accessing Values[0] on an empty
+// ReturnValue doesn't panic. This is the bug at evaluator.go:774.
+//
+// The bug is in evalProgram where it does:
+//   case *ReturnValue:
+//       return result.Values[0]  // No bounds check!
+func TestBug1_EmptyReturnValuePanic(t *testing.T) {
+	// Create a ReturnValue with empty Values slice
+	emptyReturn := &ReturnValue{Values: []Object{}}
+
+	// This simulates what happens at line 774 - accessing Values[0] without checking
+	defer func() {
+		if r := recover(); r != nil {
+			t.Logf("BUG CONFIRMED: Panic occurred when accessing empty ReturnValue.Values[0]: %v", r)
+			// Bug is confirmed - this test documents the issue
+		}
+	}()
+
+	// Direct access like line 774 does
+	if len(emptyReturn.Values) > 0 {
+		_ = emptyReturn.Values[0] // Safe access
+	} else {
+		// This is what the current code does NOT do - it just accesses [0] directly
+		// Simulating the bug:
+		_ = emptyReturn.Values[0] // This will panic
+	}
+}
+
+// TestBug1_EmptyReturnFromFunction tests that a function with empty return
+// is handled correctly.
+func TestBug1_EmptyReturnFromFunction(t *testing.T) {
+	input := `
+do empty_return() {
+    return
+}
+
+do main() {
+    temp x = empty_return()
+}
+`
+	l := lexer.NewLexer(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+
+	env := NewEnvironment()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("BUG: Panic when handling empty return: %v", r)
+		}
+	}()
+
+	result := Eval(program, env)
+
+	// Should complete without panic
+	if result != nil && result.Type() == ERROR_OBJ {
+		// An error is acceptable, but a panic is not
+		t.Logf("Got error (acceptable): %s", result.Inspect())
+	}
+}
+
+// TestBug2_IgnoredDerefError tests that Deref() errors are properly handled
+// in compound assignments. This is the bug at evaluator.go:1142.
+//
+// The bug: oldVal, _ := ref.Deref() ignores the error.
+// If Deref() fails, oldVal is nil (Go nil, not EZ NIL object).
+// This nil is passed to evalCompoundAssignment -> evalInfixExpression.
+// At line 2086: left.Type() will panic because left is nil.
+func TestBug2_IgnoredDerefError(t *testing.T) {
+	// Simulate what happens when Deref() fails and nil is passed
+	// to evalCompoundAssignment
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Logf("BUG CONFIRMED: Panic when nil passed to evalInfixExpression: %v", r)
+		}
+	}()
+
+	// This simulates the bug scenario:
+	// 1. ref.Deref() returns (nil, false)
+	// 2. The code ignores the false: oldVal, _ := ref.Deref()
+	// 3. oldVal (nil) is passed to evalCompoundAssignment
+	// 4. evalCompoundAssignment calls evalInfixExpression("+", nil, right, ...)
+	// 5. evalInfixExpression does: left.Type() - PANIC on nil
+
+	var nilObject Object = nil
+	rightValue := &Integer{Value: nil}
+
+	// This will panic at left.Type() because left is nil
+	result := evalInfixExpression("+", nilObject, rightValue, 0, 0)
+	_ = result
+}
+
+// TestBug2_DerefFailsOnMissingVariable shows that Deref can fail
+func TestBug2_DerefFailsOnMissingVariable(t *testing.T) {
+	env := NewEnvironment()
+
+	// Create a reference to a non-existent variable
+	ref := &Reference{Env: env, Name: "does_not_exist"}
+
+	val, ok := ref.Deref()
+	if ok {
+		t.Error("Deref() should return false for non-existent variable")
+	}
+	if val != nil {
+		t.Error("Deref() should return nil when variable doesn't exist")
+	}
+
+	t.Log("Confirmed: Deref() returns (nil, false) for missing variables")
+	t.Log("At line 1142, this nil would be passed to evalCompoundAssignment")
+}
+
+// TestBug3_InconsistentFileCloseErrorHandling documents the inconsistent
+// error handling in pkg/stdlib/io.go
+//
+// This is a code quality issue, not a crash bug.
+// Lines 63, 69, 75: tmpFile.Close() errors are ignored
+// Line 80: tmpFile.Close() error is properly checked
+func TestBug3_InconsistentFileCloseErrorHandling(t *testing.T) {
+	t.Log("BUG #3: Inconsistent error handling in pkg/stdlib/io.go")
+	t.Log("  - Lines 63, 69, 75: tmpFile.Close() errors ignored in error paths")
+	t.Log("  - Line 80: tmpFile.Close() error properly checked")
+	t.Log("")
+	t.Log("Impact: Low - in error paths, we're already returning an error")
+	t.Log("But it's inconsistent and could mask additional issues")
+	t.Log("")
+	t.Log("STATUS: Code quality issue - documented but not crash-inducing")
+}

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -911,46 +911,6 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.range": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) < 1 || len(args) > 3 {
-				return newError("arrays.range() takes 1 to 3 arguments")
-			}
-
-			var start, end, step int64
-
-			if len(args) == 1 {
-				end = args[0].(*object.Integer).Value.Int64()
-				start = 0
-				step = 1
-			} else if len(args) == 2 {
-				start = args[0].(*object.Integer).Value.Int64()
-				end = args[1].(*object.Integer).Value.Int64()
-				step = 1
-			} else {
-				start = args[0].(*object.Integer).Value.Int64()
-				end = args[1].(*object.Integer).Value.Int64()
-				step = args[2].(*object.Integer).Value.Int64()
-			}
-
-			if step == 0 {
-				return &object.Error{Code: "E9003", Message: "arrays.range() step cannot be zero"}
-			}
-
-			var elements []object.Object
-			if step > 0 {
-				for i := start; i < end; i += step {
-					elements = append(elements, &object.Integer{Value: big.NewInt(i)})
-				}
-			} else {
-				for i := start; i > end; i += step {
-					elements = append(elements, &object.Integer{Value: big.NewInt(i)})
-				}
-			}
-			return &object.Array{Elements: elements}
-		},
-	},
-
 	"arrays.repeat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {


### PR DESCRIPTION
## Summary
- Remove `arrays.range()` which conflicts with the builtin `range()` keyword
- The builtin `range()` already has proper type validation
- Update E9003 integration test to use builtin `range()` instead

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass (285 tests)

Fixes #746