### PR TITLE
fix(typechecker): handle ignored error returns properly

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -634,7 +634,9 @@ func (tc *TypeChecker) RegisterDeclarations(program *ast.Program) {
 			// Register global constants/variables
 			varType := node.TypeName
 			if varType == "" {
-				varType, _ = tc.inferExpressionType(node.Value)
+				if inferred, ok := tc.inferExpressionType(node.Value); ok {
+					varType = inferred
+				}
 			}
 			tc.variables[node.Name.Value] = varType
 		}
@@ -711,7 +713,10 @@ func (tc *TypeChecker) registerEnumType(node *ast.EnumDeclaration) {
 
 // checkStructDeclaration validates a struct's field types
 func (tc *TypeChecker) checkStructDeclaration(node *ast.StructDeclaration) {
-	structType, _ := tc.GetType(node.Name.Value)
+	structType, ok := tc.GetType(node.Name.Value)
+	if !ok {
+		return
+	}
 
 	for _, field := range node.Fields {
 		// Check if field type exists


### PR DESCRIPTION
## Summary
- Line 637: Check bool return from `inferExpressionType` before using value
- Line 717: Return early if `GetType` fails to prevent nil pointer panic

Note: Line 567 was a false positive - `Count()` returns `(errors, warnings)`, not `(count, error)`.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass (285 tests)

Fixes #752