### PR TITLE
fix(cli): consistent arg handling and remove stale `ez run` references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
 
       - name: Run interpreter tests
         if: runner.os != 'Windows'
-        run: ./ez run tests/comprehensive.ez
+        run: ./ez tests/comprehensive.ez
 
       - name: Run interpreter tests (Windows)
         if: runner.os == 'Windows'
-        run: .\ez.exe run tests\comprehensive.ez
+        run: .\ez.exe tests\comprehensive.ez
 
       - name: Validate example files
         if: runner.os != 'Windows'

--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -51,16 +51,15 @@ func main() {
 		startREPL()
 	case "check", "build":
 		if len(os.Args) < 3 {
-			// No argument: check project in current directory
-			checkProject(".")
+			fmt.Println("Usage: ez check <file.ez | directory>")
+			return
+		}
+		arg := os.Args[2]
+		// Check if it's a .ez file or a directory
+		if strings.HasSuffix(arg, ".ez") {
+			checkFile(arg)
 		} else {
-			arg := os.Args[2]
-			// Check if it's a .ez file or a directory
-			if strings.HasSuffix(arg, ".ez") {
-				checkFile(arg)
-			} else {
-				checkProject(arg)
-			}
+			checkProject(arg)
 		}
 	case "lex":
 		if len(os.Args) < 3 {
@@ -94,9 +93,7 @@ func printHelp() {
 	fmt.Println("  ez <command> [args] Run a specific command")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  check          Check syntax and types in current directory (requires main.ez)")
-	fmt.Println("  check <dir>    Check syntax and types in specified directory")
-	fmt.Println("  check <file>   Check syntax and types for a single file")
+	fmt.Println("  check <file | dir>   Check syntax and types for a file or directory")
 	fmt.Println("  repl           Start interactive REPL mode")
 	fmt.Println("  update         Check for updates and upgrade EZ")
 	fmt.Println("  version        Show version information")
@@ -108,7 +105,7 @@ func printHelp() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  ez myProgram.ez")
-	fmt.Println("  ez check                    # Check project in current directory")
+	fmt.Println("  ez check .                  # Check project in current directory")
 	fmt.Println("  ez check ./myproject        # Check project in myproject/")
 	fmt.Println("  ez check utils.ez           # Check single file")
 	fmt.Println("  ez repl")

--- a/examples/hello.ez
+++ b/examples/hello.ez
@@ -1,7 +1,7 @@
 /*
  * hello.ez - Your first EZ program
  *
- * Run with: ez run examples/hello.ez
+ * Run with: ez examples/hello.ez
  */
 
 import @std

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,6 @@ rm -f "$BINARY_NAME"
 
 echo ""
 echo "EZ installed successfully!"
-echo "Run 'ez run <file>' to execute EZ programs"
+echo "Run 'ez <file>' to execute EZ programs"
 echo ""
 echo "To uninstall, run: sudo rm $INSTALL_DIR/$BINARY_NAME"


### PR DESCRIPTION
## Summary

- Show usage message for `ez check` when no arguments provided (consistent with `ez lex` and `ez parse` behavior)
- Remove deprecated `ez run` references from install.sh, CI workflow, and examples

## Changes

| File | Change |
|------|--------|
| `cmd/ez/main.go` | `ez check` shows usage when no args |
| `install.sh` | `ez run <file>` → `ez <file>` |
| `.github/workflows/ci.yml` | Updated Unix and Windows test commands |
| `examples/hello.ez` | Updated run comment |

## Test plan

- [x] `ez check` without args shows usage message
- [x] `ez check examples/hello.ez` still works
- [x] `ez examples/hello.ez` runs correctly

Fixes #765