### PR TITLE
fix(language): remove broken `private:module` and add typechecker validation

### DIFF
--- a/integration-tests/fail/errors/E3037_invalid_private_usage.ez
+++ b/integration-tests/fail/errors/E3037_invalid_private_usage.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3037 - invalid-private-usage
+ * Expected: "private modifier cannot be used here"
+ */
+
+do main() {
+    private temp x int = 5  // private not allowed inside functions
+}

--- a/integration-tests/fail/multi-file/E4006_private_function_access/lib.ez
+++ b/integration-tests/fail/multi-file/E4006_private_function_access/lib.ez
@@ -1,0 +1,12 @@
+/*
+ * lib.ez - Library with private function
+ */
+module lib
+
+private do secret() -> string {
+    return "secret value"
+}
+
+do public_fn() -> string {
+    return "public"
+}

--- a/integration-tests/fail/multi-file/E4006_private_function_access/main.ez
+++ b/integration-tests/fail/multi-file/E4006_private_function_access/main.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E4006 - Accessing private function from another module
+ * Expected: "not found in module"
+ */
+
+import @std
+import "./lib"
+
+using std
+
+do main() {
+    // This should fail - secret() is private
+    println(lib.secret())
+}

--- a/integration-tests/pass/multi-file/private-visibility/lib.ez
+++ b/integration-tests/pass/multi-file/private-visibility/lib.ez
@@ -1,0 +1,23 @@
+/*
+ * lib.ez - Library with private and public functions
+ * Tests that private functions are not exported
+ */
+module lib
+
+// Private function - should NOT be accessible from main.ez
+private do internal_helper() -> string {
+    return "internal"
+}
+
+// Private constant - should NOT be accessible from main.ez
+private const SECRET_KEY string = "abc123"
+
+// Public function - SHOULD be accessible from main.ez
+do get_greeting(name string) -> string {
+    // Can call private function internally
+    temp prefix string = internal_helper()
+    return prefix + ": Hello, " + name
+}
+
+// Public constant - SHOULD be accessible from main.ez
+const VERSION string = "1.0.0"

--- a/integration-tests/pass/multi-file/private-visibility/main.ez
+++ b/integration-tests/pass/multi-file/private-visibility/main.ez
@@ -1,0 +1,47 @@
+/*
+ * main.ez - Test private visibility
+ *
+ * Tests:
+ *   - Public functions are accessible via module prefix
+ *   - Public constants are accessible via module prefix
+ *   - Private functions/constants are NOT exported (tested separately in fail tests)
+ */
+
+import @std
+import "./lib"
+
+using std
+
+do main() {
+    println("=== Private Visibility Test ===")
+    temp passed int = 0
+
+    // Test 1: Access public function
+    temp greeting string = lib.get_greeting("World")
+    if greeting == "internal: Hello, World" {
+        println("  [PASS] public function accessible")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] public function: got '${greeting}'")
+    }
+
+    // Test 2: Access public constant
+    if lib.VERSION == "1.0.0" {
+        println("  [PASS] public constant accessible")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] public constant: got '${lib.VERSION}'")
+    }
+
+    // Note: Accessing lib.internal_helper() or lib.SECRET_KEY would fail
+    // Those cases are tested in fail/multi-file tests
+
+    println("")
+    println("Results: ${passed}/2 passed")
+    
+    if passed == 2 {
+        println("ALL TESTS PASSED")
+    } otherwise {
+        println("SOME TESTS FAILED")
+    }
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -37,9 +37,8 @@ type Program struct {
 type Visibility int
 
 const (
-	VisibilityPublic        Visibility = iota // Public (default)
-	VisibilityPrivate                         // Private to this file
-	VisibilityPrivateModule                   // Private to this module (all files in directory)
+	VisibilityPublic  Visibility = iota // Public (default)
+	VisibilityPrivate                   // Private to this file/module
 )
 
 // ModuleDeclaration represents "module mymodule" at the top of a file

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -369,9 +369,6 @@ func TestVisibilityConstants(t *testing.T) {
 	if VisibilityPrivate != 1 {
 		t.Errorf("VisibilityPrivate = %d, want 1", VisibilityPrivate)
 	}
-	if VisibilityPrivateModule != 2 {
-		t.Errorf("VisibilityPrivateModule = %d, want 2", VisibilityPrivateModule)
-	}
 }
 
 // ============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -135,6 +135,7 @@ var (
 	E3034 = ErrorCode{"E3034", "any-type-not-allowed", "'any' type is reserved for internal use"}
 	E3035 = ErrorCode{"E3035", "not-all-paths-return", "not all code paths return a value"}
 	E3036 = ErrorCode{"E3036", "integer-out-of-range", "integer literal exceeds type range"}
+	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -207,8 +207,6 @@ func convertVisibility(vis ast.Visibility) Visibility {
 	switch vis {
 	case ast.VisibilityPrivate:
 		return VisibilityPrivate
-	case ast.VisibilityPrivateModule:
-		return VisibilityPrivateModule
 	default:
 		return VisibilityPublic
 	}

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -71,9 +71,8 @@ const (
 	TYPE_OBJ         = object.TYPE_OBJ
 
 	// Visibility constants
-	VisibilityPublic        = object.VisibilityPublic
-	VisibilityPrivate       = object.VisibilityPrivate
-	VisibilityPrivateModule = object.VisibilityPrivateModule
+	VisibilityPublic  = object.VisibilityPublic
+	VisibilityPrivate = object.VisibilityPrivate
 )
 
 // Re-export Visibility type

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -558,9 +558,8 @@ var (
 type Visibility int
 
 const (
-	VisibilityPublic        Visibility = iota // Public (default) - accessible from anywhere
-	VisibilityPrivate                         // Private to this file only
-	VisibilityPrivateModule                   // Private to this module (all files in directory)
+	VisibilityPublic  Visibility = iota // Public (default) - accessible from anywhere
+	VisibilityPrivate                   // Private to this file/module
 )
 
 // Environment holds variable bindings

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -731,9 +731,6 @@ func TestVisibilityConstants(t *testing.T) {
 	if VisibilityPrivate != 1 {
 		t.Errorf("VisibilityPrivate = %d, want 1", VisibilityPrivate)
 	}
-	if VisibilityPrivateModule != 2 {
-		t.Errorf("VisibilityPrivateModule = %d, want 2", VisibilityPrivateModule)
-	}
 }
 
 // ============================================================================

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -631,19 +631,7 @@ func (p *Parser) parseStatement() Statement {
 	visibility := VisibilityPublic
 	if p.currentTokenMatches(PRIVATE) {
 		visibility = VisibilityPrivate
-		// Check for private:module syntax
-		if p.peekTokenMatches(COLON) {
-			p.nextToken() // consume PRIVATE
-			p.nextToken() // consume COLON
-			if p.currentTokenMatches(IDENT) && p.currentToken.Literal == "module" {
-				visibility = VisibilityPrivateModule
-				p.nextToken() // move past "module"
-			} else {
-				p.addEZError(errors.E2002, "expected 'module' after 'private:'", p.currentToken)
-			}
-		} else {
-			p.nextToken() // move past PRIVATE to the declaration
-		}
+		p.nextToken() // move past PRIVATE to the declaration
 	}
 
 	// Validate #suppress is only used on function declarations

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1520,6 +1520,16 @@ func (tc *TypeChecker) checkStatement(stmt ast.Statement, expectedReturnTypes []
 
 // checkVariableDeclaration validates a variable declaration (Phase 3)
 func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
+	// Check if private is used inside a function (not allowed)
+	if decl.Visibility == ast.VisibilityPrivate && tc.currentScope != nil {
+		tc.addError(
+			errors.E3037,
+			"'private' modifier can only be used at module level, not inside functions",
+			decl.Token.Line,
+			decl.Token.Column,
+		)
+	}
+
 	// Handle multiple names (for multi-return assignment)
 	if len(decl.Names) > 1 {
 		tc.checkMultiReturnDeclaration(decl)


### PR DESCRIPTION
## Summary

- Remove broken `private:module` syntax (never worked due to parser bug)
- Add typechecker validation for `private` keyword usage

## Changes

| File | Change |
|------|--------|
| `pkg/ast/ast.go` | Remove `VisibilityPrivateModule` constant |
| `pkg/parser/parser.go` | Remove `:module` parsing logic |
| `pkg/object/object.go` | Remove `VisibilityPrivateModule` constant |
| `pkg/interpreter/evaluator.go` | Remove `VisibilityPrivateModule` case |
| `pkg/interpreter/object.go` | Remove re-export of `VisibilityPrivateModule` |
| `pkg/errors/codes.go` | Add `E3037` for invalid private usage |
| `pkg/typechecker/typechecker.go` | Add validation: private only at module level |
| `pkg/ast/ast_test.go` | Remove `VisibilityPrivateModule` test |
| `pkg/object/object_test.go` | Remove `VisibilityPrivateModule` test |

## Test plan

- [x] `private` at module level still works (exports are blocked)
- [x] `private` inside function now produces error E3037
- [x] All unit tests pass
- [x] All integration tests pass (285/285)

Fixes #767