### PR TITLE
chore: remove stale TODO comments

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -159,9 +159,6 @@ func isValidModule(moduleName string) bool {
 		return true
 	}
 
-	// TODO: Check for user-created modules (e.g., local .ez files)
-	// For now, we only validate against standard library
-
 	return false
 }
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -948,7 +948,7 @@ func (tc *TypeChecker) getEnumValueString(expr ast.Expression) string {
 // checkGlobalVariableDeclaration validates a global variable declaration
 func (tc *TypeChecker) checkGlobalVariableDeclaration(node *ast.VariableDeclaration) {
 	// Check each variable in the declaration
-	for i, name := range node.Names {
+	for _, name := range node.Names {
 		varName := name.Value
 
 		// Determine the type
@@ -991,11 +991,6 @@ func (tc *TypeChecker) checkGlobalVariableDeclaration(node *ast.VariableDeclarat
 		// Register variable
 		tc.variables[varName] = typeName
 
-		// If there's an initial value, check type compatibility
-		if node.Value != nil && i == 0 {
-			// TODO: Check that value type matches declared type
-			// This requires expression type inference
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove stale TODO in typechecker.go (type checking already implemented via E3001)
- Remove stale TODO in evaluator.go (user modules already handled via loadUserModule)

## Test plan
- [x] Build passes
- [x] Typechecker tests pass
- [x] Interpreter tests pass

Closes #770