### PR TITLE
fix: use existing E12001 instead of undefined E9020

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1265,8 +1265,8 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			// Map key assignment
 			// Validate that the key is hashable
 			if _, ok := HashKey(idx); !ok {
-				return newErrorWithLocation("E9020", node.Token.Line, node.Token.Column,
-					"unusable as map key: %s", idx.Type())
+				return newErrorWithLocation("E12001", node.Token.Line, node.Token.Column,
+					"map key must be a hashable type, got %s", idx.Type())
 			}
 
 			// Check if map is mutable


### PR DESCRIPTION
## Summary
- E9020 was used for "unusable as map key" but was never defined in codes.go
- E12001 (map-key-not-hashable) already exists for this exact purpose
- Changed evaluator to use E12001 instead

## Test plan
- [x] Build passes
- [x] Interpreter tests pass
- [x] All 288 integration tests pass

Closes #769