### PR TITLE
bugfixes 12-21-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
 
       - name: Run interpreter tests
         if: runner.os != 'Windows'
-        run: ./ez run tests/comprehensive.ez
+        run: ./ez tests/comprehensive.ez
 
       - name: Run interpreter tests (Windows)
         if: runner.os == 'Windows'
-        run: .\ez.exe run tests\comprehensive.ez
+        run: .\ez.exe tests\comprehensive.ez
 
       - name: Validate example files
         if: runner.os != 'Windows'

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -135,6 +135,7 @@ Type system errors
 | E3034 | any-type-not-allowed | 'any' type is reserved for internal use |
 | E3035 | not-all-paths-return | not all code paths return a value |
 | E3036 | integer-out-of-range | integer literal exceeds type range |
+| E3037 | invalid-private-usage | private modifier cannot be used here |
 
 ## Reference Errors (E4xxx)
 
@@ -368,4 +369,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 239 error/warning codes
+**Total:** 240 error/warning codes

--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -51,16 +51,15 @@ func main() {
 		startREPL()
 	case "check", "build":
 		if len(os.Args) < 3 {
-			// No argument: check project in current directory
-			checkProject(".")
+			fmt.Println("Usage: ez check <file.ez | directory>")
+			return
+		}
+		arg := os.Args[2]
+		// Check if it's a .ez file or a directory
+		if strings.HasSuffix(arg, ".ez") {
+			checkFile(arg)
 		} else {
-			arg := os.Args[2]
-			// Check if it's a .ez file or a directory
-			if strings.HasSuffix(arg, ".ez") {
-				checkFile(arg)
-			} else {
-				checkProject(arg)
-			}
+			checkProject(arg)
 		}
 	case "lex":
 		if len(os.Args) < 3 {
@@ -94,9 +93,7 @@ func printHelp() {
 	fmt.Println("  ez <command> [args] Run a specific command")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  check          Check syntax and types in current directory (requires main.ez)")
-	fmt.Println("  check <dir>    Check syntax and types in specified directory")
-	fmt.Println("  check <file>   Check syntax and types for a single file")
+	fmt.Println("  check <file | dir>   Check syntax and types for a file or directory")
 	fmt.Println("  repl           Start interactive REPL mode")
 	fmt.Println("  update         Check for updates and upgrade EZ")
 	fmt.Println("  version        Show version information")
@@ -108,7 +105,7 @@ func printHelp() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  ez myProgram.ez")
-	fmt.Println("  ez check                    # Check project in current directory")
+	fmt.Println("  ez check .                  # Check project in current directory")
 	fmt.Println("  ez check ./myproject        # Check project in myproject/")
 	fmt.Println("  ez check utils.ez           # Check single file")
 	fmt.Println("  ez repl")

--- a/examples/hello.ez
+++ b/examples/hello.ez
@@ -1,7 +1,7 @@
 /*
  * hello.ez - Your first EZ program
  *
- * Run with: ez run examples/hello.ez
+ * Run with: ez examples/hello.ez
  */
 
 import @std

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,6 @@ rm -f "$BINARY_NAME"
 
 echo ""
 echo "EZ installed successfully!"
-echo "Run 'ez run <file>' to execute EZ programs"
+echo "Run 'ez <file>' to execute EZ programs"
 echo ""
 echo "To uninstall, run: sudo rm $INSTALL_DIR/$BINARY_NAME"

--- a/integration-tests/fail/errors/E3037_invalid_private_usage.ez
+++ b/integration-tests/fail/errors/E3037_invalid_private_usage.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3037 - invalid-private-usage
+ * Expected: "private modifier cannot be used here"
+ */
+
+do main() {
+    private temp x int = 5  // private not allowed inside functions
+}

--- a/integration-tests/fail/multi-file/E4006_private_function_access/lib.ez
+++ b/integration-tests/fail/multi-file/E4006_private_function_access/lib.ez
@@ -1,0 +1,12 @@
+/*
+ * lib.ez - Library with private function
+ */
+module lib
+
+private do secret() -> string {
+    return "secret value"
+}
+
+do public_fn() -> string {
+    return "public"
+}

--- a/integration-tests/fail/multi-file/E4006_private_function_access/main.ez
+++ b/integration-tests/fail/multi-file/E4006_private_function_access/main.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E4006 - Accessing private function from another module
+ * Expected: "not found in module"
+ */
+
+import @std
+import "./lib"
+
+using std
+
+do main() {
+    // This should fail - secret() is private
+    println(lib.secret())
+}

--- a/integration-tests/pass/multi-file/private-visibility/lib.ez
+++ b/integration-tests/pass/multi-file/private-visibility/lib.ez
@@ -1,0 +1,23 @@
+/*
+ * lib.ez - Library with private and public functions
+ * Tests that private functions are not exported
+ */
+module lib
+
+// Private function - should NOT be accessible from main.ez
+private do internal_helper() -> string {
+    return "internal"
+}
+
+// Private constant - should NOT be accessible from main.ez
+private const SECRET_KEY string = "abc123"
+
+// Public function - SHOULD be accessible from main.ez
+do get_greeting(name string) -> string {
+    // Can call private function internally
+    temp prefix string = internal_helper()
+    return prefix + ": Hello, " + name
+}
+
+// Public constant - SHOULD be accessible from main.ez
+const VERSION string = "1.0.0"

--- a/integration-tests/pass/multi-file/private-visibility/main.ez
+++ b/integration-tests/pass/multi-file/private-visibility/main.ez
@@ -1,0 +1,47 @@
+/*
+ * main.ez - Test private visibility
+ *
+ * Tests:
+ *   - Public functions are accessible via module prefix
+ *   - Public constants are accessible via module prefix
+ *   - Private functions/constants are NOT exported (tested separately in fail tests)
+ */
+
+import @std
+import "./lib"
+
+using std
+
+do main() {
+    println("=== Private Visibility Test ===")
+    temp passed int = 0
+
+    // Test 1: Access public function
+    temp greeting string = lib.get_greeting("World")
+    if greeting == "internal: Hello, World" {
+        println("  [PASS] public function accessible")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] public function: got '${greeting}'")
+    }
+
+    // Test 2: Access public constant
+    if lib.VERSION == "1.0.0" {
+        println("  [PASS] public constant accessible")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] public constant: got '${lib.VERSION}'")
+    }
+
+    // Note: Accessing lib.internal_helper() or lib.SECRET_KEY would fail
+    // Those cases are tested in fail/multi-file tests
+
+    println("")
+    println("Results: ${passed}/2 passed")
+    
+    if passed == 2 {
+        println("ALL TESTS PASSED")
+    } otherwise {
+        println("SOME TESTS FAILED")
+    }
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -37,9 +37,8 @@ type Program struct {
 type Visibility int
 
 const (
-	VisibilityPublic        Visibility = iota // Public (default)
-	VisibilityPrivate                         // Private to this file
-	VisibilityPrivateModule                   // Private to this module (all files in directory)
+	VisibilityPublic  Visibility = iota // Public (default)
+	VisibilityPrivate                   // Private to this file/module
 )
 
 // ModuleDeclaration represents "module mymodule" at the top of a file

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -369,9 +369,6 @@ func TestVisibilityConstants(t *testing.T) {
 	if VisibilityPrivate != 1 {
 		t.Errorf("VisibilityPrivate = %d, want 1", VisibilityPrivate)
 	}
-	if VisibilityPrivateModule != 2 {
-		t.Errorf("VisibilityPrivateModule = %d, want 2", VisibilityPrivateModule)
-	}
 }
 
 // ============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -135,6 +135,7 @@ var (
 	E3034 = ErrorCode{"E3034", "any-type-not-allowed", "'any' type is reserved for internal use"}
 	E3035 = ErrorCode{"E3035", "not-all-paths-return", "not all code paths return a value"}
 	E3036 = ErrorCode{"E3036", "integer-out-of-range", "integer literal exceeds type range"}
+	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -159,9 +159,6 @@ func isValidModule(moduleName string) bool {
 		return true
 	}
 
-	// TODO: Check for user-created modules (e.g., local .ez files)
-	// For now, we only validate against standard library
-
 	return false
 }
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -207,8 +207,6 @@ func convertVisibility(vis ast.Visibility) Visibility {
 	switch vis {
 	case ast.VisibilityPrivate:
 		return VisibilityPrivate
-	case ast.VisibilityPrivateModule:
-		return VisibilityPrivateModule
 	default:
 		return VisibilityPublic
 	}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1265,8 +1265,8 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			// Map key assignment
 			// Validate that the key is hashable
 			if _, ok := HashKey(idx); !ok {
-				return newErrorWithLocation("E9020", node.Token.Line, node.Token.Column,
-					"unusable as map key: %s", idx.Type())
+				return newErrorWithLocation("E12001", node.Token.Line, node.Token.Column,
+					"map key must be a hashable type, got %s", idx.Type())
 			}
 
 			// Check if map is mutable

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -71,9 +71,8 @@ const (
 	TYPE_OBJ         = object.TYPE_OBJ
 
 	// Visibility constants
-	VisibilityPublic        = object.VisibilityPublic
-	VisibilityPrivate       = object.VisibilityPrivate
-	VisibilityPrivateModule = object.VisibilityPrivateModule
+	VisibilityPublic  = object.VisibilityPublic
+	VisibilityPrivate = object.VisibilityPrivate
 )
 
 // Re-export Visibility type

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -558,9 +558,8 @@ var (
 type Visibility int
 
 const (
-	VisibilityPublic        Visibility = iota // Public (default) - accessible from anywhere
-	VisibilityPrivate                         // Private to this file only
-	VisibilityPrivateModule                   // Private to this module (all files in directory)
+	VisibilityPublic  Visibility = iota // Public (default) - accessible from anywhere
+	VisibilityPrivate                   // Private to this file/module
 )
 
 // Environment holds variable bindings

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -731,9 +731,6 @@ func TestVisibilityConstants(t *testing.T) {
 	if VisibilityPrivate != 1 {
 		t.Errorf("VisibilityPrivate = %d, want 1", VisibilityPrivate)
 	}
-	if VisibilityPrivateModule != 2 {
-		t.Errorf("VisibilityPrivateModule = %d, want 2", VisibilityPrivateModule)
-	}
 }
 
 // ============================================================================

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -631,19 +631,7 @@ func (p *Parser) parseStatement() Statement {
 	visibility := VisibilityPublic
 	if p.currentTokenMatches(PRIVATE) {
 		visibility = VisibilityPrivate
-		// Check for private:module syntax
-		if p.peekTokenMatches(COLON) {
-			p.nextToken() // consume PRIVATE
-			p.nextToken() // consume COLON
-			if p.currentTokenMatches(IDENT) && p.currentToken.Literal == "module" {
-				visibility = VisibilityPrivateModule
-				p.nextToken() // move past "module"
-			} else {
-				p.addEZError(errors.E2002, "expected 'module' after 'private:'", p.currentToken)
-			}
-		} else {
-			p.nextToken() // move past PRIVATE to the declaration
-		}
+		p.nextToken() // move past PRIVATE to the declaration
 	}
 
 	// Validate #suppress is only used on function declarations

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -948,7 +948,7 @@ func (tc *TypeChecker) getEnumValueString(expr ast.Expression) string {
 // checkGlobalVariableDeclaration validates a global variable declaration
 func (tc *TypeChecker) checkGlobalVariableDeclaration(node *ast.VariableDeclaration) {
 	// Check each variable in the declaration
-	for i, name := range node.Names {
+	for _, name := range node.Names {
 		varName := name.Value
 
 		// Determine the type
@@ -991,11 +991,6 @@ func (tc *TypeChecker) checkGlobalVariableDeclaration(node *ast.VariableDeclarat
 		// Register variable
 		tc.variables[varName] = typeName
 
-		// If there's an initial value, check type compatibility
-		if node.Value != nil && i == 0 {
-			// TODO: Check that value type matches declared type
-			// This requires expression type inference
-		}
 	}
 }
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1520,6 +1520,16 @@ func (tc *TypeChecker) checkStatement(stmt ast.Statement, expectedReturnTypes []
 
 // checkVariableDeclaration validates a variable declaration (Phase 3)
 func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
+	// Check if private is used inside a function (not allowed)
+	if decl.Visibility == ast.VisibilityPrivate && tc.currentScope != nil {
+		tc.addError(
+			errors.E3037,
+			"'private' modifier can only be used at module level, not inside functions",
+			decl.Token.Line,
+			decl.Token.Column,
+		)
+	}
+
 	// Handle multiple names (for multi-return assignment)
 	if len(decl.Names) > 1 {
 		tc.checkMultiReturnDeclaration(decl)


### PR DESCRIPTION
## Summary
Bugfixes and improvements from 12-21-2025 session.

### Fixes
- **CLI consistency** (#765): Consistent argument handling across commands, removed stale `ez run` references
- **Private visibility** (#767): Removed broken `private:module` syntax, added E3037 typechecker validation for improper private usage
- **Stale TODOs** (#770): Removed misleading TODO comments that referenced already-implemented functionality
- **E9020 undefined** (#769): Used existing E12001 instead of undefined E9020 for map key hashability check

### Tests
- Added integration tests for private keyword visibility (pass + fail tests)

## Test plan
- [x] All unit tests pass
- [x] All 288 integration tests pass