### PR TITLE
fix(stdlib): write valid JSON when creating new database file

### DIFF
--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -43,7 +43,7 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			if os.IsNotExist(statErr) {
 				perms := os.FileMode(0644)
-				if err := atomicWriteFile(path.Value, []byte(""), perms); err != nil {
+				if err := atomicWriteFile(path.Value, []byte("{}"), perms); err != nil {
 					return &object.Error{Code: "E17001", Message: "db.open() failed to open database file"}
 				}
 

--- a/pkg/stdlib/db_test.go
+++ b/pkg/stdlib/db_test.go
@@ -47,6 +47,28 @@ func TestDBOpen(t *testing.T) {
 		}
 	})
 
+	t.Run("opening new file twice without closing", func(t *testing.T) {
+		path := dir + "double_open.ezdb"
+
+		// First open creates the file
+		result1 := openFn(&object.String{Value: path})
+		assertNoError(t, result1)
+
+		vals1 := getReturnValues(t, result1)
+		if _, ok := vals1[0].(*object.Database); !ok {
+			t.Fatalf("first open: expected Database, got %T", vals1[0])
+		}
+
+		// Second open should also succeed (not report corruption)
+		result2 := openFn(&object.String{Value: path})
+		assertNoError(t, result2)
+
+		vals2 := getReturnValues(t, result2)
+		if _, ok := vals2[0].(*object.Database); !ok {
+			t.Fatalf("second open: expected Database, got %T", vals2[0])
+		}
+	})
+
 	t.Run("wrong argument count", func(t *testing.T) {
 		result := openFn()
 		if !isErrorObject(result) {


### PR DESCRIPTION
## Summary

- Fix empty file corruption when opening a new database twice without closing
- Write `{}` instead of empty string when creating new database files
- Add test case for double-open scenario

## Test plan

- [x] Run `go test ./pkg/stdlib -run TestDBOpen` - new test passes
- [x] Run `go test ./...` - all tests pass
- [x] Run integration tests - all 294 pass

Fixes #780