### PR TITLE
fix(typechecker): require Database type for db module functions

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -6729,19 +6729,19 @@ func (tc *TypeChecker) checkBinaryModuleCall(funcName string, call *ast.CallExpr
 func (tc *TypeChecker) checkDBModuleCall(funcName string, call *ast.CallExpression, line, column int) {
 	signatures := map[string]StdlibFuncSig{
 		// Database management
-		"open": {1, 1, []string{"string"}, "tuple"},
-		"close": 	{1, 2, []string{"any"}, "error"},
-		"save": 	{1, 1, []string{"any"}, "error"},
+		"open":  {1, 1, []string{"string"}, "tuple"},
+		"close": {1, 1, []string{"Database"}, "nil"},
+		"save":  {1, 1, []string{"Database"}, "nil"},
 
 		// Database operations
-		"set": 		{3, 3, []string{"any", "string", "string"}, "nil"},
-		"get": 		{2, 2, []string{"any", "string"}, "tuple"},
-		"delete": {2, 2, []string{"any", "string"}, "bool"},
-		"has": 		{2, 2, []string{"any", "string"}, "bool"},
-		"keys": 	{1, 1, []string{"any"}, "[string]"},
-		"prefix": {2, 2, []string{"any", "string"}, "[string]"},
-		"count": 	{1, 1, []string{"any"}, "int"},
-		"clear": 	{1, 1, []string{"any"}, "nil"},
+		"set":    {3, 3, []string{"Database", "string", "string"}, "nil"},
+		"get":    {2, 2, []string{"Database", "string"}, "tuple"},
+		"delete": {2, 2, []string{"Database", "string"}, "bool"},
+		"has":    {2, 2, []string{"Database", "string"}, "bool"},
+		"keys":   {1, 1, []string{"Database"}, "[string]"},
+		"prefix": {2, 2, []string{"Database", "string"}, "[string]"},
+		"count":  {1, 1, []string{"Database"}, "int"},
+		"clear":  {1, 1, []string{"Database"}, "nil"},
 	}
 
 	sig, exists := signatures[funcName]


### PR DESCRIPTION
## Summary

- Change db function signatures from `"any"` to `"Database"` for the first argument
- Type errors are now caught during typechecking instead of at runtime
- Users obtain a Database from `db.open()` and pass it to other db functions

## Before
```ez
db.close("string")  // No error until runtime
```

## After
```
error[E3001]: db.close argument 1: expected Database, got string
```

## Test plan

- [x] Verified typechecker catches wrong type
- [x] `go test ./...` passes
- [x] All 294 integration tests pass

Fixes #781