### PR TITLE
ci: add PR sanity check workflow

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -20,19 +20,47 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }}
 
-      - name: Block suspicious meta/config files
+      - name: Block disallowed files by extension
         run: |
-          echo "Checking files..."
+          echo "Checking for disallowed file extensions..."
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # Block by extension
+          BLOCKED=$(echo "$CHANGED_FILES" | grep -E '\.(exe|dll|out|ezdb|db|sqlite|sqlite3)$' || true)
+          if [ -n "$BLOCKED" ]; then
+            echo "::error::Disallowed file extensions detected: $BLOCKED"
+            exit 1
+          fi
+
+          # Block IDE/OS junk folders
+          JUNK=$(echo "$CHANGED_FILES" | grep -E '^(\.idea/|\.vs/|__pycache__/)' || true)
+          if [ -n "$JUNK" ]; then
+            echo "::error::IDE/OS junk detected: $JUNK"
+            exit 1
+          fi
+
+          # Block OS junk files
+          OS_JUNK=$(echo "$CHANGED_FILES" | grep -E '(Thumbs\.db|Desktop\.ini|\.DS_Store)$' || true)
+          if [ -n "$OS_JUNK" ]; then
+            echo "::error::OS junk files detected: $OS_JUNK"
+            exit 1
+          fi
+
+          echo "No disallowed file extensions detected."
+
+      - name: Block meta/config files from other ecosystems
+        run: |
+          echo "Checking for ecosystem files..."
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
 
           # Block meta/config files from other language ecosystems
           SUSPICIOUS=$(echo "$CHANGED_FILES" | grep -E '^(package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|bun\.lockb|bunfig\.toml|deno\.json|deno\.jsonc|tsconfig\.json|jsconfig\.json|requirements\.txt|Pipfile|Gemfile|Cargo\.toml|Cargo\.lock)$|node_modules/' || true)
 
           if [ -n "$SUSPICIOUS" ]; then
-            echo "::error::Suspicious meta/config files detected: $SUSPICIOUS"
+            echo "::error::Ecosystem config files detected: $SUSPICIOUS"
             exit 1
           fi
-          echo "No suspicious meta/config files detected."
+          echo "No suspicious ecosystem files detected."
 
       - name: Reject binary files except images
         run: |

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -4,76 +4,71 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   sanity-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Block suspicious meta/config files
         run: |
           echo "Checking files..."
-          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
 
           # Block meta/config files from other language ecosystems
-          SUSPICIOUS=$(echo "$CHANGED_FILES" | grep -E '(
-            package\.json|
-            package-lock\.json|
-            yarn\.lock|
-            pnpm-lock\.yaml|
-            bun\.lockb|
-            bunfig\.toml|
-            deno\.json|
-            deno\.jsonc|
-            tsconfig\.json|
-            jsconfig\.json|
-            requirements\.txt|
-            Pipfile|
-            Gemfile|
-            Cargo\.toml|
-            Cargo\.lock|
-            node_modules/|
-            .*/node_modules/.*
-          )' || true)
+          SUSPICIOUS=$(echo "$CHANGED_FILES" | grep -E '^(package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|bun\.lockb|bunfig\.toml|deno\.json|deno\.jsonc|tsconfig\.json|jsconfig\.json|requirements\.txt|Pipfile|Gemfile|Cargo\.toml|Cargo\.lock)$|node_modules/' || true)
 
           if [ -n "$SUSPICIOUS" ]; then
-            echo "❌ Suspicious meta/config files detected:"
-            echo "$SUSPICIOUS"
+            echo "::error::Suspicious meta/config files detected: $SUSPICIOUS"
             exit 1
           fi
-          echo "✅ No suspicious meta/config files detected."
+          echo "No suspicious meta/config files detected."
 
       - name: Reject binary files except images
         run: |
           echo "Checking for binary files..."
-          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
 
           for file in $CHANGED_FILES; do
             if [ -f "$file" ]; then
-              MIME=$(file --mime "$file")
-              TYPE=$(echo "$MIME" | awk '{print $1}')
+              MIME=$(file --mime-type -b "$file")
 
               # Allow common image formats
-              if [[ "$TYPE" =~ ^image/(jpeg|png|gif|svg|webp)$ ]]; then
-                echo "ℹ️ Allowed image file: $file ($TYPE)"
+              if [[ "$MIME" =~ ^image/(jpeg|png|gif|svg\+xml|webp)$ ]]; then
+                echo "Allowed image file: $file ($MIME)"
                 continue
               fi
 
-              # Reject any other binary file
-              if echo "$MIME" | grep -q "charset=binary"; then
-                echo "❌ Binary file detected: $file ($MIME)"
+              # Reject executables and archives
+              if file "$file" | grep -qE "executable|binary|archive|compressed"; then
+                echo "::error::Binary/executable file detected: $file"
+                exit 1
+              fi
+
+              # Also check charset=binary for other binary types (but not images)
+              if file --mime "$file" | grep -q "charset=binary" && [[ ! "$MIME" =~ ^image/ ]]; then
+                echo "::error::Binary file detected: $file ($MIME)"
                 exit 1
               fi
             fi
           done
-          echo "✅ No disallowed binary files detected."
+          echo "No disallowed binary files detected."
 
-      - name: Close PR if checks fail 
+      - name: Close PR if checks fail
         if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Closing invalid PR"
           gh pr close ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --comment "❌ This PR has been automatically closed because it contains disallowed files (non-image binaries, archives, or unexpected meta/config files)."
-
+            --comment "This PR has been automatically closed because it contains disallowed files (binaries, executables, archives, or meta/config files from other ecosystems). Please remove these files and open a new PR."

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,79 @@
+name: PR Sanity Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sanity-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Block suspicious meta/config files
+        run: |
+          echo "Checking files..."
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+
+          # Block meta/config files from other language ecosystems
+          SUSPICIOUS=$(echo "$CHANGED_FILES" | grep -E '(
+            package\.json|
+            package-lock\.json|
+            yarn\.lock|
+            pnpm-lock\.yaml|
+            bun\.lockb|
+            bunfig\.toml|
+            deno\.json|
+            deno\.jsonc|
+            tsconfig\.json|
+            jsconfig\.json|
+            requirements\.txt|
+            Pipfile|
+            Gemfile|
+            Cargo\.toml|
+            Cargo\.lock|
+            node_modules/|
+            .*/node_modules/.*
+          )' || true)
+
+          if [ -n "$SUSPICIOUS" ]; then
+            echo "❌ Suspicious meta/config files detected:"
+            echo "$SUSPICIOUS"
+            exit 1
+          fi
+          echo "✅ No suspicious meta/config files detected."
+
+      - name: Reject binary files except images
+        run: |
+          echo "Checking for binary files..."
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+
+          for file in $CHANGED_FILES; do
+            if [ -f "$file" ]; then
+              MIME=$(file --mime "$file")
+              TYPE=$(echo "$MIME" | awk '{print $1}')
+
+              # Allow common image formats
+              if [[ "$TYPE" =~ ^image/(jpeg|png|gif|svg|webp)$ ]]; then
+                echo "ℹ️ Allowed image file: $file ($TYPE)"
+                continue
+              fi
+
+              # Reject any other binary file
+              if echo "$MIME" | grep -q "charset=binary"; then
+                echo "❌ Binary file detected: $file ($MIME)"
+                exit 1
+              fi
+            fi
+          done
+          echo "✅ No disallowed binary files detected."
+
+      - name: Close PR if checks fail 
+        if: failure()
+        run: |
+          echo "Closing invalid PR"
+          gh pr close ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --comment "❌ This PR has been automatically closed because it contains disallowed files (non-image binaries, archives, or unexpected meta/config files)."
+


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically rejects PRs containing:
- Binary/executable files (except images)
- Meta/config files from other language ecosystems (package.json, requirements.txt, Cargo.toml, etc.)

Based on @prjctimg's work in #793, with fixes applied to make the workflow functional.

## Changes from #793
- Added `permissions` block for `pull-requests: write`
- Added `fetch-depth: 0` for full git history access
- Added step to fetch base branch before running diff
- Changed hardcoded `origin/main` to `origin/${{ github.base_ref }}`
- Fixed multiline grep pattern that wasn't working
- Fixed MIME type extraction (was extracting file path instead of type)
- Fixed SVG mime type (`svg+xml`)
- Added `GH_TOKEN` env variable for `gh pr close`
- Added `::error::` annotations for GitHub Actions UI

Closes #793