### PR TITLE
feat: add PowerShell install script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 Want to contribute or build from source?
 
+**macOS/Linux:**
 ```bash
 # Clone the repository
 git clone https://github.com/SchoolyB/EZ.git
@@ -34,6 +35,19 @@ make build
 
 # Run a program
 ./ez examples/hello.ez
+```
+
+**Windows (PowerShell):**
+```powershell
+# Clone the repository
+git clone https://github.com/SchoolyB/EZ.git
+cd EZ
+
+# Build the binary
+go build -o ez.exe ./cmd/ez
+
+# Run a program
+.\ez.exe examples\hello.ez
 ```
 
 **Requirements:** Go 1.23.1 or higher
@@ -82,8 +96,22 @@ Invoke-WebRequest -Uri "https://github.com/SchoolyB/EZ/releases/latest/download/
 Expand-Archive ez.zip -DestinationPath .
 Remove-Item ez.zip
 
-# Move to a directory in your PATH (e.g., C:\Program Files\ez)
-Move-Item ez.exe "C:\Program Files\ez\ez.exe"
+# Create install directory and move binary
+New-Item -ItemType Directory -Path "$env:ProgramFiles\ez" -Force
+Move-Item ez.exe "$env:ProgramFiles\ez\ez.exe" -Force
+
+# Add to PATH (if not already present)
+$path = [Environment]::GetEnvironmentVariable("Path", "Machine")
+if ($path -notlike "*$env:ProgramFiles\ez*") {
+    [Environment]::SetEnvironmentVariable("Path", "$path;$env:ProgramFiles\ez", "Machine")
+    Write-Host "Added to PATH - restart your terminal for changes to take effect"
+}
+```
+
+Alternatively, if building from source, you can use the install script:
+```powershell
+# Run as Administrator for system-wide install, or as regular user for user-local install
+.\install.ps1
 ```
 
 After this one-time manual update, `ez update` will work automatically for all future versions.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,106 @@
+# EZ Language Installer for Windows
+#
+# Copyright (c) 2025-Present Marshall A Burns
+# Licensed under the MIT License. See LICENSE for details.
+#
+# Run as Administrator for system-wide installation,
+# or as regular user for user-local installation.
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "EZ Language Installer" -ForegroundColor Cyan
+Write-Host "====================" -ForegroundColor Cyan
+Write-Host ""
+
+# Check if running as Administrator
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+if ($isAdmin) {
+    $InstallDir = "$env:ProgramFiles\ez"
+    $PathScope = "Machine"
+    Write-Host "Running as Administrator - installing system-wide" -ForegroundColor Green
+} else {
+    $InstallDir = "$env:LOCALAPPDATA\ez"
+    $PathScope = "User"
+    Write-Host "Running as regular user - installing for current user only" -ForegroundColor Yellow
+    Write-Host "(Run as Administrator for system-wide installation)" -ForegroundColor Gray
+}
+
+Write-Host ""
+
+# Check if Go is installed
+try {
+    $goVersion = go version
+    Write-Host "Found: $goVersion" -ForegroundColor Green
+} catch {
+    Write-Host "Error: Go is not installed" -ForegroundColor Red
+    Write-Host "Please install Go from https://golang.org/dl/" -ForegroundColor Yellow
+    exit 1
+}
+
+# Build the binary
+Write-Host ""
+Write-Host "Building EZ..." -ForegroundColor Cyan
+try {
+    go build -o ez.exe ./cmd/ez
+    if (-not (Test-Path "ez.exe")) {
+        throw "Build failed - ez.exe not created"
+    }
+    Write-Host "Build successful" -ForegroundColor Green
+} catch {
+    Write-Host "Error: Build failed" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    exit 1
+}
+
+# Create install directory
+Write-Host ""
+Write-Host "Installing to $InstallDir..." -ForegroundColor Cyan
+try {
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+        Write-Host "Created directory: $InstallDir" -ForegroundColor Green
+    }
+
+    # Move binary to install directory
+    Move-Item -Path "ez.exe" -Destination "$InstallDir\ez.exe" -Force
+    Write-Host "Installed ez.exe to $InstallDir" -ForegroundColor Green
+} catch {
+    Write-Host "Error: Failed to install" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    # Clean up local binary if it exists
+    if (Test-Path "ez.exe") { Remove-Item "ez.exe" -Force }
+    exit 1
+}
+
+# Add to PATH if not already present
+$currentPath = [Environment]::GetEnvironmentVariable("Path", $PathScope)
+if ($currentPath -notlike "*$InstallDir*") {
+    Write-Host ""
+    Write-Host "Adding $InstallDir to PATH..." -ForegroundColor Cyan
+    try {
+        $newPath = "$currentPath;$InstallDir"
+        [Environment]::SetEnvironmentVariable("Path", $newPath, $PathScope)
+        Write-Host "Added to $PathScope PATH" -ForegroundColor Green
+        Write-Host "Note: Restart your terminal for PATH changes to take effect" -ForegroundColor Yellow
+    } catch {
+        Write-Host "Warning: Could not add to PATH automatically" -ForegroundColor Yellow
+        Write-Host "Please add '$InstallDir' to your PATH manually" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "$InstallDir is already in PATH" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "EZ installed successfully!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Run 'ez <file>' to execute EZ programs" -ForegroundColor White
+Write-Host ""
+Write-Host "To uninstall, run:" -ForegroundColor Gray
+Write-Host "  Remove-Item -Recurse -Force '$InstallDir'" -ForegroundColor Gray
+if ($PathScope -eq "Machine") {
+    Write-Host "  (Run as Administrator)" -ForegroundColor Gray
+}
+Write-Host ""


### PR DESCRIPTION
## Summary

- Add `install.ps1` for native Windows installation experience
- Fix incomplete Windows instructions in README (missing directory creation and PATH configuration)
- Add Windows build instructions to Developer Quick Start section

## Details

The install script:
- Works as Administrator (system-wide install to `Program Files`) or regular user (user-local install to `%LOCALAPPDATA%`)
- Checks for Go installation
- Builds the binary
- Creates install directory
- Adds EZ to PATH automatically
- Includes proper error handling and colored output

Closes #806