### PR TITLE
fix: type inference for user-defined module function return types

### DIFF
--- a/integration-tests/pass/multi-file/user-module-type-inference/main.ez
+++ b/integration-tests/pass/multi-file/user-module-type-inference/main.ez
@@ -1,0 +1,48 @@
+/*
+ * main.ez - Test type inference for user-defined module function return types
+ *
+ * Tests issue #807: Type inference fails for user-defined module function return types
+ */
+module main
+
+import & use @std
+import & use lib"./mylib"
+
+do needs_u64(v u64) {
+    println("Got u64: ${v}")
+}
+
+do needs_string(s string) {
+    println("Got string: ${s}")
+}
+
+do needs_float(f float) {
+    println("Got float: ${f}")
+}
+
+do main() {
+    println("========================================")
+    println("  User Module Type Inference Test")
+    println("========================================")
+    println("")
+
+    // Test 1: Type inference from user module function returning u64
+    temp val = lib.get_value()  // Type should be inferred as u64
+    needs_u64(val)              // Should work without explicit type
+    println("Test 1 PASSED: u64 type inference")
+
+    // Test 2: Type inference from user module function returning string
+    temp str = lib.get_string()  // Type should be inferred as string
+    needs_string(str)
+    println("Test 2 PASSED: string type inference")
+
+    // Test 3: Type inference from user module function returning float
+    temp flt = lib.get_float()  // Type should be inferred as float
+    needs_float(flt)
+    println("Test 3 PASSED: float type inference")
+
+    println("")
+    println("========================================")
+    println("  All Tests PASSED!")
+    println("========================================")
+}

--- a/integration-tests/pass/multi-file/user-module-type-inference/mylib.ez
+++ b/integration-tests/pass/multi-file/user-module-type-inference/mylib.ez
@@ -1,0 +1,16 @@
+/*
+ * mylib.ez - Test module for type inference from user-defined modules
+ */
+module mylib
+
+do get_value() -> u64 {
+    return 42
+}
+
+do get_string() -> string {
+    return "hello"
+}
+
+do get_float() -> float {
+    return 3.14
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4725,6 +4725,13 @@ func (tc *TypeChecker) inferModuleCallType(member *ast.MemberExpression, args []
 	case "time":
 		return tc.inferTimeCallType(funcName, args)
 	default:
+		// Check user-defined modules
+		if sig, ok := tc.GetModuleFunction(moduleName, funcName); ok {
+			if len(sig.ReturnTypes) >= 1 {
+				return sig.ReturnTypes[0], true
+			}
+			return "void", true
+		}
 		return "", false
 	}
 }


### PR DESCRIPTION
## Summary

- Fix type inference for user-defined module function return types
- Add integration test for user module type inference

## Problem

The `inferModuleCallType()` function only handled stdlib modules (`std`, `math`, `arrays`, `strings`, `time`) and returned empty types for user-defined modules. This caused type mismatch errors like `expects u64, got ` (empty) when variables were assigned from user module function calls without explicit type annotations.

## Solution

Updated the `default` case in `inferModuleCallType()` to use `GetModuleFunction()` to look up user-defined module function signatures and properly infer return types.

## Test plan

- [x] Added integration test `integration-tests/pass/multi-file/user-module-type-inference/`
- [x] All existing integration tests pass (311/312, 1 pre-existing failure unrelated)
- [x] Go unit tests pass

Fixes #807