### PR TITLE
fix: prevent array mutation during for_each iteration

### DIFF
--- a/integration-tests/fail/errors/E9006_array_modified_during_iteration.ez
+++ b/integration-tests/fail/errors/E9006_array_modified_during_iteration.ez
@@ -1,0 +1,17 @@
+/*
+ * Test: E9006 - Cannot modify array during for_each iteration
+ * Expected: Runtime error when trying to modify array during iteration
+ */
+module main
+
+import & use @std, @arrays
+
+do main() {
+    temp arr [int] = {1, 2, 3, 4, 5}
+    for_each item in arr {
+        println("item: ${item}")
+        if item == 2 {
+            arrays.remove(arr, 0)  // ERROR: cannot modify during iteration
+        }
+    }
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -294,6 +294,7 @@ var (
 	E9003 = ErrorCode{"E9003", "range-step-zero", "range step cannot be zero"}
 	E9004 = ErrorCode{"E9004", "chunk-size-invalid", "chunk size must be greater than zero"}
 	E9005 = ErrorCode{"E9005", "range-invalid-bounds", "range start must be less than or equal to end"}
+	E9006 = ErrorCode{"E9006", "array-modified-during-iteration", "cannot modify array during for_each iteration"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1798,6 +1798,9 @@ func evalForEachStatement(node *ast.ForEachStatement, env *Environment) Object {
 
 	// Handle arrays
 	if arr, ok := collection.(*Array); ok {
+		arr.IteratingCount++
+		defer func() { arr.IteratingCount-- }()
+
 		for _, elem := range arr.Elements {
 			loopEnv.Set(node.Variable.Value, elem, true) // loop vars are mutable
 

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -282,9 +282,15 @@ func (b *Builtin) Inspect() string  { return "builtin function" }
 
 // Array represents an array
 type Array struct {
-	Elements    []Object
-	Mutable     bool
-	ElementType string // Type of array elements (e.g., "int", "Task")
+	Elements       []Object
+	Mutable        bool
+	ElementType    string // Type of array elements (e.g., "int", "Task")
+	IteratingCount int    // Tracks active for_each iterations over this array
+}
+
+// IsIterating returns true if the array is currently being iterated over
+func (a *Array) IsIterating() bool {
+	return a.IteratingCount > 0
 }
 
 func (a *Array) Type() ObjectType { return ARRAY_OBJ }

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -12,6 +12,17 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
+// checkIterating returns an error if the array is being iterated over
+func checkIterating(arr *object.Array, funcName string) *object.Error {
+	if arr.IsIterating() {
+		return &object.Error{
+			Code:    "E9006",
+			Message: fmt.Sprintf("%s() cannot modify array during for_each iteration", funcName),
+		}
+	}
+	return nil
+}
+
 // ArraysBuiltins contains the arrays module functions
 var ArraysBuiltins = map[string]*object.Builtin{
 	"arrays.is_empty": {
@@ -45,6 +56,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.append"); err != nil {
+				return err
+			}
 			arr.Elements = append(arr.Elements, args[1:]...)
 			return object.NIL
 		},
@@ -64,6 +78,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E5007",
 				}
+			}
+			if err := checkIterating(arr, "arrays.unshift"); err != nil {
+				return err
 			}
 			// Prepend elements in-place
 			newElements := make([]object.Object, 0, len(arr.Elements)+len(args)-1)
@@ -88,6 +105,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.insert"); err != nil {
+				return err
 			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
@@ -120,6 +140,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.pop"); err != nil {
+				return err
+			}
 			if len(arr.Elements) == 0 {
 				return &object.Error{Code: "E9001", Message: "arrays.pop() cannot pop from empty array"}
 			}
@@ -143,6 +166,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.shift"); err != nil {
+				return err
 			}
 			if len(arr.Elements) == 0 {
 				return &object.Error{Code: "E9001", Message: "arrays.shift() cannot shift from empty array"}
@@ -195,6 +221,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.remove"); err != nil {
+				return err
+			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.remove() requires an integer index"}
@@ -226,6 +255,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.remove_value"); err != nil {
+				return err
 			}
 			for i, el := range arr.Elements {
 				if objectsEqual(el, args[1]) {
@@ -272,6 +304,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.clear"); err != nil {
+				return err
 			}
 			arr.Elements = []object.Object{}
 			return object.NIL
@@ -345,6 +380,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.set"); err != nil {
+				return err
 			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
@@ -585,6 +623,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.sort"); err != nil {
+				return err
+			}
 			if len(arr.Elements) == 0 {
 				return object.NIL
 			}
@@ -613,6 +654,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.sort_desc"); err != nil {
+				return err
+			}
 			if len(arr.Elements) == 0 {
 				return object.NIL
 			}
@@ -640,6 +684,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.shuffle"); err != nil {
+				return err
 			}
 
 			// Shuffle in-place (Fisher-Yates)
@@ -946,6 +993,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.fill"); err != nil {
+				return err
 			}
 			for i := range arr.Elements {
 				arr.Elements[i] = args[1]


### PR DESCRIPTION
## Summary

- Prevent array mutation during `for_each` iteration
- Add error E9006 when mutation is attempted
- Protect 13 mutating array functions

## Problem

Modifying an array during `for_each` iteration caused silent data corruption - items were skipped and/or duplicated because the iterator index wasn't adjusted when elements were removed.

## Solution

Added `IteratingCount` field to Array struct that tracks active iterations. All mutating array functions now check this count and raise `E9006` if modification is attempted during iteration.

**Protected functions:**
- `arrays.append`, `arrays.unshift`, `arrays.insert`
- `arrays.pop`, `arrays.shift`
- `arrays.remove`, `arrays.remove_value`, `arrays.clear`
- `arrays.set`, `arrays.sort`, `arrays.sort_desc`
- `arrays.shuffle`, `arrays.fill`

## Test plan

- [x] Integration test for E9006 error
- [x] Edge cases tested:
  - Function that modifies array during iteration → ERROR
  - Modify different array during iteration → allowed
  - Nested loops (both arrays protected)
  - Modify after loop ends / break / return → allowed
- [x] All existing tests pass (312/313, 1 pre-existing failure)

Fixes #796