### PR TITLE
fix: mutable parameters now work with indexed/member expressions

### DIFF
--- a/integration-tests/pass/core/mutable-indexed-params.ez
+++ b/integration-tests/pass/core/mutable-indexed-params.ez
@@ -1,0 +1,75 @@
+/*
+ * Test: Mutable parameters with indexed/member expressions
+ * Tests fix for issue #797: Mutable parameters silently fail for indexed/member expressions
+ */
+module main
+
+import & use @std
+
+const Point struct {
+    x int
+    y int
+}
+
+do modify_int(&x int) {
+    x = 999
+}
+
+do increment(&x int) {
+    x += 1
+}
+
+do main() {
+    println("=== Mutable Indexed/Member Expression Tests ===")
+
+    // Test 1: Array element
+    temp arr [int] = {1, 2, 3}
+    modify_int(arr[0])
+    if arr[0] != 999 {
+        panic("FAIL: arr[0] should be 999")
+    }
+    println("Test 1 PASS: Array element mutation works")
+
+    // Test 2: Array element with compound assignment
+    temp arr2 [int] = {10, 20, 30}
+    increment(arr2[1])
+    if arr2[1] != 21 {
+        panic("FAIL: arr2[1] should be 21")
+    }
+    println("Test 2 PASS: Array element compound assignment works")
+
+    // Test 3: Struct field
+    temp p Point = Point{x: 10, y: 20}
+    modify_int(p.x)
+    if p.x != 999 {
+        panic("FAIL: p.x should be 999")
+    }
+    println("Test 3 PASS: Struct field mutation works")
+
+    // Test 4: Struct field with compound assignment
+    temp p2 Point = Point{x: 5, y: 15}
+    increment(p2.y)
+    if p2.y != 16 {
+        panic("FAIL: p2.y should be 16")
+    }
+    println("Test 4 PASS: Struct field compound assignment works")
+
+    // Test 5: Map value
+    temp m map[string:int] = {"a": 1, "b": 2}
+    modify_int(m["a"])
+    if m["a"] != 999 {
+        panic("FAIL: m[\"a\"] should be 999")
+    }
+    println("Test 5 PASS: Map value mutation works")
+
+    // Test 6: Map value with compound assignment
+    temp m2 map[string:int] = {"x": 100}
+    increment(m2["x"])
+    if m2["x"] != 101 {
+        panic("FAIL: m2[\"x\"] should be 101")
+    }
+    println("Test 6 PASS: Map value compound assignment works")
+
+    println("")
+    println("=== All Tests PASSED ===")
+}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2559,11 +2559,55 @@ func evalArgsWithReferences(argExprs []ast.Expression, params []*ast.Parameter, 
 	args := make([]Object, len(argExprs))
 
 	for i, argExpr := range argExprs {
-		// Check if this parameter is mutable and the argument is a variable
+		// Check if this parameter is mutable
 		if i < len(params) && params[i].Mutable {
+			// Simple variable reference
 			if label, ok := argExpr.(*ast.Label); ok {
-				// Create a reference to the original variable
 				args[i] = &Reference{Env: env, Name: label.Value}
+				continue
+			}
+
+			// Indexed expression (arr[i], map[k])
+			if indexExpr, ok := argExpr.(*ast.IndexExpression); ok {
+				container := Eval(indexExpr.Left, env)
+				if isError(container) {
+					return []Object{container}
+				}
+				index := Eval(indexExpr.Index, env)
+				if isError(index) {
+					return []Object{index}
+				}
+				// Get the variable name for display
+				varName := ""
+				if label, ok := indexExpr.Left.(*ast.Label); ok {
+					varName = label.Value
+				}
+				args[i] = &Reference{
+					Env:       env,
+					Name:      varName,
+					Container: container,
+					Index:     index,
+				}
+				continue
+			}
+
+			// Member expression (s.field)
+			if memberExpr, ok := argExpr.(*ast.MemberExpression); ok {
+				container := Eval(memberExpr.Object, env)
+				if isError(container) {
+					return []Object{container}
+				}
+				// Get the variable name for display
+				varName := ""
+				if label, ok := memberExpr.Object.(*ast.Label); ok {
+					varName = label.Value
+				}
+				args[i] = &Reference{
+					Env:       env,
+					Name:      varName,
+					Container: container,
+					Field:     memberExpr.Member.Value,
+				}
 				continue
 			}
 		}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -166,14 +166,78 @@ func (fh *FileHandle) Inspect() string {
 type Reference struct {
 	Env  *Environment // The environment where the original variable lives
 	Name string       // The variable name in that environment
+
+	// For indexed expressions (arr[i], map[k]) - Container and Index are set
+	Container Object // The array/map object (nil for simple variable references)
+	Index     Object // The index/key for array/map access
+
+	// For member expressions (s.field) - Container and Field are set
+	Field string // The field name for struct access
 }
 
 func (r *Reference) Type() ObjectType { return REFERENCE_OBJ }
-func (r *Reference) Inspect() string  { return fmt.Sprintf("<ref %s>", r.Name) }
+func (r *Reference) Inspect() string {
+	if r.Container != nil && r.Field != "" {
+		return fmt.Sprintf("<ref %s.%s>", r.Name, r.Field)
+	}
+	if r.Container != nil && r.Index != nil {
+		return fmt.Sprintf("<ref %s[%s]>", r.Name, r.Index.Inspect())
+	}
+	return fmt.Sprintf("<ref %s>", r.Name)
+}
 
 // Deref returns the current value of the referenced variable
 // Recursively dereferences if the target is also a Reference (for nested mutable param forwarding)
 func (r *Reference) Deref() (Object, bool) {
+	// Handle indexed references (arr[i], map[k])
+	if r.Container != nil && r.Index != nil {
+		switch container := r.Container.(type) {
+		case *Array:
+			if idx, ok := r.Index.(*Integer); ok {
+				i := int(idx.Value.Int64())
+				if i >= 0 && i < len(container.Elements) {
+					val := container.Elements[i]
+					// Chase through nested references
+					if ref, isRef := val.(*Reference); isRef {
+						return ref.Deref()
+					}
+					return val, true
+				}
+			}
+			return nil, false
+		case *Map:
+			hash, ok := HashKey(r.Index)
+			if !ok {
+				return nil, false
+			}
+			if idx, ok := container.Index[hash]; ok {
+				val := container.Pairs[idx].Value
+				// Chase through nested references
+				if ref, isRef := val.(*Reference); isRef {
+					return ref.Deref()
+				}
+				return val, true
+			}
+			return nil, false
+		}
+		return nil, false
+	}
+
+	// Handle member references (s.field)
+	if r.Container != nil && r.Field != "" {
+		if structObj, ok := r.Container.(*Struct); ok {
+			if val, ok := structObj.Fields[r.Field]; ok {
+				// Chase through nested references
+				if ref, isRef := val.(*Reference); isRef {
+					return ref.Deref()
+				}
+				return val, true
+			}
+		}
+		return nil, false
+	}
+
+	// Handle simple variable references
 	val, ok := r.Env.Get(r.Name)
 	if !ok {
 		return nil, false
@@ -188,6 +252,44 @@ func (r *Reference) Deref() (Object, bool) {
 // SetValue updates the referenced variable's value
 // Traverses the scope chain to find and update the variable
 func (r *Reference) SetValue(val Object) bool {
+	// Handle indexed references (arr[i], map[k])
+	if r.Container != nil && r.Index != nil {
+		switch container := r.Container.(type) {
+		case *Array:
+			if idx, ok := r.Index.(*Integer); ok {
+				i := int(idx.Value.Int64())
+				if i >= 0 && i < len(container.Elements) {
+					container.Elements[i] = val
+					return true
+				}
+			}
+			return false
+		case *Map:
+			hash, ok := HashKey(r.Index)
+			if !ok {
+				return false
+			}
+			if idx, ok := container.Index[hash]; ok {
+				container.Pairs[idx].Value = val
+				return true
+			}
+			return false
+		}
+		return false
+	}
+
+	// Handle member references (s.field)
+	if r.Container != nil && r.Field != "" {
+		if structObj, ok := r.Container.(*Struct); ok {
+			if _, ok := structObj.Fields[r.Field]; ok {
+				structObj.Fields[r.Field] = val
+				return true
+			}
+		}
+		return false
+	}
+
+	// Handle simple variable references
 	return r.Env.updateRef(r.Name, val)
 }
 


### PR DESCRIPTION
## Summary

- Fix mutable parameters for indexed/member expressions
- Array elements, struct fields, and map values can now be passed to `&` parameters

## Problem

Passing `arr[0]`, `p.x`, or `m["key"]` to mutable (`&`) parameters would silently discard mutations. The code would compile and run, but the original container was never modified.

## Solution

Extended the `Reference` type to support:
- **Array elements**: Stores container array + index
- **Struct fields**: Stores container struct + field name  
- **Map values**: Stores container map + key

The `Deref()` and `SetValue()` methods now handle these cases, properly reading from and writing to the container elements.

## Test plan

- [x] Integration test `integration-tests/pass/core/mutable-indexed-params.ez`
- [x] Tests array elements, struct fields, map values
- [x] Tests compound assignment (`+=`) through references
- [x] All existing tests pass (312/313, 1 pre-existing failure)

Fixes #797