### PR TITLE
Bugfixes 12-24-2025

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -276,6 +276,7 @@ Array-specific errors
 | E9003 | range-step-zero | range step cannot be zero |
 | E9004 | chunk-size-invalid | chunk size must be greater than zero |
 | E9005 | range-invalid-bounds | range start must be less than or equal to end |
+| E9006 | array-modified-during-iteration | cannot modify array during for_each iteration |
 
 ## String Errors (E10xxx)
 
@@ -369,4 +370,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 240 error/warning codes
+**Total:** 246 error/warning codes

--- a/integration-tests/fail/errors/E9006_array_modified_during_iteration.ez
+++ b/integration-tests/fail/errors/E9006_array_modified_during_iteration.ez
@@ -1,0 +1,17 @@
+/*
+ * Test: E9006 - Cannot modify array during for_each iteration
+ * Expected: Runtime error when trying to modify array during iteration
+ */
+module main
+
+import & use @std, @arrays
+
+do main() {
+    temp arr [int] = {1, 2, 3, 4, 5}
+    for_each item in arr {
+        println("item: ${item}")
+        if item == 2 {
+            arrays.remove(arr, 0)  // ERROR: cannot modify during iteration
+        }
+    }
+}

--- a/integration-tests/pass/core/mutable-indexed-params.ez
+++ b/integration-tests/pass/core/mutable-indexed-params.ez
@@ -1,0 +1,75 @@
+/*
+ * Test: Mutable parameters with indexed/member expressions
+ * Tests fix for issue #797: Mutable parameters silently fail for indexed/member expressions
+ */
+module main
+
+import & use @std
+
+const Point struct {
+    x int
+    y int
+}
+
+do modify_int(&x int) {
+    x = 999
+}
+
+do increment(&x int) {
+    x += 1
+}
+
+do main() {
+    println("=== Mutable Indexed/Member Expression Tests ===")
+
+    // Test 1: Array element
+    temp arr [int] = {1, 2, 3}
+    modify_int(arr[0])
+    if arr[0] != 999 {
+        panic("FAIL: arr[0] should be 999")
+    }
+    println("Test 1 PASS: Array element mutation works")
+
+    // Test 2: Array element with compound assignment
+    temp arr2 [int] = {10, 20, 30}
+    increment(arr2[1])
+    if arr2[1] != 21 {
+        panic("FAIL: arr2[1] should be 21")
+    }
+    println("Test 2 PASS: Array element compound assignment works")
+
+    // Test 3: Struct field
+    temp p Point = Point{x: 10, y: 20}
+    modify_int(p.x)
+    if p.x != 999 {
+        panic("FAIL: p.x should be 999")
+    }
+    println("Test 3 PASS: Struct field mutation works")
+
+    // Test 4: Struct field with compound assignment
+    temp p2 Point = Point{x: 5, y: 15}
+    increment(p2.y)
+    if p2.y != 16 {
+        panic("FAIL: p2.y should be 16")
+    }
+    println("Test 4 PASS: Struct field compound assignment works")
+
+    // Test 5: Map value
+    temp m map[string:int] = {"a": 1, "b": 2}
+    modify_int(m["a"])
+    if m["a"] != 999 {
+        panic("FAIL: m[\"a\"] should be 999")
+    }
+    println("Test 5 PASS: Map value mutation works")
+
+    // Test 6: Map value with compound assignment
+    temp m2 map[string:int] = {"x": 100}
+    increment(m2["x"])
+    if m2["x"] != 101 {
+        panic("FAIL: m2[\"x\"] should be 101")
+    }
+    println("Test 6 PASS: Map value compound assignment works")
+
+    println("")
+    println("=== All Tests PASSED ===")
+}

--- a/integration-tests/pass/multi-file/user-module-type-inference/main.ez
+++ b/integration-tests/pass/multi-file/user-module-type-inference/main.ez
@@ -1,0 +1,48 @@
+/*
+ * main.ez - Test type inference for user-defined module function return types
+ *
+ * Tests issue #807: Type inference fails for user-defined module function return types
+ */
+module main
+
+import & use @std
+import & use lib"./mylib"
+
+do needs_u64(v u64) {
+    println("Got u64: ${v}")
+}
+
+do needs_string(s string) {
+    println("Got string: ${s}")
+}
+
+do needs_float(f float) {
+    println("Got float: ${f}")
+}
+
+do main() {
+    println("========================================")
+    println("  User Module Type Inference Test")
+    println("========================================")
+    println("")
+
+    // Test 1: Type inference from user module function returning u64
+    temp val = lib.get_value()  // Type should be inferred as u64
+    needs_u64(val)              // Should work without explicit type
+    println("Test 1 PASSED: u64 type inference")
+
+    // Test 2: Type inference from user module function returning string
+    temp str = lib.get_string()  // Type should be inferred as string
+    needs_string(str)
+    println("Test 2 PASSED: string type inference")
+
+    // Test 3: Type inference from user module function returning float
+    temp flt = lib.get_float()  // Type should be inferred as float
+    needs_float(flt)
+    println("Test 3 PASSED: float type inference")
+
+    println("")
+    println("========================================")
+    println("  All Tests PASSED!")
+    println("========================================")
+}

--- a/integration-tests/pass/multi-file/user-module-type-inference/mylib.ez
+++ b/integration-tests/pass/multi-file/user-module-type-inference/mylib.ez
@@ -1,0 +1,16 @@
+/*
+ * mylib.ez - Test module for type inference from user-defined modules
+ */
+module mylib
+
+do get_value() -> u64 {
+    return 42
+}
+
+do get_string() -> string {
+    return "hello"
+}
+
+do get_float() -> float {
+    return 3.14
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -294,6 +294,7 @@ var (
 	E9003 = ErrorCode{"E9003", "range-step-zero", "range step cannot be zero"}
 	E9004 = ErrorCode{"E9004", "chunk-size-invalid", "chunk size must be greater than zero"}
 	E9005 = ErrorCode{"E9005", "range-invalid-bounds", "range start must be less than or equal to end"}
+	E9006 = ErrorCode{"E9006", "array-modified-during-iteration", "cannot modify array during for_each iteration"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1798,6 +1798,9 @@ func evalForEachStatement(node *ast.ForEachStatement, env *Environment) Object {
 
 	// Handle arrays
 	if arr, ok := collection.(*Array); ok {
+		arr.IteratingCount++
+		defer func() { arr.IteratingCount-- }()
+
 		for _, elem := range arr.Elements {
 			loopEnv.Set(node.Variable.Value, elem, true) // loop vars are mutable
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2559,11 +2559,55 @@ func evalArgsWithReferences(argExprs []ast.Expression, params []*ast.Parameter, 
 	args := make([]Object, len(argExprs))
 
 	for i, argExpr := range argExprs {
-		// Check if this parameter is mutable and the argument is a variable
+		// Check if this parameter is mutable
 		if i < len(params) && params[i].Mutable {
+			// Simple variable reference
 			if label, ok := argExpr.(*ast.Label); ok {
-				// Create a reference to the original variable
 				args[i] = &Reference{Env: env, Name: label.Value}
+				continue
+			}
+
+			// Indexed expression (arr[i], map[k])
+			if indexExpr, ok := argExpr.(*ast.IndexExpression); ok {
+				container := Eval(indexExpr.Left, env)
+				if isError(container) {
+					return []Object{container}
+				}
+				index := Eval(indexExpr.Index, env)
+				if isError(index) {
+					return []Object{index}
+				}
+				// Get the variable name for display
+				varName := ""
+				if label, ok := indexExpr.Left.(*ast.Label); ok {
+					varName = label.Value
+				}
+				args[i] = &Reference{
+					Env:       env,
+					Name:      varName,
+					Container: container,
+					Index:     index,
+				}
+				continue
+			}
+
+			// Member expression (s.field)
+			if memberExpr, ok := argExpr.(*ast.MemberExpression); ok {
+				container := Eval(memberExpr.Object, env)
+				if isError(container) {
+					return []Object{container}
+				}
+				// Get the variable name for display
+				varName := ""
+				if label, ok := memberExpr.Object.(*ast.Label); ok {
+					varName = label.Value
+				}
+				args[i] = &Reference{
+					Env:       env,
+					Name:      varName,
+					Container: container,
+					Field:     memberExpr.Member.Value,
+				}
 				continue
 			}
 		}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -282,9 +282,15 @@ func (b *Builtin) Inspect() string  { return "builtin function" }
 
 // Array represents an array
 type Array struct {
-	Elements    []Object
-	Mutable     bool
-	ElementType string // Type of array elements (e.g., "int", "Task")
+	Elements       []Object
+	Mutable        bool
+	ElementType    string // Type of array elements (e.g., "int", "Task")
+	IteratingCount int    // Tracks active for_each iterations over this array
+}
+
+// IsIterating returns true if the array is currently being iterated over
+func (a *Array) IsIterating() bool {
+	return a.IteratingCount > 0
 }
 
 func (a *Array) Type() ObjectType { return ARRAY_OBJ }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -166,14 +166,78 @@ func (fh *FileHandle) Inspect() string {
 type Reference struct {
 	Env  *Environment // The environment where the original variable lives
 	Name string       // The variable name in that environment
+
+	// For indexed expressions (arr[i], map[k]) - Container and Index are set
+	Container Object // The array/map object (nil for simple variable references)
+	Index     Object // The index/key for array/map access
+
+	// For member expressions (s.field) - Container and Field are set
+	Field string // The field name for struct access
 }
 
 func (r *Reference) Type() ObjectType { return REFERENCE_OBJ }
-func (r *Reference) Inspect() string  { return fmt.Sprintf("<ref %s>", r.Name) }
+func (r *Reference) Inspect() string {
+	if r.Container != nil && r.Field != "" {
+		return fmt.Sprintf("<ref %s.%s>", r.Name, r.Field)
+	}
+	if r.Container != nil && r.Index != nil {
+		return fmt.Sprintf("<ref %s[%s]>", r.Name, r.Index.Inspect())
+	}
+	return fmt.Sprintf("<ref %s>", r.Name)
+}
 
 // Deref returns the current value of the referenced variable
 // Recursively dereferences if the target is also a Reference (for nested mutable param forwarding)
 func (r *Reference) Deref() (Object, bool) {
+	// Handle indexed references (arr[i], map[k])
+	if r.Container != nil && r.Index != nil {
+		switch container := r.Container.(type) {
+		case *Array:
+			if idx, ok := r.Index.(*Integer); ok {
+				i := int(idx.Value.Int64())
+				if i >= 0 && i < len(container.Elements) {
+					val := container.Elements[i]
+					// Chase through nested references
+					if ref, isRef := val.(*Reference); isRef {
+						return ref.Deref()
+					}
+					return val, true
+				}
+			}
+			return nil, false
+		case *Map:
+			hash, ok := HashKey(r.Index)
+			if !ok {
+				return nil, false
+			}
+			if idx, ok := container.Index[hash]; ok {
+				val := container.Pairs[idx].Value
+				// Chase through nested references
+				if ref, isRef := val.(*Reference); isRef {
+					return ref.Deref()
+				}
+				return val, true
+			}
+			return nil, false
+		}
+		return nil, false
+	}
+
+	// Handle member references (s.field)
+	if r.Container != nil && r.Field != "" {
+		if structObj, ok := r.Container.(*Struct); ok {
+			if val, ok := structObj.Fields[r.Field]; ok {
+				// Chase through nested references
+				if ref, isRef := val.(*Reference); isRef {
+					return ref.Deref()
+				}
+				return val, true
+			}
+		}
+		return nil, false
+	}
+
+	// Handle simple variable references
 	val, ok := r.Env.Get(r.Name)
 	if !ok {
 		return nil, false
@@ -188,6 +252,44 @@ func (r *Reference) Deref() (Object, bool) {
 // SetValue updates the referenced variable's value
 // Traverses the scope chain to find and update the variable
 func (r *Reference) SetValue(val Object) bool {
+	// Handle indexed references (arr[i], map[k])
+	if r.Container != nil && r.Index != nil {
+		switch container := r.Container.(type) {
+		case *Array:
+			if idx, ok := r.Index.(*Integer); ok {
+				i := int(idx.Value.Int64())
+				if i >= 0 && i < len(container.Elements) {
+					container.Elements[i] = val
+					return true
+				}
+			}
+			return false
+		case *Map:
+			hash, ok := HashKey(r.Index)
+			if !ok {
+				return false
+			}
+			if idx, ok := container.Index[hash]; ok {
+				container.Pairs[idx].Value = val
+				return true
+			}
+			return false
+		}
+		return false
+	}
+
+	// Handle member references (s.field)
+	if r.Container != nil && r.Field != "" {
+		if structObj, ok := r.Container.(*Struct); ok {
+			if _, ok := structObj.Fields[r.Field]; ok {
+				structObj.Fields[r.Field] = val
+				return true
+			}
+		}
+		return false
+	}
+
+	// Handle simple variable references
 	return r.Env.updateRef(r.Name, val)
 }
 

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -12,6 +12,17 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
+// checkIterating returns an error if the array is being iterated over
+func checkIterating(arr *object.Array, funcName string) *object.Error {
+	if arr.IsIterating() {
+		return &object.Error{
+			Code:    "E9006",
+			Message: fmt.Sprintf("%s() cannot modify array during for_each iteration", funcName),
+		}
+	}
+	return nil
+}
+
 // ArraysBuiltins contains the arrays module functions
 var ArraysBuiltins = map[string]*object.Builtin{
 	"arrays.is_empty": {
@@ -45,6 +56,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.append"); err != nil {
+				return err
+			}
 			arr.Elements = append(arr.Elements, args[1:]...)
 			return object.NIL
 		},
@@ -64,6 +78,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E5007",
 				}
+			}
+			if err := checkIterating(arr, "arrays.unshift"); err != nil {
+				return err
 			}
 			// Prepend elements in-place
 			newElements := make([]object.Object, 0, len(arr.Elements)+len(args)-1)
@@ -88,6 +105,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.insert"); err != nil {
+				return err
 			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
@@ -120,6 +140,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.pop"); err != nil {
+				return err
+			}
 			if len(arr.Elements) == 0 {
 				return &object.Error{Code: "E9001", Message: "arrays.pop() cannot pop from empty array"}
 			}
@@ -143,6 +166,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.shift"); err != nil {
+				return err
 			}
 			if len(arr.Elements) == 0 {
 				return &object.Error{Code: "E9001", Message: "arrays.shift() cannot shift from empty array"}
@@ -195,6 +221,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.remove"); err != nil {
+				return err
+			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
 				return &object.Error{Code: "E7004", Message: "arrays.remove() requires an integer index"}
@@ -226,6 +255,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.remove_value"); err != nil {
+				return err
 			}
 			for i, el := range arr.Elements {
 				if objectsEqual(el, args[1]) {
@@ -272,6 +304,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.clear"); err != nil {
+				return err
 			}
 			arr.Elements = []object.Object{}
 			return object.NIL
@@ -345,6 +380,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.set"); err != nil {
+				return err
 			}
 			idx, ok := args[1].(*object.Integer)
 			if !ok {
@@ -585,6 +623,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.sort"); err != nil {
+				return err
+			}
 			if len(arr.Elements) == 0 {
 				return object.NIL
 			}
@@ -613,6 +654,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Code:    "E4005",
 				}
 			}
+			if err := checkIterating(arr, "arrays.sort_desc"); err != nil {
+				return err
+			}
 			if len(arr.Elements) == 0 {
 				return object.NIL
 			}
@@ -640,6 +684,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.shuffle"); err != nil {
+				return err
 			}
 
 			// Shuffle in-place (Fisher-Yates)
@@ -946,6 +993,9 @@ var ArraysBuiltins = map[string]*object.Builtin{
 					Message: "cannot modify immutable array (declared as const)",
 					Code:    "E4005",
 				}
+			}
+			if err := checkIterating(arr, "arrays.fill"); err != nil {
+				return err
 			}
 			for i := range arr.Elements {
 				arr.Elements[i] = args[1]

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4725,6 +4725,13 @@ func (tc *TypeChecker) inferModuleCallType(member *ast.MemberExpression, args []
 	case "time":
 		return tc.inferTimeCallType(funcName, args)
 	default:
+		// Check user-defined modules
+		if sig, ok := tc.GetModuleFunction(moduleName, funcName); ok {
+			if len(sig.ReturnTypes) >= 1 {
+				return sig.ReturnTypes[0], true
+			}
+			return "void", true
+		}
 		return "", false
 	}
 }


### PR DESCRIPTION
## Summary

This PR includes 3 bug fixes:

### 1. Type inference for user-defined module function return types (#807)
- Fixed `inferModuleCallType()` to handle user-defined modules
- Variables now correctly infer types from user module function calls

### 2. Prevent array mutation during for_each iteration (#796)
- Added `IteratingCount` to track active iterations
- 13 mutating array functions now raise `E9006` if called during iteration
- Prevents silent data corruption from skipped/duplicated items

### 3. Mutable parameters work with indexed/member expressions (#797)
- Extended `Reference` type to support array elements, struct fields, and map values
- `modify(&arr[0])`, `modify(&p.x)`, `modify(&m["key"])` now work correctly

## Test plan

- [x] All existing integration tests pass (312/313, 1 pre-existing db failure)
- [x] All Go unit tests pass
- [x] New integration tests added for each fix

## Issues Fixed

- Fixes #807
- Fixes #796
- Fixes #797