### PR TITLE
fix: prevent panic on multi-return type mismatch (#816)

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1896,16 +1896,18 @@ func (tc *TypeChecker) checkMultiReturnDeclaration(decl *ast.VariableDeclaration
 		returnType := funcSig.ReturnTypes[i]
 
 		if !tc.typesCompatible(declaredType, returnType) {
-			// Get position from the variable name at this index
+			// Get position and name from the variable at this index
 			line, col := 0, 0
+			varName := "<unknown>"
 			if i < len(decl.Names) && decl.Names[i] != nil {
+				varName = decl.Names[i].Value
 				line = decl.Names[i].Token.Line
 				col = decl.Names[i].Token.Column
 			}
 			tc.addError(
 				errors.E3001,
 				fmt.Sprintf("type mismatch in multi-return: variable '%s' declared as %s but function returns %s",
-					decl.Names[i].Value, declaredType, returnType),
+					varName, declaredType, returnType),
 				line,
 				col,
 			)


### PR DESCRIPTION
## Summary

- Add bounds checking before accessing `decl.Names[i].Value` in the error message
- Use `"<unknown>"` fallback for variable name when index is out of bounds
- Consistent with how line/column info was already being handled

## Test plan

- [x] All typechecker tests pass
- [x] All integration tests pass (except unrelated db test - known issue #800)
- [x] Verified type mismatch errors still report correctly

Fixes #816