### PR TITLE
fix: prevent `json.encode()` from overwriting EncodeAsString conversion (#818)

### DIFF
--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -270,9 +270,12 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 						m[tag.Name] = v.Inspect()
 					case *object.Float:
 						m[tag.Name] = v.Inspect()
+					default:
+						m[tag.Name] = goVal
 					}
+				} else {
+					m[tag.Name] = goVal
 				}
-				m[tag.Name] = goVal
 			default:
 				m[key] = goVal
 			}


### PR DESCRIPTION
## Summary

When `EncodeAsString` JSON tag was set, the string conversion for integers and floats (lines 270, 272) was immediately overwritten by line 275 which unconditionally assigned the original value.

Fix by restructuring to use if/else:
- If `EncodeAsString`: convert integers/floats to string via `Inspect()`, use `goVal` for other types
- If not `EncodeAsString`: use `goVal` directly

## Test plan

- [x] All JSON tests pass
- [x] All unit tests pass

Fixes #818