### PR TITLE
fix: properly extract first rune in `strings.from_chars()` (#819)

### DIFF
--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -453,7 +453,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 					runes[i] = v.Value
 				case *object.String:
 					if len(v.Value) > 0 {
-						runes[i] = rune(v.Value[0])
+						runes[i] = []rune(v.Value)[0]
 					}
 				default:
 					return &object.Error{Code: "E7003", Message: "strings.from_chars() requires an array of chars"}


### PR DESCRIPTION
## Summary

Changed `rune(v.Value[0])` to `[]rune(v.Value)[0]` to correctly extract the first Unicode code point instead of just the first byte.

The old code would corrupt multi-byte UTF-8 characters (e.g., Chinese, emoji) by only taking the first byte of the UTF-8 sequence.

## Test plan

- [x] All unit tests pass

Fixes #819