### PR TITLE
fix: make `arrays.remove_all()` consistent with other remove functions (#820)

### DIFF
--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -271,6 +271,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// arrays.remove_all(arr, value) - Removes ALL occurrences of the specified VALUE.
+	// Modifies array in-place, returns NIL.
 	"arrays.remove_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -280,13 +282,23 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7002", Message: "arrays.remove_all() requires an array"}
 			}
+			if !arr.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable array (declared as const)",
+					Code:    "E4005",
+				}
+			}
+			if err := checkIterating(arr, "arrays.remove_all"); err != nil {
+				return err
+			}
 			newElements := []object.Object{}
 			for _, el := range arr.Elements {
 				if !objectsEqual(el, args[1]) {
 					newElements = append(newElements, el)
 				}
 			}
-			return &object.Array{Elements: newElements}
+			arr.Elements = newElements
+			return object.NIL
 		},
 	},
 


### PR DESCRIPTION
## Summary

Made `arrays.remove_all()` consistent with `arrays.remove()` and `arrays.remove_value()`:

- Add mutability check (error on const arrays)
- Add iteration check (error if array is being iterated)
- Modify array in-place instead of returning new array
- Return NIL instead of new array

## Test plan

- [x] All unit tests pass

Fixes #820