### PR TITLE
fix: add overflow and division-by-zero checks for float arithmetic (#798)

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2232,14 +2232,32 @@ func evalFloatInfixExpression(operator string, left, right Object, line, col int
 
 	switch operator {
 	case "+":
-		return &Float{Value: leftVal + rightVal}
+		result := leftVal + rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5005", line, col, "float overflow: %v + %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "-":
-		return &Float{Value: leftVal - rightVal}
+		result := leftVal - rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5006", line, col, "float overflow: %v - %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "*":
-		return &Float{Value: leftVal * rightVal}
+		result := leftVal * rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5007", line, col, "float overflow: %v * %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "/":
-		// Float division by zero returns +Inf, -Inf, or NaN per IEEE 754
-		return &Float{Value: leftVal / rightVal}
+		if rightVal == 0 {
+			return newErrorWithLocation("E5001", line, col, "division by zero")
+		}
+		result := leftVal / rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5007", line, col, "float overflow: %v / %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "<":
 		return nativeBoolToBooleanObject(leftVal < rightVal)
 	case ">":


### PR DESCRIPTION
## Summary

Float operations now error instead of silently producing infinity:

- Addition/subtraction/multiplication: error if result is `+Inf` or `-Inf`
- Division: error if divisor is zero (E5001)
- Division: error if result overflows to infinity (E5007)

Uses `math.IsInf()` to detect infinity results. Consistent with how integer and byte overflow is already handled.

## Test plan

- [x] All unit tests pass
- [x] Manually verified:
  - `1.0e308 * 10.0` → E5007 float overflow error
  - `1.0 / 0.0` → E5001 division by zero error

Fixes #798