### PR TITLE
fix: os.exec now returns error on non-zero exit code (#799)

### DIFF
--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -427,6 +427,11 @@ var OSBuiltins = map[string]*object.Builtin{
 			if err != nil {
 				if exitErr, ok := err.(*exec.ExitError); ok {
 					exitCode = int64(exitErr.ExitCode())
+					// Command ran but returned non-zero exit code - return error for consistency with os.exec_output
+					return &object.ReturnValue{Values: []object.Object{
+						&object.Integer{Value: big.NewInt(exitCode)},
+						createOSError("E7031", fmt.Sprintf("command exited with code %d", exitCode)),
+					}}
 				} else {
 					// Command failed to start entirely
 					return &object.ReturnValue{Values: []object.Object{

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -623,9 +623,9 @@ func TestOSExec(t *testing.T) {
 			t.Errorf("expected exit code 42, got %s", exitCode.Value.String())
 		}
 
-		// Error should still be nil for non-zero exit
-		if rv.Values[1] != object.NIL {
-			t.Errorf("expected nil error for non-zero exit, got %T", rv.Values[1])
+		// Error should be returned for non-zero exit (consistent with os.exec_output)
+		if rv.Values[1] == object.NIL {
+			t.Errorf("expected error for non-zero exit, got nil")
 		}
 	})
 


### PR DESCRIPTION
## Summary

Made `os.exec` consistent with `os.exec_output` - both now return an error when the command exits with a non-zero status.

Previously `os.exec` would return `(exit_code, nil)` for failed commands, while `os.exec_output` would return `(output, error)`. This inconsistency meant users could not rely on checking `err != nil` across `os.*` functions.

Now both functions return an error (E7031) when the command fails.

## Test plan

- [x] All unit tests pass (updated test to expect error on non-zero exit)

Fixes #799