### PR TITLE
fix: add cleanup for database test files (#800)

### DIFF
--- a/integration-tests/pass/stdlib/db.ez
+++ b/integration-tests/pass/stdlib/db.ez
@@ -2,7 +2,7 @@
  * db.ez - Test @db standard library with PROPER ASSERTIONS
  */
 
-import @std, @db, @json
+import @std, @db, @json, @io
 using std
 
 const User struct {
@@ -394,4 +394,9 @@ do main() {
     } otherwise {
         println("ALL TESTS PASSED")
     }
+
+    // Cleanup test database files
+    temp _, cleanup_err1 = io.remove("mydb.ezdb")
+    temp _, cleanup_err2 = io.remove("rename_test.ezdb")
+    temp _, cleanup_err3 = io.remove("sort_test.ezdb")
 }

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -126,6 +126,9 @@ for test_file in "$SCRIPT_DIR"/fail/errors/*.ez; do
     fi
 done
 
+# Cleanup any .ezdb files created by error tests (they are created in cwd, not the test directory)
+rm -f ./*.ezdb
+
 # Multi-file error tests (single files)
 for test_file in "$SCRIPT_DIR"/fail/multi-file/*.ez; do
     if [ -f "$test_file" ]; then


### PR DESCRIPTION
## Summary
- Add cleanup in `db.ez` to remove `.ezdb` files after tests complete
- Add cleanup in `run_tests.sh` to remove any `.ezdb` files created by fail tests

Fixes #800