### PR TITLE
fix: add cleanup for database test files (#800)

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -77,6 +77,12 @@ jobs:
                 continue
               fi
 
+              # Allow shell scripts (they report as "executable" but are text files)
+              if [[ "$file" =~ \.sh$ ]]; then
+                echo "Allowed shell script: $file"
+                continue
+              fi
+
               # Reject executables and archives
               if file "$file" | grep -qE "executable|binary|archive|compressed"; then
                 echo "::error::Binary/executable file detected: $file"

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -126,6 +126,9 @@ for test_file in "$SCRIPT_DIR"/fail/errors/*.ez; do
     fi
 done
 
+# Cleanup any .ezdb files created by error tests (they are created in cwd, not the test directory)
+rm -f ./*.ezdb
+
 # Multi-file error tests (single files)
 for test_file in "$SCRIPT_DIR"/fail/multi-file/*.ez; do
     if [ -f "$test_file" ]; then


### PR DESCRIPTION
## Summary
- Add cleanup in `run_tests.sh` to remove any `.ezdb` files created by fail tests
- Update sanity check workflow to allow `.sh` files (they were incorrectly flagged as binaries)

Fixes #800