### PR TITLE
fix: #suppress before function now correctly applies to function only (#830, #831)

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -86,7 +86,7 @@ Syntax and parsing errors
 | E2048 | when-bool-condition | when condition cannot be a boolean. Use if/or/otherwise instead |
 | E2049 | when-nil-condition | when condition cannot be nil. Use if/otherwise to check for nil |
 | E2050 | when-collection-condition | when condition cannot be an array or map |
-| E2051 | suppress-invalid-target | #suppress can only be applied to function declarations |
+| E2051 | suppress-invalid-target | #suppress can only be applied at file scope or to function declarations |
 | E2052 | suppress-invalid-code | warning code cannot be suppressed |
 | E2053 | type-definition-in-function | type definitions must be at file level |
 | E2054 | when-strict-non-enum-case | #strict when requires explicit enum member values in cases |

--- a/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
+++ b/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
@@ -1,13 +1,21 @@
 /*
  * Error Test: E2051 - suppress-invalid-target
- * Expected: "#suppress can only be applied to function declarations"
+ * Expected: "#suppress can only be applied at file scope or to function declarations"
  */
 
 module main
 
+import @std
+using std
+
+do helper() {
+    println("helper")
+}
+
 #suppress(W1001)
-const x = 5  // #suppress on variable declaration is not allowed
+const x = 5  // #suppress on variable declaration is not allowed (after a function)
 
 do main() {
+    helper()
     println(x)
 }

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -87,7 +87,7 @@ var (
 	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean. Use if/or/otherwise instead"}
 	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil. Use if/otherwise to check for nil"}
 	E2050 = ErrorCode{"E2050", "when-collection-condition", "when condition cannot be an array or map"}
-	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "#suppress can only be applied to function declarations"}
+	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "#suppress can only be applied at file scope or to function declarations"}
 	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}
 	E2053 = ErrorCode{"E2053", "type-definition-in-function", "type definitions must be at file level"}
 	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "#strict when requires explicit enum member values in cases"}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -27,6 +27,35 @@ type LexerError struct {
 	Code    string // Error code like "E1005"
 }
 
+// LexerPosition stores the lexer state for backtracking
+type LexerPosition struct {
+	position     int
+	readPosition int
+	ch           byte
+	line         int
+	column       int
+}
+
+// GetPosition returns the current lexer position for later restoration
+func (l *Lexer) GetPosition() LexerPosition {
+	return LexerPosition{
+		position:     l.position,
+		readPosition: l.readPosition,
+		ch:           l.ch,
+		line:         l.line,
+		column:       l.column,
+	}
+}
+
+// SetPosition restores the lexer to a previously saved position
+func (l *Lexer) SetPosition(pos LexerPosition) {
+	l.position = pos.position
+	l.readPosition = pos.readPosition
+	l.ch = pos.ch
+	l.line = pos.line
+	l.column = pos.column
+}
+
 func NewLexer(input string) *Lexer {
 	l := &Lexer{input: input, line: 1, column: 0, errors: []LexerError{}}
 	l.readChar()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -121,6 +121,56 @@ func hasStrictAttribute(attrs []*Attribute) *Attribute {
 	return nil
 }
 
+// isSuppressForFunction checks if #suppress is followed by a function declaration
+// by peeking ahead past the #suppress(...) to see if DO or PRIVATE follows
+func (p *Parser) isSuppressForFunction() bool {
+	// We're at SUPPRESS, need to look past #suppress(...) to see what follows
+	// Save current position
+	savedPos := p.l.GetPosition()
+	savedCurrent := p.currentToken
+	savedPeek := p.peekToken
+
+	// Skip past #suppress
+	p.nextToken()
+
+	// Skip past opening paren
+	if !p.currentTokenMatches(LPAREN) {
+		// Restore and return false
+		p.l.SetPosition(savedPos)
+		p.currentToken = savedCurrent
+		p.peekToken = savedPeek
+		return false
+	}
+	p.nextToken()
+
+	// Skip past contents until closing paren
+	depth := 1
+	for depth > 0 && !p.currentTokenMatches(EOF) {
+		if p.currentTokenMatches(LPAREN) {
+			depth++
+		} else if p.currentTokenMatches(RPAREN) {
+			depth--
+		}
+		if depth > 0 {
+			p.nextToken()
+		}
+	}
+
+	// Now at RPAREN, check what follows
+	p.nextToken()
+
+	// Check if followed by DO or PRIVATE (private function) or another attribute
+	isForFunction := p.currentTokenMatches(DO) || p.currentTokenMatches(PRIVATE) ||
+		p.currentTokenMatches(SUPPRESS) || p.currentTokenMatches(STRICT)
+
+	// Restore position
+	p.l.SetPosition(savedPos)
+	p.currentToken = savedCurrent
+	p.peekToken = savedPeek
+
+	return isForFunction
+}
+
 // parseFileLevelSuppress parses a file-level #suppress(...) and returns the warning codes
 func (p *Parser) parseFileLevelSuppress() []string {
 	var codes []string
@@ -137,25 +187,21 @@ func (p *Parser) parseFileLevelSuppress() []string {
 
 	// Parse warning codes
 	for !p.currentTokenMatches(RPAREN) && !p.currentTokenMatches(EOF) {
-		if p.currentTokenMatches(STRING) {
+		if p.currentTokenMatches(STRING) || p.currentTokenMatches(IDENT) {
 			code := p.currentToken.Literal
 			// Validate the warning code
 			if !isValidWarningCode(code) {
 				p.addEZError(errors.E2052, fmt.Sprintf("%s is not a valid warning code", code), p.currentToken)
 			} else if !isWarningSuppressible(code) {
-				p.addEZError(errors.E2053, fmt.Sprintf("%s cannot be suppressed", code), p.currentToken)
+				p.addEZError(errors.E2052, fmt.Sprintf("warning code %s cannot be suppressed", code), p.currentToken)
 			} else {
 				codes = append(codes, code)
 			}
 			p.nextToken()
-		} else if p.currentTokenMatches(IDENT) && p.currentToken.Literal == "ALL" {
-			// Allow ALL without quotes
-			codes = append(codes, "ALL")
-			p.nextToken()
 		} else if p.currentTokenMatches(COMMA) {
 			p.nextToken()
 		} else {
-			p.addEZError(errors.E2002, "expected warning code string in #suppress", p.currentToken)
+			p.addEZError(errors.E2002, "expected warning code in #suppress", p.currentToken)
 			p.nextToken()
 		}
 	}
@@ -521,7 +567,9 @@ func (p *Parser) ParseProgram() *Program {
 		}
 
 		// Handle file-level #suppress (must come after imports/using, before other declarations)
-		if p.currentTokenMatches(SUPPRESS) {
+		// If we haven't seen other declarations yet, treat #suppress as file-level
+		// If we have seen declarations, treat #suppress as function-level (let parseStatement handle it)
+		if p.currentTokenMatches(SUPPRESS) && !seenOtherDeclaration {
 			// Parse the #suppress(...) and store in program
 			suppressCodes := p.parseFileLevelSuppress()
 			program.FileSuppressWarnings = append(program.FileSuppressWarnings, suppressCodes...)


### PR DESCRIPTION
## Summary
- **#830**: `#suppress` before a function now correctly applies only to that function, not the entire file
- **#831**: File-level `#suppress` now accepts unquoted warning codes like `W2009` (not just quoted `"W2009"` or `ALL`)

## Changes
- Added lexer position save/restore for lookahead parsing
- Modified `ParseProgram()` to distinguish between file-level and function-level `#suppress`:
  - If `#suppress` appears before any declarations → file-level (applies to entire file)
  - If `#suppress` appears after declarations (before a function) → function-level (applies to that function only)
- Updated E2051 error message to clarify that `#suppress` can be applied at file scope or to functions
- Updated E2051 test case to properly test the error scenario

Fixes #830, Fixes #831