### PR TITLE
Bugfixes/12-25-2025

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -77,6 +77,12 @@ jobs:
                 continue
               fi
 
+              # Allow shell scripts (they report as "executable" but are text files)
+              if [[ "$file" =~ \.sh$ ]]; then
+                echo "Allowed shell script: $file"
+                continue
+              fi
+
               # Reject executables and archives
               if file "$file" | grep -qE "executable|binary|archive|compressed"; then
                 echo "::error::Binary/executable file detected: $file"

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -371,4 +371,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 246 error/warning codes
+**Total:** 247 error/warning codes

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -158,6 +158,7 @@ Undefined variables, functions, modules
 | E4013 | shadows-function | variable shadows a function |
 | E4014 | shadows-module | variable shadows an imported module |
 | E4015 | shadows-used-module-function | variable shadows a function from a used module |
+| E4016 | loop-variable-shadows-loop-variable | loop variable shadows outer loop variable |
 
 ## Runtime Errors (E5xxx)
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -86,7 +86,7 @@ Syntax and parsing errors
 | E2048 | when-bool-condition | when condition cannot be a boolean. Use if/or/otherwise instead |
 | E2049 | when-nil-condition | when condition cannot be nil. Use if/otherwise to check for nil |
 | E2050 | when-collection-condition | when condition cannot be an array or map |
-| E2051 | suppress-invalid-target | #suppress can only be applied to function declarations |
+| E2051 | suppress-invalid-target | #suppress can only be applied at file scope or to function declarations |
 | E2052 | suppress-invalid-code | warning code cannot be suppressed |
 | E2053 | type-definition-in-function | type definitions must be at file level |
 | E2054 | when-strict-non-enum-case | #strict when requires explicit enum member values in cases |

--- a/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
+++ b/integration-tests/fail/errors/E2051_suppress_invalid_target.ez
@@ -1,13 +1,21 @@
 /*
  * Error Test: E2051 - suppress-invalid-target
- * Expected: "#suppress can only be applied to function declarations"
+ * Expected: "#suppress can only be applied at file scope or to function declarations"
  */
 
 module main
 
+import @std
+using std
+
+do helper() {
+    println("helper")
+}
+
 #suppress(W1001)
-const x = 5  // #suppress on variable declaration is not allowed
+const x = 5  // #suppress on variable declaration is not allowed (after a function)
 
 do main() {
+    helper()
     println(x)
 }

--- a/integration-tests/fail/errors/E4016_loop_variable_shadows.ez
+++ b/integration-tests/fail/errors/E4016_loop_variable_shadows.ez
@@ -1,0 +1,11 @@
+module main
+import @std
+using std
+
+do main() {
+    for i in range(0, 2) {
+        for i in range(0, 3) {  // E4016: loop variable 'i' shadows outer loop variable
+            println(i)
+        }
+    }
+}

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -126,6 +126,9 @@ for test_file in "$SCRIPT_DIR"/fail/errors/*.ez; do
     fi
 done
 
+# Cleanup any .ezdb files created by error tests (they are created in cwd, not the test directory)
+rm -f ./*.ezdb
+
 # Multi-file error tests (single files)
 for test_file in "$SCRIPT_DIR"/fail/multi-file/*.ez; do
     if [ -f "$test_file" ]; then

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -157,6 +157,7 @@ var (
 	E4013 = ErrorCode{"E4013", "shadows-function", "variable shadows a function"}
 	E4014 = ErrorCode{"E4014", "shadows-module", "variable shadows an imported module"}
 	E4015 = ErrorCode{"E4015", "shadows-used-module-function", "variable shadows a function from a used module"}
+	E4016 = ErrorCode{"E4016", "loop-variable-shadows-loop-variable", "loop variable shadows outer loop variable"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -87,7 +87,7 @@ var (
 	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean. Use if/or/otherwise instead"}
 	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil. Use if/otherwise to check for nil"}
 	E2050 = ErrorCode{"E2050", "when-collection-condition", "when condition cannot be an array or map"}
-	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "#suppress can only be applied to function declarations"}
+	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "#suppress can only be applied at file scope or to function declarations"}
 	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}
 	E2053 = ErrorCode{"E2053", "type-definition-in-function", "type definitions must be at file level"}
 	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "#strict when requires explicit enum member values in cases"}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2232,14 +2232,32 @@ func evalFloatInfixExpression(operator string, left, right Object, line, col int
 
 	switch operator {
 	case "+":
-		return &Float{Value: leftVal + rightVal}
+		result := leftVal + rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5005", line, col, "float overflow: %v + %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "-":
-		return &Float{Value: leftVal - rightVal}
+		result := leftVal - rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5006", line, col, "float overflow: %v - %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "*":
-		return &Float{Value: leftVal * rightVal}
+		result := leftVal * rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5007", line, col, "float overflow: %v * %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "/":
-		// Float division by zero returns +Inf, -Inf, or NaN per IEEE 754
-		return &Float{Value: leftVal / rightVal}
+		if rightVal == 0 {
+			return newErrorWithLocation("E5001", line, col, "division by zero")
+		}
+		result := leftVal / rightVal
+		if math.IsInf(result, 0) {
+			return newErrorWithLocation("E5007", line, col, "float overflow: %v / %v exceeds float range", leftVal, rightVal)
+		}
+		return &Float{Value: result}
 	case "<":
 		return nativeBoolToBooleanObject(leftVal < rightVal)
 	case ">":

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -27,6 +27,35 @@ type LexerError struct {
 	Code    string // Error code like "E1005"
 }
 
+// LexerPosition stores the lexer state for backtracking
+type LexerPosition struct {
+	position     int
+	readPosition int
+	ch           byte
+	line         int
+	column       int
+}
+
+// GetPosition returns the current lexer position for later restoration
+func (l *Lexer) GetPosition() LexerPosition {
+	return LexerPosition{
+		position:     l.position,
+		readPosition: l.readPosition,
+		ch:           l.ch,
+		line:         l.line,
+		column:       l.column,
+	}
+}
+
+// SetPosition restores the lexer to a previously saved position
+func (l *Lexer) SetPosition(pos LexerPosition) {
+	l.position = pos.position
+	l.readPosition = pos.readPosition
+	l.ch = pos.ch
+	l.line = pos.line
+	l.column = pos.column
+}
+
 func NewLexer(input string) *Lexer {
 	l := &Lexer{input: input, line: 1, column: 0, errors: []LexerError{}}
 	l.readChar()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -121,6 +121,56 @@ func hasStrictAttribute(attrs []*Attribute) *Attribute {
 	return nil
 }
 
+// isSuppressForFunction checks if #suppress is followed by a function declaration
+// by peeking ahead past the #suppress(...) to see if DO or PRIVATE follows
+func (p *Parser) isSuppressForFunction() bool {
+	// We're at SUPPRESS, need to look past #suppress(...) to see what follows
+	// Save current position
+	savedPos := p.l.GetPosition()
+	savedCurrent := p.currentToken
+	savedPeek := p.peekToken
+
+	// Skip past #suppress
+	p.nextToken()
+
+	// Skip past opening paren
+	if !p.currentTokenMatches(LPAREN) {
+		// Restore and return false
+		p.l.SetPosition(savedPos)
+		p.currentToken = savedCurrent
+		p.peekToken = savedPeek
+		return false
+	}
+	p.nextToken()
+
+	// Skip past contents until closing paren
+	depth := 1
+	for depth > 0 && !p.currentTokenMatches(EOF) {
+		if p.currentTokenMatches(LPAREN) {
+			depth++
+		} else if p.currentTokenMatches(RPAREN) {
+			depth--
+		}
+		if depth > 0 {
+			p.nextToken()
+		}
+	}
+
+	// Now at RPAREN, check what follows
+	p.nextToken()
+
+	// Check if followed by DO or PRIVATE (private function) or another attribute
+	isForFunction := p.currentTokenMatches(DO) || p.currentTokenMatches(PRIVATE) ||
+		p.currentTokenMatches(SUPPRESS) || p.currentTokenMatches(STRICT)
+
+	// Restore position
+	p.l.SetPosition(savedPos)
+	p.currentToken = savedCurrent
+	p.peekToken = savedPeek
+
+	return isForFunction
+}
+
 // parseFileLevelSuppress parses a file-level #suppress(...) and returns the warning codes
 func (p *Parser) parseFileLevelSuppress() []string {
 	var codes []string
@@ -137,25 +187,21 @@ func (p *Parser) parseFileLevelSuppress() []string {
 
 	// Parse warning codes
 	for !p.currentTokenMatches(RPAREN) && !p.currentTokenMatches(EOF) {
-		if p.currentTokenMatches(STRING) {
+		if p.currentTokenMatches(STRING) || p.currentTokenMatches(IDENT) {
 			code := p.currentToken.Literal
 			// Validate the warning code
 			if !isValidWarningCode(code) {
 				p.addEZError(errors.E2052, fmt.Sprintf("%s is not a valid warning code", code), p.currentToken)
 			} else if !isWarningSuppressible(code) {
-				p.addEZError(errors.E2053, fmt.Sprintf("%s cannot be suppressed", code), p.currentToken)
+				p.addEZError(errors.E2052, fmt.Sprintf("warning code %s cannot be suppressed", code), p.currentToken)
 			} else {
 				codes = append(codes, code)
 			}
 			p.nextToken()
-		} else if p.currentTokenMatches(IDENT) && p.currentToken.Literal == "ALL" {
-			// Allow ALL without quotes
-			codes = append(codes, "ALL")
-			p.nextToken()
 		} else if p.currentTokenMatches(COMMA) {
 			p.nextToken()
 		} else {
-			p.addEZError(errors.E2002, "expected warning code string in #suppress", p.currentToken)
+			p.addEZError(errors.E2002, "expected warning code in #suppress", p.currentToken)
 			p.nextToken()
 		}
 	}
@@ -521,7 +567,9 @@ func (p *Parser) ParseProgram() *Program {
 		}
 
 		// Handle file-level #suppress (must come after imports/using, before other declarations)
-		if p.currentTokenMatches(SUPPRESS) {
+		// If we haven't seen other declarations yet, treat #suppress as file-level
+		// If we have seen declarations, treat #suppress as function-level (let parseStatement handle it)
+		if p.currentTokenMatches(SUPPRESS) && !seenOtherDeclaration {
 			// Parse the #suppress(...) and store in program
 			suppressCodes := p.parseFileLevelSuppress()
 			program.FileSuppressWarnings = append(program.FileSuppressWarnings, suppressCodes...)

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -271,6 +271,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// arrays.remove_all(arr, value) - Removes ALL occurrences of the specified VALUE.
+	// Modifies array in-place, returns NIL.
 	"arrays.remove_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -280,13 +282,23 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !ok {
 				return &object.Error{Code: "E7002", Message: "arrays.remove_all() requires an array"}
 			}
+			if !arr.Mutable {
+				return &object.Error{
+					Message: "cannot modify immutable array (declared as const)",
+					Code:    "E4005",
+				}
+			}
+			if err := checkIterating(arr, "arrays.remove_all"); err != nil {
+				return err
+			}
 			newElements := []object.Object{}
 			for _, el := range arr.Elements {
 				if !objectsEqual(el, args[1]) {
 					newElements = append(newElements, el)
 				}
 			}
-			return &object.Array{Elements: newElements}
+			arr.Elements = newElements
+			return object.NIL
 		},
 	},
 

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -270,9 +270,12 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 						m[tag.Name] = v.Inspect()
 					case *object.Float:
 						m[tag.Name] = v.Inspect()
+					default:
+						m[tag.Name] = goVal
 					}
+				} else {
+					m[tag.Name] = goVal
 				}
-				m[tag.Name] = goVal
 			default:
 				m[key] = goVal
 			}

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -427,6 +427,11 @@ var OSBuiltins = map[string]*object.Builtin{
 			if err != nil {
 				if exitErr, ok := err.(*exec.ExitError); ok {
 					exitCode = int64(exitErr.ExitCode())
+					// Command ran but returned non-zero exit code - return error for consistency with os.exec_output
+					return &object.ReturnValue{Values: []object.Object{
+						&object.Integer{Value: big.NewInt(exitCode)},
+						createOSError("E7031", fmt.Sprintf("command exited with code %d", exitCode)),
+					}}
 				} else {
 					// Command failed to start entirely
 					return &object.ReturnValue{Values: []object.Object{

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -623,9 +623,9 @@ func TestOSExec(t *testing.T) {
 			t.Errorf("expected exit code 42, got %s", exitCode.Value.String())
 		}
 
-		// Error should still be nil for non-zero exit
-		if rv.Values[1] != object.NIL {
-			t.Errorf("expected nil error for non-zero exit, got %T", rv.Values[1])
+		// Error should be returned for non-zero exit (consistent with os.exec_output)
+		if rv.Values[1] == object.NIL {
+			t.Errorf("expected error for non-zero exit, got nil")
 		}
 	})
 

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -453,7 +453,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 					runes[i] = v.Value
 				case *object.String:
 					if len(v.Value) > 0 {
-						runes[i] = rune(v.Value[0])
+						runes[i] = []rune(v.Value)[0]
 					}
 				default:
 					return &object.Error{Code: "E7003", Message: "strings.from_chars() requires an array of chars"}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1896,16 +1896,18 @@ func (tc *TypeChecker) checkMultiReturnDeclaration(decl *ast.VariableDeclaration
 		returnType := funcSig.ReturnTypes[i]
 
 		if !tc.typesCompatible(declaredType, returnType) {
-			// Get position from the variable name at this index
+			// Get position and name from the variable at this index
 			line, col := 0, 0
+			varName := "<unknown>"
 			if i < len(decl.Names) && decl.Names[i] != nil {
+				varName = decl.Names[i].Value
 				line = decl.Names[i].Token.Line
 				col = decl.Names[i].Token.Column
 			}
 			tc.addError(
 				errors.E3001,
 				fmt.Sprintf("type mismatch in multi-return: variable '%s' declared as %s but function returns %s",
-					decl.Names[i].Value, declaredType, returnType),
+					varName, declaredType, returnType),
 				line,
 				col,
 			)


### PR DESCRIPTION
## Summary
Bug fixes

- fix: prevent panic on multi-return type mismatch with fewer names than types (#816)
- fix: add overflow/underflow checks for byte arithmetic (#817)
- fix: prevent `json.encode()` from overwriting EncodeAsString conversion (#818)
- fix: properly extract first rune in `strings.from_chars()` (#819)
- fix: make `arrays.remove_all()` consistent with other remove functions (#820)
- fix: add overflow and division-by-zero checks for float arithmetic (#798)
- fix: `os.exec()` now returns error on non-zero exit code (#799)
- fix: add cleanup for database test files (#800)
- fix: `#suppress()` before function now correctly applies to function only (#830, #831)

## Test plan
- All integration tests pass
- Individual bug fixes were tested in their respective PRs