### PR TITLE
feat: Add warning for unused imports

### DIFF
--- a/integration-tests/pass/W1002_unused_import.ez
+++ b/integration-tests/pass/W1002_unused_import.ez
@@ -1,0 +1,11 @@
+/* Test file for unused import warning (W1002)
+ * Expected: "imported module 'arrays' is not used"
+ */
+
+import @std, @strings, @arrays
+
+do main() {
+    // Only using std and strings modules
+    // arrays is imported but never used - should trigger W1002
+    std.println(strings.upper("hello"))
+}

--- a/integration-tests/pass/all_imports_used.ez
+++ b/integration-tests/pass/all_imports_used.ez
@@ -1,0 +1,10 @@
+/* Test file for no unused import warning
+ * Expected: no warnings (all imports are used)
+ */
+
+import @std, @strings
+
+do main() {
+    // Both std and strings modules are used
+    std.println(strings.upper("hello"))
+}


### PR DESCRIPTION
## Summary
Implements issue #639 - adds a warning (W1002) when a module is imported but never used in the code.

## Changes
- Added `usedModules` and `importLocations` tracking maps to TypeChecker
- Track module usage when functions are called or members accessed
- Emit W1002 warning for imported modules that are not used
- `import & use` and `using` statements automatically mark modules as used
- Added integration tests for the new warning

## Example
```
warning[W1002]: imported module 'arrays' is not used
  --> file.ez:5:1
   |
5 | import @std, @strings, @arrays
   | ^ module imported but not used
```

Closes #639