### PR TITLE
chore: Standardize error message punctuation

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -84,8 +84,8 @@ var (
 	E2045 = ErrorCode{"E2045", "when-strict-non-enum", "strict attribute only allowed on enum when statements"}
 	E2046 = ErrorCode{"E2046", "when-strict-missing-case", "strict when statement missing enum case"}
 	E2047 = ErrorCode{"E2047", "when-type-as-condition", "when condition must be a value, not a type name"}
-	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean. Use if/or/otherwise instead"}
-	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil. Use if/otherwise to check for nil"}
+	E2048 = ErrorCode{"E2048", "when-bool-condition", "when condition cannot be a boolean; use if/or/otherwise instead"}
+	E2049 = ErrorCode{"E2049", "when-nil-condition", "when condition cannot be nil; use if/otherwise to check for nil"}
 	E2050 = ErrorCode{"E2050", "when-collection-condition", "when condition cannot be an array or map"}
 	E2051 = ErrorCode{"E2051", "suppress-invalid-target", "#suppress can only be applied at file scope or to function declarations"}
 	E2052 = ErrorCode{"E2052", "suppress-invalid-code", "warning code cannot be suppressed"}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -466,7 +466,7 @@ func Eval(node ast.Node, env *Environment) Object {
 					if !isValidModule(item.Module) {
 						if suggestion := suggestModule(item.Module); suggestion != "" {
 							return newErrorWithLocation("E6002", node.Token.Line, node.Token.Column,
-								"module '%s' not found. Did you mean @%s?", item.Module, suggestion)
+								"module '%s' not found; did you mean @%s?", item.Module, suggestion)
 						}
 						return newErrorWithLocation("E6002", node.Token.Line, node.Token.Column,
 							"module '%s' not found", item.Module)
@@ -505,7 +505,7 @@ func Eval(node ast.Node, env *Environment) Object {
 			if !isValidModule(node.Module) {
 				if suggestion := suggestModule(node.Module); suggestion != "" {
 					return newErrorWithLocation("E6002", node.Token.Line, node.Token.Column,
-						"module '%s' not found. Did you mean @%s?", node.Module, suggestion)
+						"module '%s' not found; did you mean @%s?", node.Module, suggestion)
 				}
 				return newErrorWithLocation("E6002", node.Token.Line, node.Token.Column,
 					"module '%s' not found", node.Module)
@@ -3132,7 +3132,7 @@ func evalStructValue(node *ast.StructValue, env *Environment) Object {
 			if len(foundModules) > 1 {
 				moduleList := strings.Join(foundModules, ", ")
 				return newErrorWithLocation("E3002", node.Token.Line, node.Token.Column,
-					"type '%s' found in multiple modules: %s. Use explicit module prefix: %s.%s",
+					"type '%s' found in multiple modules: %s; use explicit module prefix: %s.%s",
 					typeName, moduleList, foundModules[0], typeName)
 			}
 
@@ -3224,7 +3224,7 @@ func evalNewExpression(node *ast.NewExpression, env *Environment) Object {
 			if len(foundModules) > 1 {
 				moduleList := strings.Join(foundModules, ", ")
 				return newErrorWithLocation("E3002", node.Token.Line, node.Token.Column,
-					"type '%s' found in multiple modules: %s. Use explicit module prefix: %s.%s",
+					"type '%s' found in multiple modules: %s; use explicit module prefix: %s.%s",
 					typeName, moduleList, foundModules[0], typeName)
 			}
 


### PR DESCRIPTION
## Summary
Implements issue #635 - standardizes error message punctuation and formatting across the codebase.

## Standardization Rule
When an error message contains a suggestion (like "use X", "did you mean X?"), use a **semicolon** instead of a period before the suggestion. This keeps it as one cohesive message.

## Changes
- `pkg/errors/codes.go`: Fixed E2048, E2049 descriptions
- `pkg/interpreter/evaluator.go`: Fixed 4 error messages

## Examples
```diff
- "module '%s' not found. Did you mean @%s?"
+ "module '%s' not found; did you mean @%s?"

- "type '%s' found in multiple modules: %s. Use explicit module prefix"
+ "type '%s' found in multiple modules: %s; use explicit module prefix"
```

Closes #635