### PR TITLE
docs: Add doc comments to stdlib modules

### DIFF
--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -23,8 +23,12 @@ func checkIterating(arr *object.Array, funcName string) *object.Error {
 	return nil
 }
 
-// ArraysBuiltins contains the arrays module functions
+// ArraysBuiltins contains the arrays module functions for array manipulation.
+// All functions are prefixed with "arrays." and operate on array values.
+// Many functions modify arrays in-place (append, pop, etc.) while others return new arrays.
 var ArraysBuiltins = map[string]*object.Builtin{
+	// Returns true if the array has no elements
+	// arrays.is_empty(arr [T]) -> bool
 	"arrays.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -41,6 +45,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Appends one or more elements to the end of an array (modifies in-place)
+	// arrays.append(arr [T], value T, ...) -> nil
 	"arrays.append": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -64,6 +70,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Prepends one or more elements to the beginning of an array (modifies in-place)
+	// arrays.unshift(arr [T], value T, ...) -> [T]
 	"arrays.unshift": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {

--- a/pkg/stdlib/binary.go
+++ b/pkg/stdlib/binary.go
@@ -126,7 +126,10 @@ func padBigIntBytesUnsigned(val *big.Int, size int) []byte {
 	return result
 }
 
-// BinaryBuiltins contains the binary module functions for encoding/decoding
+// BinaryBuiltins contains the binary module functions for encoding/decoding integers.
+// All functions are prefixed with "binary." and support 8/16/32/64/128-bit integers.
+// Both signed (i8/i16/i32/i64/i128) and unsigned (u8/u16/u32/u64/u128) types supported.
+// Functions are available in both little-endian and big-endian variants.
 var BinaryBuiltins = map[string]*object.Builtin{
 	// ============================================================================
 	// 8-bit Encoding/Decoding (no endianness needed)

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -10,7 +10,9 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// DBBuiltings contains the db module functions for database operations
+// DBBuiltins contains the db module functions for simple key-value database operations.
+// All functions are prefixed with "db." and operate on Database objects (.ezdb files).
+// Provides CRUD operations, key searching, sorting, and automatic persistence.
 var DBBuiltins = map[string]*object.Builtin{
 	// ============================================================================
 	// Database Management
@@ -51,8 +53,8 @@ var DBBuiltins = map[string]*object.Builtin{
 
 				return &object.ReturnValue{Values: []object.Object{
 					&object.Database{
-						Path: *path,
-						Store: *object.NewMap(),
+						Path:     *path,
+						Store:    *object.NewMap(),
 						IsClosed: object.Boolean{Value: false},
 					},
 					object.NIL,
@@ -88,8 +90,8 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			return &object.ReturnValue{Values: []object.Object{
 				&object.Database{
-					Path: *path,
-					Store: *dbContent,
+					Path:     *path,
+					Store:    *dbContent,
 					IsClosed: object.Boolean{Value: false},
 				},
 				object.NIL,
@@ -127,7 +129,7 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			db.IsClosed = object.Boolean{Value: true}
 
-			return	&object.Nil{}
+			return &object.Nil{}
 		},
 	},
 
@@ -312,7 +314,7 @@ var DBBuiltins = map[string]*object.Builtin{
 				keys.Elements = append(keys.Elements, pair.Key)
 			}
 
-			return	&keys
+			return &keys
 		},
 	},
 

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -12,7 +12,9 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// JsonBuiltins contains the json module functions
+// JsonBuiltins contains the json module functions for JSON encoding and decoding.
+// All functions are prefixed with "json." and provide serialization to/from EZ types.
+// Supports encoding primitives, arrays, maps, and structs to JSON strings.
 var JsonBuiltins = map[string]*object.Builtin{
 	// json.encode(value) -> (string, error)
 	// Serializes an EZ value to a JSON string

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -9,8 +9,12 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// MapsBuiltins contains the maps module functions
+// MapsBuiltins contains the maps module functions for map/dictionary manipulation.
+// All functions are prefixed with "maps." and operate on map values.
+// Maps use hashable types (string, int, bool, char) as keys.
 var MapsBuiltins = map[string]*object.Builtin{
+	// Returns true if the map has no entries
+	// maps.is_empty(m map) -> bool
 	"maps.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -27,6 +31,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns true if the map contains the specified key
+	// maps.has(m map, key K) -> bool
 	"maps.has": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -48,6 +54,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Gets a value by key, returns default (or nil) if not found
+	// maps.get(m map, key K, default V?) -> V
 	"maps.get": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {

--- a/pkg/stdlib/random.go
+++ b/pkg/stdlib/random.go
@@ -10,7 +10,9 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// RandomBuiltins contains the random module functions
+// RandomBuiltins contains the random module functions for generating random values.
+// All functions are prefixed with "random." and provide various random generation utilities.
+// Uses Go's crypto/rand seeded math/rand for pseudo-random number generation.
 var RandomBuiltins = map[string]*object.Builtin{
 	// random.float() - returns float [0.0, 1.0)
 	// random.float(min, max) - returns float [min, max)

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -12,8 +12,11 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// StringsBuiltins contains the strings module functions
+// StringsBuiltins contains the strings module functions for string manipulation.
+// All functions are prefixed with "strings." and operate on string values.
 var StringsBuiltins = map[string]*object.Builtin{
+	// Converts a string to uppercase
+	// strings.upper(s string) -> string
 	"strings.upper": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -27,6 +30,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Converts a string to lowercase
+	// strings.lower(s string) -> string
 	"strings.lower": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -40,6 +45,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Removes leading and trailing whitespace from a string
+	// strings.trim(s string) -> string
 	"strings.trim": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -53,6 +60,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Checks if a string contains a substring
+	// strings.contains(s string, substr string) -> bool
 	"strings.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -73,6 +82,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Splits a string by a separator into an array of strings
+	// strings.split(s string, sep string) -> [string]
 	"strings.split": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -95,6 +106,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Joins an array of strings with a separator
+	// strings.join(arr [string], sep string) -> string
 	"strings.join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -121,6 +134,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Replaces all occurrences of old with new in the string
+	// strings.replace(s string, old string, new string) -> string
 	"strings.replace": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -142,6 +157,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns the index of the first occurrence of substr, or -1 if not found
+	// strings.index(s string, substr string) -> int
 	"strings.index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -159,6 +176,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns true if the string starts with the prefix
+	// strings.starts_with(s string, prefix string) -> bool
 	"strings.starts_with": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -179,6 +198,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns true if the string ends with the suffix
+	// strings.ends_with(s string, suffix string) -> bool
 	"strings.ends_with": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -199,6 +220,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Repeats a string n times
+	// strings.repeat(s string, count int) -> string
 	"strings.repeat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -219,6 +242,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns a substring from start index to optional end index (supports negative indices)
+	// strings.slice(s string, start int, end int?) -> string
 	"strings.slice": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -271,6 +296,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Removes leading whitespace from a string
+	// strings.trim_left(s string) -> string
 	"strings.trim_left": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -284,6 +311,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Removes trailing whitespace from a string
+	// strings.trim_right(s string) -> string
 	"strings.trim_right": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -297,6 +326,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Pads a string on the left to reach target width
+	// strings.pad_left(s string, width int, pad_char string?) -> string
 	"strings.pad_left": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -333,6 +364,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Pads a string on the right to reach target width
+	// strings.pad_right(s string, width int, pad_char string?) -> string
 	"strings.pad_right": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -369,6 +402,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Reverses a string (handles UTF-8 correctly)
+	// strings.reverse(s string) -> string
 	"strings.reverse": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -386,6 +421,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Counts occurrences of substr in the string
+	// strings.count(s string, substr string) -> int
 	"strings.count": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -403,6 +440,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns true if the string is empty or contains only whitespace
+	// strings.is_empty(s string) -> bool
 	"strings.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -419,6 +458,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Splits a string into an array of characters
+	// strings.chars(s string) -> [char]
 	"strings.chars": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -437,6 +478,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Creates a string from an array of characters
+	// strings.from_chars(arr [char]) -> string
 	"strings.from_chars": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -463,6 +506,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns the index of the last occurrence of substr, or -1 if not found
+	// strings.last_index(s string, substr string) -> int
 	"strings.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -480,6 +525,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Capitalizes the first character of a string
+	// strings.capitalize(s string) -> string
 	"strings.capitalize": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -498,6 +545,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Capitalizes the first character of each word
+	// strings.title(s string) -> string
 	"strings.title": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -522,6 +571,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Replaces the first n occurrences of old with new
+	// strings.replace_n(s string, old string, new string, n int) -> string
 	"strings.replace_n": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 4 {
@@ -547,6 +598,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns true if the string contains only numeric digits
+	// strings.is_numeric(s string) -> bool
 	"strings.is_numeric": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -568,6 +621,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Returns true if the string contains only alphabetic characters
+	// strings.is_alpha(s string) -> bool
 	"strings.is_alpha": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -589,6 +644,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Truncates a string to max length with a suffix
+	// strings.truncate(s string, max_len int, suffix string) -> string
 	"strings.truncate": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -629,6 +686,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Lexicographically compares two strings: returns -1, 0, or 1
+	// strings.compare(a string, b string) -> int
 	"strings.compare": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -646,6 +705,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Parses a string as an integer
+	// strings.to_int(s string) -> int
 	"strings.to_int": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -665,6 +726,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Parses a string as a float
+	// strings.to_float(s string) -> float
 	"strings.to_float": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -684,6 +747,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// Parses a string as a boolean (accepts: true/false, 1/0, yes/no, on/off)
+	// strings.to_bool(s string) -> bool
 	"strings.to_bool": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -10,9 +10,13 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// TimeBuiltins contains the time module functions
+// TimeBuiltins contains the time module functions for date/time manipulation.
+// All functions are prefixed with "time." and work with Unix timestamps (seconds since epoch).
+// The module provides: current time, sleep, time components, formatting, parsing,
+// timestamp creation, arithmetic, differences, comparisons, timezone, and calendar utilities.
 var TimeBuiltins = map[string]*object.Builtin{
-	// Current time
+	// Current time functions
+	// time.now() -> int (Unix timestamp in seconds)
 	"time.now": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(time.Now().Unix())}


### PR DESCRIPTION
## Summary
Implements issue #633 - adds comprehensive Go-style documentation comments to all standard library modules.

## Changes
Added documentation following the existing pattern in `builtins.go`:

| Module | Changes |
|--------|---------|
| `strings.go` | Doc comments for all 30+ functions with signatures |
| `arrays.go` | Module comment + doc comments for core operations |
| `time.go` | Enhanced module comment describing capabilities |
| `maps.go` | Module comment + function docs for key operations |
| `random.go` | Enhanced module comment |
| `json.go` | Enhanced module comment |
| `binary.go` | Enhanced module comment for encoding types |
| `db.go` | Enhanced module comment + fixed typo in DBBuiltings |

## Documentation Pattern
```go
// ModuleBuiltins contains the module functions for X.
// All functions are prefixed with "module." and operate on Y.
var ModuleBuiltins = map[string]*object.Builtin{
    // Description of function
    // function.name(args) -> return_type
    "function.name": { ... },
}
```

Closes #633