### PR TITLE
fix(examples): resolve W2009 warning in json.ez

### DIFF
--- a/examples/json/json.ez
+++ b/examples/json/json.ez
@@ -28,7 +28,7 @@ do main() {
     println("Reading data.json...")
     temp content string, read_err error = io.read_file("examples/json/data.json")
     if read_err != nil {
-        println("Error reading file: ${read_err.message}")
+        println("Error reading file: ${read_err}")
         return
     }
     println("File loaded successfully!")


### PR DESCRIPTION
Resolves #357. Audited all examples for compatibility. Checked existing samples against v0.33.4. Fixed minor warning in `examples/json/json.ez`.