### PR TITLE
fix(typechecker): resolve struct parameter member access for imported types

### DIFF
--- a/integration-tests/pass/multi-file/struct-param-member-access/library/types.ez
+++ b/integration-tests/pass/multi-file/struct-param-member-access/library/types.ez
@@ -1,0 +1,10 @@
+/*
+ * types.ez - Defines TestStruct type
+ * Regression test for issue #851 - struct parameter member access bug
+ */
+module library
+
+const TestStruct struct {
+    Value u8
+    Name string
+}

--- a/integration-tests/pass/multi-file/struct-param-member-access/main.ez
+++ b/integration-tests/pass/multi-file/struct-param-member-access/main.ez
@@ -1,0 +1,29 @@
+/*
+ * main.ez - Test struct parameter member access across modules
+ * Regression test for issue #851 - struct parameter member access bug
+ */
+module main
+
+import @std
+import proc"./processor"
+
+using std
+
+do main() {
+    println("=== Struct Parameter Member Access Test ===")
+
+    // Create a struct instance using the processor module
+    temp ts = proc.create_test_struct(42, "test")
+
+    // Call processor function that takes the struct as a parameter
+    temp val = proc.process(ts)
+    temp name = proc.get_name(ts)
+
+    if val == 42 && name == "test" {
+        println("  [PASS] struct parameter member access works")
+        println("ALL TESTS PASSED")
+    } otherwise {
+        println("  [FAIL] expected val=42, name='test', got val=${val}, name='${name}'")
+        println("TESTS FAILED")
+    }
+}

--- a/integration-tests/pass/multi-file/struct-param-member-access/processor/handler.ez
+++ b/integration-tests/pass/multi-file/struct-param-member-access/processor/handler.ez
@@ -1,0 +1,21 @@
+/*
+ * handler.ez - Processes structs from another module
+ * Regression test for issue #851 - struct parameter member access bug
+ */
+module processor
+
+import lib"../library"
+using lib
+
+do create_test_struct(v u8, n string) -> TestStruct {
+    temp ts = TestStruct{Value: v, Name: n}
+    return ts
+}
+
+do process(s TestStruct) -> u8 {
+    return s.Value
+}
+
+do get_name(s TestStruct) -> string {
+    return s.Name
+}


### PR DESCRIPTION
## Summary
- Fixes struct parameter member access failing with E4011 error when struct type is from imported module
- Restructures `checkFile` and `runFile` to use true two-pass approach (parse ALL modules, then type check)
- Preserves import aliases for nested module imports
- Adds multi-file module internal type registration

Fixes #851

## Test plan
- [x] Added regression test in `integration-tests/pass/multi-file/struct-param-member-access/`
- [x] Verified fix with 5 edge case scenarios (deeply nested imports, multiple structs, nested struct fields, param+return types, complex expressions)
- [x] All 316 integration tests pass