### PR TITLE
Feature: `ensure` keyword for guaranteed cleanup on function exit #804

### DIFF
--- a/.github/workflows/sync-errors-doc.yml
+++ b/.github/workflows/sync-errors-doc.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -137,6 +137,7 @@ Type system errors
 | E3036 | integer-out-of-range | integer literal exceeds type range |
 | E3037 | invalid-private-usage | private modifier cannot be used here |
 | E3038 | void-type-not-allowed | 'void' is a return type, not a value type |
+| E3039 | ensure-expects-call | ensure expects a function call |
 
 ## Reference Errors (E4xxx)
 
@@ -372,4 +373,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 248 error/warning codes
+**Total:** 249 error/warning codes

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -317,6 +317,15 @@ type ReturnStatement struct {
 func (r *ReturnStatement) statementNode()       {}
 func (r *ReturnStatement) TokenLiteral() string { return r.Token.Literal }
 
+// EnsureStatement represents an ensure statement that runs cleanup on function exit
+type EnsureStatement struct {
+	Token      Token
+	Expression Expression // Must be a call expression
+}
+
+func (e *EnsureStatement) statementNode()       {}
+func (e *EnsureStatement) TokenLiteral() string { return e.Token.Literal }
+
 // ExpressionStatement wraps an expression as a statement
 type ExpressionStatement struct {
 	Token      Token

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -137,6 +137,7 @@ var (
 	E3036 = ErrorCode{"E3036", "integer-out-of-range", "integer literal exceeds type range"}
 	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
 	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is a return type, not a value type"}
+	E3039 = ErrorCode{"E3039", "ensure-expects-call", "ensure expects a function call"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -367,6 +367,9 @@ func Eval(node ast.Node, env *Environment) Object {
 	case *ast.ReturnStatement:
 		return evalReturn(node, env)
 
+	case *ast.EnsureStatement:
+		return evalEnsure(node, env)
+
 	case *ast.BlockStatement:
 		return evalBlockStatement(node, env)
 
@@ -1415,6 +1418,18 @@ func evalReturn(node *ast.ReturnStatement, env *Environment) Object {
 		values[i] = val
 	}
 	return &ReturnValue{Values: values}
+}
+
+func evalEnsure(node *ast.EnsureStatement, env *Environment) Object {
+	// Validate that it's a call expression
+	if callExpr, ok := node.Expression.(*ast.CallExpression); ok {
+		// Push the call expression onto the ensure stack
+		env.PushEnsure(callExpr)
+		return NIL
+	}
+	// This should not happen if parser validation works correctly
+	return newErrorWithLocation("E3039", node.Token.Line, node.Token.Column,
+		"ensure expects a function call")
 }
 
 func evalIfStatement(node *ast.IfStatement, env *Environment) Object {
@@ -2780,7 +2795,15 @@ func applyFunction(fn Object, args []Object, line, col int) Object {
 		}
 
 		evaluated := Eval(fn.Body, extendedEnv)
-
+		
+		// Execute ensure statements before returning (LIFO order)
+		ensures := extendedEnv.ExecuteEnsures()
+		for _, ensureCall := range ensures {
+			Eval(ensureCall, extendedEnv)
+			// Note: We ignore errors from ensure statements to ensure cleanup always runs
+		}
+		extendedEnv.ClearEnsures()
+		
 		// Restore current file
 		if globalEvalContext != nil && fn.File != "" {
 			globalEvalContext.CurrentFile = oldFile
@@ -3549,6 +3572,7 @@ func getStatementFile(stmt ast.Statement) string {
 		return s.Token.File
 	case *ast.ContinueStatement:
 		return s.Token.File
+	
 	case *ast.ImportStatement:
 		return s.Token.File
 	case *ast.UsingStatement:

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -24,6 +24,7 @@ var reservedKeywords = map[string]bool{
 	"import": true, "using": true, "struct": true, "enum": true,
 	"nil": true, "new": true, "true": true, "false": true,
 	"module": true, "private": true, "from": true, "use": true,
+	"ensure": true,
 }
 
 // Builtin function and type names that cannot be redefined
@@ -683,6 +684,8 @@ func (p *Parser) parseStatement() Statement {
 		return stmt
 	case RETURN:
 		return p.parseReturnStatement()
+	case ENSURE:
+		return p.parseEnsureStatement()
 	case IF:
 		return p.parseIfStatement()
 	case WHEN:
@@ -1059,6 +1062,57 @@ func (p *Parser) parseReturnStatement() *ReturnStatement {
 		p.nextToken() // consume comma
 		p.nextToken() // move to next value
 		stmt.Values = append(stmt.Values, p.parseExpression(LOWEST))
+	}
+
+	return stmt
+}
+
+func (p *Parser) parseEnsureStatement() *EnsureStatement {
+	stmt := &EnsureStatement{Token: p.currentToken}
+
+	p.nextToken() // move to expression
+
+	// Check for invalid patterns: ensure cannot be followed by declarations or blocks
+	switch p.currentToken.Type {
+	case DO:
+		msg := "ensure cannot be used with function declarations; ensure expects a function call"
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E3039, msg, p.currentToken)
+		return nil
+	case CONST:
+		msg := "ensure cannot be used with const declarations; ensure expects a function call"
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E3039, msg, p.currentToken)
+		return nil
+	case STRUCT:
+		msg := "ensure cannot be used with struct declarations; ensure expects a function call"
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E3039, msg, p.currentToken)
+		return nil
+	case ENUM:
+		msg := "ensure cannot be used with enum declarations; ensure expects a function call"
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E3039, msg, p.currentToken)
+		return nil
+	case LBRACE:
+		msg := "ensure cannot be used with block statements; ensure expects a function call"
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E3039, msg, p.currentToken)
+		return nil
+	}
+
+	// Parse the expression (must be a call expression)
+	expr := p.parseExpression(LOWEST)
+
+	// Validate that it's a call expression
+	if callExpr, ok := expr.(*CallExpression); ok {
+		stmt.Expression = callExpr
+	} else {
+		// Error: ensure expects a function call
+		msg := "ensure expects a function call"
+		p.errors = append(p.errors, msg)
+		p.addEZError(errors.E3039, msg, p.currentToken)
+		return nil
 	}
 
 	return stmt

--- a/pkg/tokenizer/token.go
+++ b/pkg/tokenizer/token.go
@@ -106,6 +106,7 @@ const (
 	TRUE       TokenType = "TRUE"
 	FALSE      TokenType = "FALSE"
 	BLANK      TokenType = "BLANK" // _ blank identifier
+	ENSURE     TokenType = "ENSURE"
 	SUPPRESS   TokenType = "SUPPRESS"
 	STRICT     TokenType = "STRICT"
 	ENUM_ATTR  TokenType = "ENUM_ATTR" // @enum(type)
@@ -161,6 +162,7 @@ var keywords = map[string]TokenType{
 	"is":         IS,
 	"default":    DEFAULT,
 	"cast":       CAST,
+	"ensure":     ENSURE,
 }
 
 // Looks up the passed in identifier(i)
@@ -180,7 +182,7 @@ func IsKeyword(t TokenType) bool {
 		FOR, FOR_EACH, AS_LONG_AS, LOOP, BREAK, CONTINUE,
 		IN, NOT_IN, RANGE, IMPORT, USING, STRUCT, ENUM,
 		NIL, NEW, TRUE, FALSE, BLANK, MODULE, PRIVATE, USE,
-		WHEN, IS, DEFAULT, CAST:
+		WHEN, IS, DEFAULT, CAST, ENSURE:
 		return true
 	}
 	return false


### PR DESCRIPTION
additional implementation
Error code E3039 (replaces incorrect E3016)
Tests based on  feedback