### PR TITLE
Feat: add`@http` module HTTP client for web requests

### DIFF
--- a/examples/http.ez
+++ b/examples/http.ez
@@ -1,0 +1,47 @@
+import @std, @http
+using std
+
+do main() {
+    // Simple GET request
+    temp resp, err = http.get("https://api.example.com/users")
+    if err != nil {
+        println("Error: ${err.message}")
+        return
+    }
+    println("Status: ${resp.status}")
+    println("Body: ${resp.body}")
+		temp content_type = resp.headers["Content-Type"][0]
+		println("Headers: ${content_type}")
+
+    // POST with JSON body
+    temp post_resp, post_err = http.post(
+        "https://api.example.com/users",
+        http.json_body({"name": "John", "email": "john@example.com"})
+    )
+
+    // Advanced request with custom headers
+    temp headers map[string:string] = {
+        "Authorization": "Bearer token123",
+        "Content-Type": "application/json"
+    }
+    temp adv_resp, adv_err = http.request(
+        "POST",
+        "https://api.example.com/posts",
+				http.json_body({"title": "foo", "body": "bar"}),
+        headers,
+        60
+    )
+		if adv_err != nil {
+        println("Error: ${adv_err.message}")
+        return
+		}
+
+    // URL utilities
+    temp encoded string = http.encode_url("hello world")  // "hello%20world"
+		temp decoded string, decode_err error = http.decode_url(encoded)
+		if decode_err != nil {
+			println("${decode_err}")
+			return
+		}
+    temp query string = http.build_query({"page": "1", "limit": "10"})  // "page=1&limit=10"
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -343,6 +343,19 @@ var (
 )
 
 // =============================================================================
+// HTTP ERRORS (E14xxx) - HTTP-specific domain errors
+// These are errors unique to HTTP operations
+// =============================================================================
+var (
+	E14001 = ErrorCode{"E14001", "http-invalid-url",					"invalid URL"}
+	E14002 = ErrorCode{"E14002", "http-failed-request",       "request failed (network error)"}
+	E14003 = ErrorCode{"E14003", "http-timeout",							"timeout exceeded"}
+	E14004 = ErrorCode{"E14004", "http-invalid-method",				"invalid HTTP method"}
+	E14005 = ErrorCode{"E14005", "http-failed-url-decode",		"URL decode failed"}
+	E14006 = ErrorCode{"E14006", "http-failed-json-encoding", "JSON encoding failed"}
+)
+
+// =============================================================================
 //
 //	DB ERRORS (E17xxx) - DB-specific domain errors
 //

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -154,6 +154,7 @@ var validModules = map[string]bool{
 	"uuid":     true, // UUID generation and validation
 	"encoding": true, // Base64, hex, and URL encoding/decoding
 	"crypto":   true, // Cryptographic hashing and secure random
+	"http":			true, // HTTP client for web requests
 }
 
 // isValidModule checks if a module name is valid (either standard library or user-created)

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -388,8 +388,13 @@ var HttpBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
 
+			timeout := DEFAULT_TIMEOUT
+			if timeout > 0 {
+				timeout = int(timeoutArg.Value.Uint64())
+			}
+
 			client := http.Client{
-				Timeout: time.Duration(timeoutArg.Value.Uint64())*time.Second,
+				Timeout: time.Duration(timeout)*time.Second,
 			}
 
 			var req *http.Request

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -113,6 +113,71 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	"http.put": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "http.put() takes exactly 2 arguments"}
+			}
+
+			url, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.put() requires a string argument"}
+			}
+
+			body, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.put() requires a string argument"}
+			}
+
+			req, err := http.NewRequest(http.MethodPut, url.Value, bytes.NewBuffer([]byte(body.Value)))
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "request failed"),
+					},
+				}
+			}
+
+			client := &http.Client{}
+			res, err := client.Do(req)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "request failed"),
+					},
+				}
+			}
+
+			responseBody, err := io.ReadAll(res.Body)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "could not read body"),
+					},
+				}
+			}
+
+			headers := object.NewMap()
+			for key, vals := range res.Header {
+				values := &object.Array{}
+				for _, val := range vals {
+					values.Elements = append(values.Elements, &object.String{Value: val})
+				}
+				headers.Set(&object.String{Value: key}, values)
+			}
+
+			return &object.ReturnValue{
+				Values: []object.Object{
+					newHttpResponse(res.StatusCode, string(responseBody), headers),
+					&object.Nil{},
+				},
+			}
+		},
+	},
+
 	"http.json_body": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -389,7 +389,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			timeout := DEFAULT_TIMEOUT
-			if timeout > 0 {
+			if timeoutArg.Value.Uint64() > 0 {
 				timeout = int(timeoutArg.Value.Uint64())
 			}
 

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -529,7 +529,15 @@ var HttpBuiltins = map[string]*object.Builtin{
 
 			q := url.Values{}
 			for _, pair := range m.Pairs {
-				q.Set(pair.Key.(*object.String).Value, pair.Value.(*object.String).Value)
+				key, ok := pair.Key.(*object.String)
+				if !ok {
+					return &object.Error{Code: "E7007", Message: "http.build_query() requires a map[string:string] argument"}
+				}
+				val, ok := pair.Value.(*object.String)
+				if !ok {
+					return &object.Error{Code: "E7007", Message: "http.build_query() requires a map[string:string] argument"}
+				}
+				q.Set(key.Value, val.Value)
 			}
 
 			return &object.String{Value: q.Encode()}

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -1,0 +1,83 @@
+package stdlib
+
+import (
+	"io"
+	"math/big"
+	"net/http"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+var HttpBuiltins = map[string]*object.Builtin{
+	"http.get": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "http.get() takes exactly 1 argument"}
+			}
+
+			url, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.get() requires a string argument"}
+			}
+
+			res, err := http.Get(url.Value)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "request failed"),
+					},
+				}
+			}
+
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "could not read body"),
+					},
+				}
+			}
+
+			headers := object.NewMap()
+			for key, vals := range res.Header {
+				values := &object.Array{}
+				for _, val := range vals {
+					values.Elements = append(values.Elements, &object.String{Value: val})
+				}
+				headers.Set(&object.String{Value: key}, values)
+			}
+
+			return &object.ReturnValue{
+				Values: []object.Object{
+					newHttpResponse(res.StatusCode, string(body), headers),
+					&object.Nil{},
+				},
+			}
+		},
+	},
+} 
+
+func createHttpError(code, message string) *object.Struct {
+	return &object.Struct{
+		TypeName: "Error",
+		Mutable: false,
+		Fields: map[string]object.Object{
+			"message": &object.String{Value: message},
+			"code":    &object.String{Value: code},
+		},
+	}
+}
+
+func newHttpResponse(status int, body string, headers *object.Map) *object.Struct {
+	return &object.Struct{
+		TypeName: "HttpResponse",
+		Mutable: false,
+		Fields: map[string]object.Object{
+			"status": &object.Integer{Value: big.NewInt(int64(status))},
+			"body": &object.String{Value: body},
+			"headers": headers,
+		},
+	}
+}

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -1,6 +1,7 @@
 package stdlib
 
 import (
+	"bytes"
 	"io"
 	"math/big"
 	"net/http"
@@ -55,6 +56,79 @@ var HttpBuiltins = map[string]*object.Builtin{
 					&object.Nil{},
 				},
 			}
+		},
+	},
+
+	"http.post": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "http.post() takes exactly 2 arguments"}
+			}
+
+			url, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.post() requires a string argument"}
+			}
+
+			body, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.post() requires a string argument"}
+			}
+
+			res, err := http.Post(url.Value, "", bytes.NewBuffer([]byte(body.Value)))
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "request failed"),
+					},
+				}
+			}
+
+			responseBody, err := io.ReadAll(res.Body)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "could not read body"),
+					},
+				}
+			}
+
+			headers := object.NewMap()
+			for key, vals := range res.Header {
+				values := &object.Array{}
+				for _, val := range vals {
+					values.Elements = append(values.Elements, &object.String{Value: val})
+				}
+				headers.Set(&object.String{Value: key}, values)
+			}
+
+			return &object.ReturnValue{
+				Values: []object.Object{
+					newHttpResponse(res.StatusCode, string(responseBody), headers),
+					&object.Nil{},
+				},
+			}
+		},
+	},
+
+	"http.json_body": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "http.json_body() takes exactly 1 arguments"}
+			}
+			m, ok := args[0].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E7007", Message: "http.json_body() requires a map argument"}
+			}
+
+			result, err := encodeToJSON(m, make(map[uintptr]bool))
+			if err != nil {
+				return &object.Error{Code: "E14006", Message: err.message}
+			}
+
+			return &object.String{Value: result}
 		},
 	},
 } 

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -11,8 +11,10 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-var client = &http.Client{
-	Timeout: time.Duration(30)*time.Second,
+const DEFAULT_TIMEOUT = 30
+
+var defaultClient = &http.Client{
+	Timeout: time.Duration(DEFAULT_TIMEOUT)*time.Second,
 }
 
 var HttpBuiltins = map[string]*object.Builtin{
@@ -22,16 +24,16 @@ var HttpBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7001", Message: "http.get() takes exactly 1 argument"}
 			}
 
-			str, ok := args[0].(*object.String)
+			urlArg, ok := args[0].(*object.String)
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "http.get() requires a string argument"}
 			}
 
-			if _, err := url.ParseRequestURI(str.Value); err != nil {
+			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
 
-			req, err := http.NewRequest(http.MethodGet, str.Value, nil)
+			req, err := http.NewRequest(http.MethodGet, urlArg.Value, nil)
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
@@ -41,12 +43,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 				}
 			}
 
-			res, err := client.Do(req)
+			res, err := defaultClient.Do(req)
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
 						&object.Nil{},
-						createHttpError("E14002", "request failed"),
+						createHttpError("E14002", "request failed: "+err.Error()),
 					},
 				}
 			}
@@ -86,21 +88,21 @@ var HttpBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7001", Message: "http.post() takes exactly 2 arguments"}
 			}
 
-			str, ok := args[0].(*object.String)
+			urlArg, ok := args[0].(*object.String)
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "http.post() requires a string argument"}
 			}
 
-			if _, err := url.ParseRequestURI(str.Value); err != nil {
+			body, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.post() requires a string argument"}
+			}
+
+			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
 
-			body, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Code: "E7003", Message: "http.post() requires a string argument"}
-			}
-
-			req, err := http.NewRequest(http.MethodPost, str.Value, bytes.NewBuffer([]byte(body.Value)))
+			req, err := http.NewRequest(http.MethodPost, urlArg.Value, bytes.NewBuffer([]byte(body.Value)))
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
@@ -110,12 +112,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 				}
 			}
 
-			res, err := client.Do(req)
+			res, err := defaultClient.Do(req)
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
 						&object.Nil{},
-						createHttpError("E14002", "request failed"),
+						createHttpError("E14002", "request failed: "+err.Error()),
 					},
 				}
 			}
@@ -155,21 +157,21 @@ var HttpBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7001", Message: "http.put() takes exactly 2 arguments"}
 			}
 
-			str, ok := args[0].(*object.String)
+			urlArg, ok := args[0].(*object.String)
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "http.put() requires a string argument"}
 			}
 
-			if _, err := url.ParseRequestURI(str.Value); err != nil {
+			body, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.put() requires a string argument"}
+			}
+
+			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
 
-			body, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Code: "E7003", Message: "http.put() requires a string argument"}
-			}
-
-			req, err := http.NewRequest(http.MethodPut, str.Value, bytes.NewBuffer([]byte(body.Value)))
+			req, err := http.NewRequest(http.MethodPut, urlArg.Value, bytes.NewBuffer([]byte(body.Value)))
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
@@ -179,12 +181,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 				}
 			}
 
-			res, err := client.Do(req)
+			res, err := defaultClient.Do(req)
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
 						&object.Nil{},
-						createHttpError("E14002", "request failed"),
+						createHttpError("E14002", "request failed: "+err.Error()),
 					},
 				}
 			}
@@ -224,16 +226,16 @@ var HttpBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7001", Message: "http.delete() takes exactly 1 argument"}
 			}
 
-			str, ok := args[0].(*object.String)
+			urlArg, ok := args[0].(*object.String)
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "http.delete() requires a string argument"}
 			}
 
-			if _, err := url.ParseRequestURI(str.Value); err != nil {
+			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
 			
-			req, err := http.NewRequest(http.MethodDelete, str.Value, nil)
+			req, err := http.NewRequest(http.MethodDelete, urlArg.Value, nil)
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
@@ -243,12 +245,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 				}
 			}
 
-			res, err := client.Do(req)
+			res, err := defaultClient.Do(req)
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
 						&object.Nil{},
-						createHttpError("E14002", "request failed"),
+						createHttpError("E14002", "request failed: "+err.Error()),
 					},
 				}
 			}
@@ -288,21 +290,21 @@ var HttpBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7001", Message: "http.patch() takes exactly 2 arguments"}
 			}
 
-			str, ok := args[0].(*object.String)
+			urlArg, ok := args[0].(*object.String)
 			if !ok {
 				return &object.Error{Code: "E7003", Message: "http.patch() requires a string argument"}
 			}
 
-			if _, err := url.ParseRequestURI(str.Value); err != nil {
+			body, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.patch() requires a string argument"}
+			}
+
+			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
 
-			body, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Code: "E7003", Message: "http.patch() requires a string argument"}
-			}
-
-			req, err := http.NewRequest(http.MethodPatch, str.Value, bytes.NewBuffer([]byte(body.Value)))
+			req, err := http.NewRequest(http.MethodPatch, urlArg.Value, bytes.NewBuffer([]byte(body.Value)))
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
@@ -312,12 +314,123 @@ var HttpBuiltins = map[string]*object.Builtin{
 				}
 			}
 
-			res, err := client.Do(req)
+			res, err := defaultClient.Do(req)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "request failed: "+err.Error()),
+					},
+				}
+			}
+			defer res.Body.Close()
+
+			responseBody, err := io.ReadAll(res.Body)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "could not read body"),
+					},
+				}
+			}
+
+			headers := object.NewMap()
+			for key, vals := range res.Header {
+				values := &object.Array{}
+				for _, val := range vals {
+					values.Elements = append(values.Elements, &object.String{Value: val})
+				}
+				headers.Set(&object.String{Value: key}, values)
+			}
+
+			return &object.ReturnValue{
+				Values: []object.Object{
+					newHttpResponse(res.StatusCode, string(responseBody), headers),
+					&object.Nil{},
+				},
+			}
+		},
+	},
+
+	"http.request": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 5 {
+				return &object.Error{Code: "E7001", Message: "http.request() takes exactly 5 arguments"}
+			}
+
+			methodArg, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.request() requires a string argument"}
+			}
+
+			urlArg, ok := args[1].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.request() requires a string argument"}
+			}
+
+			bodyArg, ok := args[2].(*object.String)
+			if !ok {
+				return &object.Error{Code: "E7003", Message: "http.request() requires a string argument"}
+			}
+
+			headersArg, ok := args[3].(*object.Map)
+			if !ok {
+				return &object.Error{Code: "E7007", Message: "http.request() requires a map argument"}
+			}
+
+			timeoutArg, ok := args[4].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "http.request() requires a integer argument"}
+			}
+
+			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
+				return &object.Error{Code: "E14001", Message: "invalid url"}
+			}
+
+			client := http.Client{
+				Timeout: time.Duration(timeoutArg.Value.Uint64())*time.Second,
+			}
+
+			var req *http.Request
+			var err error
+			switch methodArg.Value {
+			case "GET":
+				req, err = http.NewRequest(http.MethodGet, urlArg.Value, nil)
+			case "POST":
+				req, err = http.NewRequest(http.MethodPost, urlArg.Value, bytes.NewBuffer([]byte(bodyArg.Value)))
+			case "PUT":
+				req, err = http.NewRequest(http.MethodPut, urlArg.Value, bytes.NewBuffer([]byte(bodyArg.Value)))
+			case "DELETE":
+				req, err = http.NewRequest(http.MethodDelete, urlArg.Value, nil)
+			case "PATCH":
+				req, err = http.NewRequest(http.MethodPatch, urlArg.Value, bytes.NewBuffer([]byte(bodyArg.Value)))
+			case "OPTIONS":
+				req, err = http.NewRequest(http.MethodOptions, urlArg.Value, nil)
+			case "HEAD":
+				req, err = http.NewRequest(http.MethodHead, urlArg.Value, nil)
+			default:
+				return &object.Error{Code: "E14004", Message: "invalid HTTP method: `"+methodArg.Value+"`"}
+			}
 			if err != nil {
 				return &object.ReturnValue{
 					Values: []object.Object{
 						&object.Nil{},
 						createHttpError("E14002", "request failed"),
+					},
+				}
+			}
+
+			for _, pair := range headersArg.Pairs {
+				req.Header.Add(pair.Key.(*object.String).Value, pair.Value.(*object.String).Value)
+			}
+
+			res, err := client.Do(req)
+			if err != nil {
+				return &object.ReturnValue{
+					Values: []object.Object{
+						&object.Nil{},
+						createHttpError("E14002", "request failed: "+err.Error()),
 					},
 				}
 			}

--- a/pkg/stdlib/http_test.go
+++ b/pkg/stdlib/http_test.go
@@ -1,0 +1,1 @@
+package stdlib

--- a/pkg/stdlib/http_test.go
+++ b/pkg/stdlib/http_test.go
@@ -1,1 +1,327 @@
 package stdlib
+
+import (
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/marshallburns/ez/pkg/object"
+)
+
+// ============================================================================
+// HTTP request tests
+// ============================================================================
+
+func TestHTTPRequests(t *testing.T) {
+	getFn        := HttpBuiltins["http.get"].Fn
+	postFn       := HttpBuiltins["http.post"].Fn
+	putFn        := HttpBuiltins["http.put"].Fn
+	deleteFn     := HttpBuiltins["http.delete"].Fn
+	patchFn      := HttpBuiltins["http.patch"].Fn
+	advRequestFn := HttpBuiltins["http.request"].Fn
+
+	serverState := map[string]string{}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		body, _ := io.ReadAll(r.Body)
+		q := r.URL.Query()
+		id := q.Get("id")
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method {
+		case http.MethodGet:
+			val, ok := serverState[id]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.Write([]byte(val))
+
+		case http.MethodPost:
+			serverState[id] = string(body)
+			w.WriteHeader(http.StatusCreated)
+
+		case http.MethodPut:
+			if _, ok := serverState[id]; !ok {
+				http.NotFound(w, r)
+				return
+			}
+			serverState[id] = string(body)
+			w.WriteHeader(http.StatusOK)
+
+		case http.MethodPatch:
+			serverState[id] += string(body)
+			w.WriteHeader(http.StatusOK)
+
+		case http.MethodDelete:
+			delete(serverState, id)
+			w.WriteHeader(http.StatusNoContent)
+
+		case http.MethodOptions:
+			w.Header().Set("Allow", "GET,POST,PUT,DELETE,PATCH,OPTIONS,HEAD")
+			w.WriteHeader(http.StatusNoContent)
+
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+
+	t.Run("POST request", func(t *testing.T) {
+		resource := &object.String{Value: server.URL + "?id=1" }
+		res := postFn(resource, &object.String{Value: "hello"})
+		assertNoError(t, res)
+
+		status := getReturnValues(t, res)[0].(*object.Struct).Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusCreated {
+			t.Fatalf("expected %d, got %d", http.StatusCreated, status)
+		}
+
+		val, ok := serverState["1"]
+		if !ok {
+			t.Fatalf("expected key to be set")
+		}
+		if val != "hello" {
+			t.Fatalf("expected 'hello', got %q", val)
+		}
+	})
+
+	t.Run("GET request", func(t *testing.T) {
+		resource := &object.String{Value: server.URL + "?id=1" }
+		res := getFn(resource)
+		assertNoError(t, res)
+
+		response := getReturnValues(t, res)[0].(*object.Struct)
+		status := response.Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, status)
+		}
+
+		body := response.Fields["body"].(*object.String).Value
+		if body != "hello" {
+			t.Fatalf("expected 'hello', got %q", body)
+		}
+	})
+
+	t.Run("PUT request", func(t *testing.T) {
+		resource := &object.String{Value: server.URL + "?id=1" }
+		res := putFn(resource, &object.String{Value: "world"})
+		assertNoError(t, res)
+
+		status := getReturnValues(t, res)[0].(*object.Struct).Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, status)
+		}
+
+		val, ok := serverState["1"]
+		if !ok {
+			t.Fatalf("expected key to be set")
+		}
+		if val != "world" {
+			t.Fatalf("expected 'world', got %q", val)
+		}
+	})
+
+	t.Run("PATCH request", func(t *testing.T) {
+		resource := &object.String{Value: server.URL + "?id=1" }
+		res := patchFn(resource, &object.String{Value: "123"})
+		assertNoError(t, res)
+
+		status := getReturnValues(t, res)[0].(*object.Struct).Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, status)
+		}
+
+		val, ok := serverState["1"]
+		if !ok {
+			t.Fatalf("expected key to be set")
+		}
+		if val != "world123" {
+			t.Fatalf("expected key to be 'world123', got %q", val)
+		}
+	})
+
+	t.Run("OPTIONS request", func(t *testing.T) {
+		method := &object.String{Value: "OPTIONS"}
+		resource := &object.String{Value: server.URL }
+		res := advRequestFn(method, resource, &object.String{Value: ""}, object.NewMap(), &object.Integer{Value: big.NewInt(0)})
+		assertNoError(t, res)
+
+		response := getReturnValues(t, res)[0].(*object.Struct)
+		status := response.Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusNoContent {
+			t.Fatalf("expected %d, got %d", http.StatusNoContent, status)
+		}
+		
+		headerValue, ok := response.Fields["headers"].(*object.Map).Get(&object.String{Value: "Allow"})
+		if !ok {
+			t.Fatalf("expected 'Allow' header field to be set")
+		}
+
+		if headerValue.(*object.Array).Elements[0].(*object.String).Value != "GET,POST,PUT,DELETE,PATCH,OPTIONS,HEAD" {
+			t.Fatalf("header content not set correctly")
+		}
+	})
+
+	t.Run("HEAD request", func(t *testing.T) {
+		method := &object.String{Value: "HEAD"}
+		resource := &object.String{Value: server.URL }
+		res := advRequestFn(method, resource, &object.String{Value: ""}, object.NewMap(), &object.Integer{Value: big.NewInt(0)})
+		assertNoError(t, res)
+
+		response := getReturnValues(t, res)[0].(*object.Struct)
+		status := response.Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, status)
+		}
+	})
+
+	t.Run("DELETE request", func(t *testing.T) {
+		resource := &object.String{Value: server.URL + "?id=1" }
+		res := deleteFn(resource)
+		assertNoError(t, res)
+
+		status := getReturnValues(t, res)[0].(*object.Struct).Fields["status"].(*object.Integer).Value.Uint64()
+		if status != http.StatusNoContent {
+			t.Fatalf("expected %d, got %d", http.StatusNoContent, status)
+		}
+
+		if _, ok := serverState["1"]; ok {
+			t.Fatalf("expected key, value pair to be deleted")
+		}
+	})
+}
+
+// ============================================================================
+// HTTP url utility tests
+// ============================================================================
+
+func TestURLUtility(t *testing.T) {
+	encodeURLFn  := HttpBuiltins["http.encode_url"].Fn
+	decodeURLFn  := HttpBuiltins["http.decode_url"].Fn
+	buildQueryFn := HttpBuiltins["http.build_query"].Fn
+
+	t.Run("encode_url", func(t *testing.T) {
+		input := &object.String{Value: "hello world & golang"}
+
+		res := encodeURLFn(input)
+
+		str, ok := res.(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", res)
+		}
+
+		expected := "hello+world+%26+golang"
+		if str.Value != expected {
+			t.Fatalf("expected %q, got %q", expected, str.Value)
+		}
+	})
+
+	t.Run("decode_url", func(t *testing.T) {
+		input := &object.String{Value: "hello+world+%26+golang"}
+
+		res := decodeURLFn(input)
+		assertNoError(t, res)
+
+		str, ok := getReturnValues(t, res)[0].(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", res)
+		}
+
+		expected := "hello world & golang"
+		if str.Value != expected {
+			t.Fatalf("expected %q, got %q", expected, str.Value)
+		}
+	})
+
+	t.Run("build_query", func(t *testing.T) {
+		input := object.NewMap()
+		input.Set(&object.String{Value: "q"}, &object.String{Value: "hello world"})
+		input.Set(&object.String{Value: "page"}, &object.String{Value: "1"})
+
+		res := buildQueryFn(input)
+
+		str, ok := res.(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", res)
+		}
+
+		expected := "page=1&q=hello+world"
+		if str.Value != expected {
+			t.Fatalf("expected %q, got %q", expected, str.Value)
+		}
+	})
+}
+
+// ============================================================================
+// HTTP json helper tests
+// ============================================================================
+
+func TestJSONelper(t *testing.T) {
+	jsonHelperFn := HttpBuiltins["http.json_body"].Fn
+
+	t.Run("simple map", func(t *testing.T) {
+		input := object.NewMap()
+		input.Set(&object.String{Value: "name"}, &object.String{Value: "alice"})
+		input.Set(&object.String{Value: "age"}, &object.Integer{Value: big.NewInt(30)})
+
+		res := jsonHelperFn(input)
+
+		str, ok := res.(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", res)
+		}
+		expected := `{"age":30,"name":"alice"}`
+
+		if str.Value != expected {
+			t.Fatalf("unexpected json output: %q", str.Value)
+		}
+	})
+
+	t.Run("nested map", func(t *testing.T) {
+		address := object.NewMap()
+		address.Set(&object.String{Value: "city"}, &object.String{Value: "Paris"})
+		address.Set(&object.String{Value: "zip"}, &object.Integer{Value: big.NewInt(75000)})
+
+		input := object.NewMap()
+		input.Set(&object.String{Value: "user"}, address)
+		input.Set(&object.String{Value: "active"}, &object.Boolean{Value: true})
+
+		res := jsonHelperFn(input)
+
+		str, ok := res.(*object.String)
+		if !ok {
+			t.Fatalf("expected String, got %T", res)
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(str.Value), &decoded); err != nil {
+			t.Fatalf("invalid json output: %v", err)
+		}
+
+		if decoded["active"] != true {
+			t.Fatalf("expected active=true, got %v", decoded["active"])
+		}
+
+		user, ok := decoded["user"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected user object, got %T", decoded["user"])
+		}
+
+		if user["city"] != "Paris" {
+			t.Fatalf("expected city=Paris, got %v", user["city"])
+		}
+	})
+}

--- a/pkg/stdlib/stdlib.go
+++ b/pkg/stdlib/stdlib.go
@@ -64,6 +64,9 @@ func GetAllBuiltins() map[string]*object.Builtin {
 	for name, builtin := range CryptoBuiltins {
 		all[name] = builtin
 	}
+	for name, builtin := range HttpBuiltins {
+		all[name] = builtin
+	}
 
 	return all
 }

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4848,7 +4848,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 	
 	case "http":
 		switch funcName {
-		case "get", "post", "put":
+		case "get", "post", "put", "delete":
 			return []string{"HttpResponse", "error"}
 		}
 	}
@@ -5791,7 +5791,7 @@ func (tc *TypeChecker) isDBFunction(name string) bool {
 
 func (tc *TypeChecker) isHttpFunction(name string) bool {
 	httpFuncs := map[string]bool{
-		"get": true, "post": true, "put": true,
+		"get": true, "post": true, "put": true, "delete": true,
 
 		"json_body": true,
 	}
@@ -7062,6 +7062,7 @@ func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpres
 		"get": {1, 1, []string{"string"}, "tuple"},
 		"post": {2, 2, []string{"string", "string"}, "tuple"},
 		"put": {2, 2, []string{"string", "string"}, "tuple"},
+		"delete": {1, 1, []string{"string"}, "tuple"},
 
 		"json_body": {1, 1, []string{"map"}, "string"},
 	}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4848,7 +4848,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 	
 	case "http":
 		switch funcName {
-		case "get", "post", "put", "delete", "patch":
+		case "get", "post", "put", "delete", "patch", "request":
 			return []string{"HttpResponse", "error"}
 		}
 	}
@@ -5793,6 +5793,8 @@ func (tc *TypeChecker) isHttpFunction(name string) bool {
 	httpFuncs := map[string]bool{
 		"get": true, "post": true, "put": true, "delete": true,
 		"patch": true,
+
+		"request": true,
 
 		"json_body": true,
 	}
@@ -7065,6 +7067,8 @@ func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpres
 		"put": {2, 2, []string{"string", "string"}, "tuple"},
 		"delete": {1, 1, []string{"string"}, "tuple"},
 		"patch": {2, 2, []string{"string", "string"}, "tuple"},
+
+		"request": {5, 5, []string{"string", "string", "string", "map", "int"}, "tuple"},
 
 		"json_body": {1, 1, []string{"map"}, "string"},
 	}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -334,6 +334,18 @@ func (tc *TypeChecker) registerBuiltinTypes() {
 	}
 	tc.types["Error"] = errorType
 	tc.types["error"] = errorType // Alias for convenience
+
+	// Built-in HTTP Response struct
+	httpResponseType := &Type{
+		Name: "HttpResponse",
+		Kind: StructType,
+		Fields: map[string]*Type{
+			"status": {Name: "int", Kind: PrimitiveType},
+			"body": 	{Name: "string", Kind: PrimitiveType},
+			"headers":{Name: "headers", Kind: MapType},
+		},
+	}
+	tc.types["HttpResponse"] = httpResponseType
 }
 
 // TypeExists checks if a type name is registered

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4848,7 +4848,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 	
 	case "http":
 		switch funcName {
-		case "get", "post", "put", "delete":
+		case "get", "post", "put", "delete", "patch":
 			return []string{"HttpResponse", "error"}
 		}
 	}
@@ -5792,6 +5792,7 @@ func (tc *TypeChecker) isDBFunction(name string) bool {
 func (tc *TypeChecker) isHttpFunction(name string) bool {
 	httpFuncs := map[string]bool{
 		"get": true, "post": true, "put": true, "delete": true,
+		"patch": true,
 
 		"json_body": true,
 	}
@@ -7063,6 +7064,7 @@ func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpres
 		"post": {2, 2, []string{"string", "string"}, "tuple"},
 		"put": {2, 2, []string{"string", "string"}, "tuple"},
 		"delete": {1, 1, []string{"string"}, "tuple"},
+		"patch": {2, 2, []string{"string", "string"}, "tuple"},
 
 		"json_body": {1, 1, []string{"map"}, "string"},
 	}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4848,7 +4848,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 	
 	case "http":
 		switch funcName {
-		case "get":
+		case "get", "post":
 			return []string{"HttpResponse", "error"}
 		}
 	}
@@ -5791,7 +5791,9 @@ func (tc *TypeChecker) isDBFunction(name string) bool {
 
 func (tc *TypeChecker) isHttpFunction(name string) bool {
 	httpFuncs := map[string]bool{
-		"get": true,
+		"get": true, "post": true,
+
+		"json_body": true,
 	}
 	return httpFuncs[name]
 }
@@ -7058,6 +7060,9 @@ func (tc *TypeChecker) checkCryptoModuleCall(funcName string, call *ast.CallExpr
 func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpression, line, column int) {
 	signatures := map[string]StdlibFuncSig{
 		"get": {1, 1, []string{"string"}, "tuple"},
+		"post": {2, 2, []string{"string", "string"}, "tuple"},
+
+		"json_body": {1, 1, []string{"map"}, "string"},
 	}
 
 	sig, exists := signatures[funcName]

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4850,6 +4850,8 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 		switch funcName {
 		case "get", "post", "put", "delete", "patch", "request":
 			return []string{"HttpResponse", "error"}
+		case "decode_url":
+			return []string{"string", "error"}
 		}
 	}
 	return nil
@@ -5795,6 +5797,8 @@ func (tc *TypeChecker) isHttpFunction(name string) bool {
 		"patch": true,
 
 		"request": true,
+
+		"encode_url": true, "decode_url": true, "build_query": true,
 
 		"json_body": true,
 	}
@@ -7068,7 +7072,11 @@ func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpres
 		"delete": {1, 1, []string{"string"}, "tuple"},
 		"patch": {2, 2, []string{"string", "string"}, "tuple"},
 
-		"request": {5, 5, []string{"string", "string", "string", "map", "int"}, "tuple"},
+		"request": {5, 5, []string{"string", "string", "string", "map[string:string]", "int"}, "tuple"},
+
+		"encode_url": {1, 1, []string{"string"}, "string"},
+		"decode_url": {1, 1, []string{"string"}, "tuple"},
+		"build_query": {1, 1, []string{"map[string:string]"}, "string"},
 
 		"json_body": {1, 1, []string{"map"}, "string"},
 	}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -342,7 +342,7 @@ func (tc *TypeChecker) registerBuiltinTypes() {
 		Fields: map[string]*Type{
 			"status": {Name: "int", Kind: PrimitiveType},
 			"body": 	{Name: "string", Kind: PrimitiveType},
-			"headers":{Name: "headers", Kind: MapType},
+			"headers":{Name: "map[string:[string]]", Kind: MapType},
 		},
 	}
 	tc.types["HttpResponse"] = httpResponseType

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4848,7 +4848,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string) []
 	
 	case "http":
 		switch funcName {
-		case "get", "post":
+		case "get", "post", "put":
 			return []string{"HttpResponse", "error"}
 		}
 	}
@@ -5791,7 +5791,7 @@ func (tc *TypeChecker) isDBFunction(name string) bool {
 
 func (tc *TypeChecker) isHttpFunction(name string) bool {
 	httpFuncs := map[string]bool{
-		"get": true, "post": true,
+		"get": true, "post": true, "put": true,
 
 		"json_body": true,
 	}
@@ -7061,6 +7061,7 @@ func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpres
 	signatures := map[string]StdlibFuncSig{
 		"get": {1, 1, []string{"string"}, "tuple"},
 		"post": {2, 2, []string{"string", "string"}, "tuple"},
+		"put": {2, 2, []string{"string", "string"}, "tuple"},
 
 		"json_body": {1, 1, []string{"map"}, "string"},
 	}


### PR DESCRIPTION
# Summary
Introduces new standard library module - `@http` as a HTTP client for web requests

## `HttpResponse` structure
```
// Fields:
//     status        int                     - HTTP status code
//     body          string                  - Response body as string
//     headers       map[string:[string]]    - Response headers
```
## Basic Request Functions
| Function | Signature |
|---|---|
| `http.get` | `(url string) -> (HttpResponse, Error)` |
| `http.post` | `(url string, body string) -> (HttpResponse, Error)` |
| `http.put` | `(url string, body string) -> (HttpResponse, Error)` |
| `http.delete` | `(url string) -> (HttpResponse, Error)` |
| `http.patch` | `(url string, body string) -> (HttpResponse, Error)` |

`Default timeout is 30 seconds`

## Advanced Request
| Function | Signature |
|---|---|
| `http.request` | `(method string, url string, body string, headers map[string:string], timeout int) -> (HttpResponse, Error)` |

Parameters
- `method` - HTTP method (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD)
- `url` - Request URL
- `body` - Request body (empty string `""` for no body)
- `headers` - Custom headers (use empty map `{}` for no headers)
- `timeout` - Timeout in seconds (use 0 for default 30 seconds)

## URL Utilities
| Function | Signature |
|---|---|
| `http.encode_url` | `(s string) -> string` |
| `http.decode_url` | `(s string) -> (string, Error)` |
| `http.encode_url` | `(params map[string:string]) -> string` |

## JSON Helper
| Function | Signature |
|---|---|
| `http.json_body` | `(data map) -> string` |

## Error Codes
| Code | Description |
|---|---|
| E14001 | Invalid URL |
| E14002 | Request failed (network error) |
| E14003 | Timeout exceeded |
| E14004 | Invalid HTTP method |
| E14005 | URL decode failed |
| E14006 | JSON encoding failed |

# Test Plan
- [x] All `@http` module unit tests pass
- [x] All existing tests pass 

CLOSES #438 