### PR TITLE
CLI Migration to Cobra

### DIFF
--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -42,14 +42,6 @@ var updateCmd = &cobra.Command{
 	},
 }
 
-var helpCmd = &cobra.Command{
-	Use:   "help",
-	Short: "Help about EZ",
-	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.Help()
-	},
-}
-
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
@@ -96,7 +88,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd, helpCmd, versionCmd)
+	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd, versionCmd)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		CheckForUpdateAsync()
 	}

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -35,10 +35,17 @@ var replCmd = &cobra.Command{
 }
 
 var updateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   "update [url]",
 	Short: "Check for updates and upgrade EZ",
+	Long:  "Check for updates and upgrade EZ. Optionally specify a custom URL for the update source.",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		runUpdate(args)
+		confirm, _ := cmd.Flags().GetBool("confirm")
+		var url string
+		if len(args) > 0 {
+			url = args[0]
+		}
+		runUpdate(confirm, url)
 	},
 }
 

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func filterEzFiles(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	return []cobra.Completion{"ez"}, cobra.ShellCompDirectiveFilterFileExt
+}
+
+var checkCmd = &cobra.Command{
+	Use:               "check [file.ez | directory]",
+	Short:             "Check syntax and types for a file or directory",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: filterEzFiles,
+	Run: func(cmd *cobra.Command, args []string) {
+		arg := args[0]
+		if strings.HasSuffix(arg, ".ez") {
+			checkFile(arg)
+		} else {
+			checkProject(arg)
+		}
+	},
+}
+
+var buildCmd = &cobra.Command{
+	Use:               "build [file.ez | directory]",
+	Short:             "Check syntax and types for a file or directory (alias for check)",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: filterEzFiles,
+	Run: func(cmd *cobra.Command, args []string) {
+		arg := args[0]
+		if strings.HasSuffix(arg, ".ez") {
+			checkFile(arg)
+		} else {
+			checkProject(arg)
+		}
+	},
+}
+
+var replCmd = &cobra.Command{
+	Use:   "repl",
+	Short: "Start interactive REPL mode",
+	Run: func(cmd *cobra.Command, args []string) {
+		startREPL()
+	},
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Check for updates and upgrade EZ",
+	Run: func(cmd *cobra.Command, args []string) {
+		runUpdate(args)
+	},
+}
+
+var lexCmd = &cobra.Command{
+	Use:               "lex [file]",
+	Short:             "Tokenize a file",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: filterEzFiles,
+	Hidden:            true,
+	Run: func(cmd *cobra.Command, args []string) {
+		lexFile(args[0])
+	},
+}
+
+var parseCmd = &cobra.Command{
+	Use:               "parse [file]",
+	Short:             "Parse a file",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: filterEzFiles,
+	Hidden:            true,
+	Run: func(cmd *cobra.Command, args []string) {
+		parse_file(args[0])
+	},
+}
+
+var rootCmd = &cobra.Command{
+	Use:     "ez [file.ez]",
+	Short:   "EZ Language Interpreter",
+	Long:    "A simple, interpreted, statically-typed programming language designed for clarity and ease of use.",
+	Args:    cobra.MaximumNArgs(1),
+	Version: getVersionString(),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 && strings.HasSuffix(args[0], ".ez") {
+			runFile(args[0])
+			return nil
+		}
+		return cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, buildCmd, lexCmd, parseCmd)
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		CheckForUpdateAsync()
+	}
+	updateCmd.Flags().Bool("confirm", false, "Skip confirmation prompt")
+}

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -42,6 +42,22 @@ var updateCmd = &cobra.Command{
 	},
 }
 
+var helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Help about EZ",
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.Help()
+	},
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.Printf("%s\n", getVersionString())
+	},
+}
+
 var lexCmd = &cobra.Command{
 	Use:               "lex [file]",
 	Short:             "Tokenize a file",
@@ -80,7 +96,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd)
+	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd, helpCmd, versionCmd)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		CheckForUpdateAsync()
 	}

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -12,22 +12,8 @@ func filterEzFiles(cmd *cobra.Command, args []string, toComplete string) ([]cobr
 
 var checkCmd = &cobra.Command{
 	Use:               "check [file.ez | directory]",
+	Aliases:           []string{"build"},
 	Short:             "Check syntax and types for a file or directory",
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: filterEzFiles,
-	Run: func(cmd *cobra.Command, args []string) {
-		arg := args[0]
-		if strings.HasSuffix(arg, ".ez") {
-			checkFile(arg)
-		} else {
-			checkProject(arg)
-		}
-	},
-}
-
-var buildCmd = &cobra.Command{
-	Use:               "build [file.ez | directory]",
-	Short:             "Check syntax and types for a file or directory (alias for check)",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: filterEzFiles,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -94,7 +80,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, buildCmd, lexCmd, parseCmd)
+	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		CheckForUpdateAsync()
 	}

--- a/cmd/ez/update.go
+++ b/cmd/ez/update.go
@@ -224,10 +224,10 @@ func CheckForUpdateAsync() {
 // runUpdate runs the interactive update command
 // If args contains "--confirm" followed by a URL, it skips confirmation and installs directly
 // (used when re-executing with sudo)
-func runUpdate(args []string) {
+func runUpdate(confirm bool, url string) {
 	// Check for --confirm flag (used by sudo re-exec)
-	if len(args) >= 2 && args[0] == "--confirm" {
-		downloadURL := args[1]
+	if confirm {
+		downloadURL := url
 		fmt.Printf("Installing update...\n")
 		if err := downloadAndInstall(downloadURL); err != nil {
 			fmt.Printf("Error during update: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/marshallburns/ez
 
 go 1.23.1
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Feature: Migrate CLI to Cobra Framework to enable shell completions

### Summary
This PR migrates the EZ language CLI from manual argument parsing to the [Cobra](https://github.com/spf13/cobra) framework mainly for the purpose of achieving CLI completions for various shells and a better overall UX.

### Changes Made

Code Level Changes:
- **NEW**: cmd/ez/commands.go - Command definitions using Cobra.
- **MODIFIED**: cmd/ez/main.go
  - Changed from manual args parsing to Cobra root command setup.
  - Added a `getVersionString` method which returns the version string instead of printing it out.
- **ADDED**: Cobra dependency with required transitive dependencies.

Command Structure Changes:
- Added shell completion support with `.ez` file filtering.
- Added `build' as an alias for the `check` command (Due to a cobra's limitation, autocomplete wouldn't complete build, only check).
- Added `completion` command with support for `bash`, `fish`, `zsh` and `powershell`.

### Tab Completion Behavior
- For the root command `ez`, pressing `Tab` shows and cycles through the list of available commands.
- For `check`, `lex` and `parse` commands, pressing `Tab` shows and cycles through a list of files (filtered to only *.ez) and directories.
- Flags are autocompleted by pressing `Tab` after `--` or `-` wherever applicable.

### Testing
- All existing functionality preserved.
- Integration tests should pass without modification.
- The tab completions were tested on ZSH (MacOS).

### Notes
In order to make minimal changes and keep the PR change log small, the suggested hierarchical folder structure suggested by cobra's docs has not been strictly followed in this migration.

All cobra related command definitions exist in the `commands.go` file but in the future it would be beneficial to break up the `main.go` code into individual files where each file pertains to a command definition(from `command.go`) and has all necessary functions(from `main.go`) needed.

The `version` and `help` commands are not strictly _needed_ anymore but have been migrated to the new system to maintain backwards compatibility. The use of flags over commands for these two use cases is almost always preferred in most modern CLIs but since this will be a breaking change, it can be done as a part of a major release.