### PR TITLE
fix(typechecker): runtime string relational operator failure

### DIFF
--- a/integration-tests/fail/errors/E3002_string_comparison.ez
+++ b/integration-tests/fail/errors/E3002_string_comparison.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E3002 - invalid-operator-for-type
+ * Expected: "cannot use '<' on strings; use strings.compare() instead"
+ */
+do main() {
+    temp s1 string = "apple"
+    temp s2 string = "banana"
+    if s1 < s2 {
+        println("less")
+    }
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2833,13 +2833,24 @@ func (tc *TypeChecker) checkInfixExpression(infix *ast.InfixExpression) {
 		}
 
 	case "<", ">", "<=", ">=":
-		// Only valid for numbers, strings, chars, or enums with numeric/string base type
-		leftComparable := tc.isNumericType(leftType) || leftType == "string" || leftType == "char" || tc.isComparableEnumType(leftType)
-		rightComparable := tc.isNumericType(rightType) || rightType == "string" || rightType == "char" || tc.isComparableEnumType(rightType)
+		// Check for string comparison explicitly to give helpful message (#887)
+		if leftType == "string" && rightType == "string" {
+			tc.addError(
+				errors.E3002,
+				fmt.Sprintf("cannot use '%s' on strings; use strings.compare() instead", infix.Operator),
+				line,
+				column,
+			)
+			return
+		}
+
+		// Only valid for numbers, chars, or enums with numeric base type
+		leftComparable := tc.isNumericType(leftType) || leftType == "char" || tc.isComparableEnumType(leftType)
+		rightComparable := tc.isNumericType(rightType) || rightType == "char" || tc.isComparableEnumType(rightType)
 		if !leftComparable {
 			tc.addError(
 				errors.E3002,
-				fmt.Sprintf("invalid operand for '%s': %s (expected numeric or string)", infix.Operator, leftType),
+				fmt.Sprintf("invalid operand for '%s': %s (expected numeric)", infix.Operator, leftType),
 				line,
 				column,
 			)
@@ -2847,7 +2858,7 @@ func (tc *TypeChecker) checkInfixExpression(infix *ast.InfixExpression) {
 		if !rightComparable {
 			tc.addError(
 				errors.E3002,
-				fmt.Sprintf("invalid operand for '%s': %s (expected numeric or string)", infix.Operator, rightType),
+				fmt.Sprintf("invalid operand for '%s': %s (expected numeric)", infix.Operator, rightType),
 				line,
 				column,
 			)

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5592,10 +5592,10 @@ func (tc *TypeChecker) isEnumType(typeName string) bool {
 	return false
 }
 
-// isComparableEnumType checks if a type is an enum with a comparable base type (numeric or string)
+// isComparableEnumType checks if a type is an enum with a comparable base type (numeric)
 func (tc *TypeChecker) isComparableEnumType(typeName string) bool {
 	if t, exists := tc.types[typeName]; exists && t.Kind == EnumType {
-		return tc.isNumericType(t.EnumBaseType) || t.EnumBaseType == "string"
+		return tc.isNumericType(t.EnumBaseType)
 	}
 	return false
 }


### PR DESCRIPTION
## Summary of changes

1. Modified `pkg/typechecker/typechecker.go` to explicitly disallow relational operators for string types
2. Added a clear compile-time error message
  `cannot use '[operator]' on strings; use strings.compare() instead`
3. Added a new regression test  
  `integration-tests/fail/errors/E3002_string_comparison.ez`

## Related Issue

- Fixes #887
