### PR TITLE
Fix: empty literal `{}` is now passed as a map #886

### DIFF
--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -376,7 +376,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 
 			headersArg, ok := args[3].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "http.request() requires a map argument"}
+				// Special case: empty {} is parsed as empty Array, convert to empty Map
+				if arr, isArr := args[3].(*object.Array); isArr && len(arr.Elements) == 0 {
+					headersArg = object.NewMap()
+				} else {
+					return &object.Error{Code: "E7007", Message: "http.request() requires a map argument"}
+				}
 			}
 
 			timeoutArg, ok := args[4].(*object.Integer)
@@ -524,7 +529,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "http.build_query() requires a map argument"}
+				// Special case: empty {} is parsed as empty Array, convert to empty Map
+				if arr, isArr := args[0].(*object.Array); isArr && len(arr.Elements) == 0 {
+					m = object.NewMap()
+				} else {
+					return &object.Error{Code: "E7007", Message: "http.build_query() requires a map argument"}
+				}
 			}
 
 			q := url.Values{}
@@ -552,7 +562,12 @@ var HttpBuiltins = map[string]*object.Builtin{
 
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "http.json_body() requires a map argument"}
+				// Special case: empty {} is parsed as empty Array, convert to empty Map
+				if arr, isArr := args[0].(*object.Array); isArr && len(arr.Elements) == 0 {
+					m = object.NewMap()
+				} else {
+					return &object.Error{Code: "E7007", Message: "http.json_body() requires a map argument"}
+				}
 			}
 
 			result, err := encodeToJSON(m, make(map[uintptr]bool))

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -7762,8 +7762,22 @@ func (tc *TypeChecker) typeMatchesExpected(actual, expected string) bool {
 	case "array":
 		return tc.isArrayType(actual)
 	case "map":
-		return tc.isMapType(actual)
+		// Use typesCompatible to allow empty arrays [] to be compatible with map types
+		// Check both directions: actual is map, or actual is [] and expected is map
+		if tc.isMapType(actual) {
+			return true
+		}
+		// Empty braces {} parsed as empty array [] should also be compatible with map types
+		if actual == "[]" {
+			return true
+		}
+		return false
 	default:
+		// For specific map types like "map[string:string]", use typesCompatible
+		// which handles empty arrays [] being compatible with map types
+		if tc.isMapType(expected) && actual == "[]" {
+			return true
+		}
 		return tc.typesCompatible(expected, actual)
 	}
 }


### PR DESCRIPTION
Initially, I tried changing the `parser` to return `MapValue` for empty `{}`, but that would break existing code that expects `{}` to be an array when used with array types.

So, i changed `Stdlib` functions which now convert empty `Array` to empty `Map` at runtime and 
`Typechecker` that  allows `[]` to be compatible with map types