### PR TITLE
fix(repl): add multi-line navigation support

### DIFF
--- a/cmd/ez/repl.go
+++ b/cmd/ez/repl.go
@@ -149,26 +149,11 @@ func needsMoreInput(line string) bool {
 
 // readMultiLineInputWithEditor continues reading input for multi-line statements using the line editor
 func readMultiLineInputWithEditor(editor *lineeditor.Editor, initial string) string {
-	var lines []string
-	lines = append(lines, initial)
-
-	for {
-		line, err := editor.ReadLine(CONTINUE)
-		if err != nil {
-			return "" // EOF, interrupt, or error
-		}
-
-		lines = append(lines, line)
-
-		// Check if we have balanced braces
-		fullText := strings.Join(lines, "\n")
-		openBraces := strings.Count(fullText, "{")
-		closeBraces := strings.Count(fullText, "}")
-
-		if openBraces == closeBraces {
-			return fullText
-		}
+	result, err := editor.ReadMultiLine(PROMPT, CONTINUE, initial)
+	if err != nil {
+		return "" // EOF, interrupt, or error
 	}
+	return result
 }
 
 // evaluateLine parses and evaluates a single line/statement


### PR DESCRIPTION
## Summary
- Adds Up/Down arrow navigation within multi-line input blocks in the REPL
- Users can now navigate between lines to fix typos instead of retyping the entire block
- Implements `ReadMultiLine` method in the line editor with full cursor navigation

## Test plan
- [x] Run `./ez repl`
- [x] Type `do main() {` and press Enter
- [x] Verify continuation prompt `.. ` appears
- [x] Press Up arrow - cursor should move to first line
- [x] Press Down arrow - cursor should return to continuation line
- [x] Complete the block with `}` and press Enter to submit

Closes #875