### PR TITLE
fix: void function fixes and comprehensive type rejection

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -136,7 +136,7 @@ Type system errors
 | E3035 | not-all-paths-return | not all code paths return a value |
 | E3036 | integer-out-of-range | integer literal exceeds type range |
 | E3037 | invalid-private-usage | private modifier cannot be used here |
-| E3038 | void-type-not-allowed | 'void' is a return type, not a value type |
+| E3038 | void-type-not-allowed | 'void' is not a valid type |
 | E3039 | ensure-expects-call | ensure expects a function call |
 
 ## Reference Errors (E4xxx)

--- a/integration-tests/fail/errors/E3038_void_array_element.ez
+++ b/integration-tests/fail/errors/E3038_void_array_element.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "variable declarations"
+ */
+
+do main() {
+    temp arr [void] = {}  // Should fail: void cannot be array element type
+}

--- a/integration-tests/fail/errors/E3038_void_assignment.ez
+++ b/integration-tests/fail/errors/E3038_void_assignment.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "cannot assign"
+ */
+
+do main() {
+    temp x = voidFunc()  // Should fail: cannot assign void function result
+}
+
+do voidFunc() {
+    return
+}

--- a/integration-tests/fail/errors/E3038_void_map_value.ez
+++ b/integration-tests/fail/errors/E3038_void_map_value.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "variable declarations"
+ */
+
+do main() {
+    temp m map[string:void]  // Should fail: void cannot be map value type
+}

--- a/integration-tests/fail/errors/E3038_void_parameter_type.ez
+++ b/integration-tests/fail/errors/E3038_void_parameter_type.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "parameter type"
+ */
+
+do main() {
+    test()
+}
+
+do test(x void) {  // Should fail: void cannot be used as parameter type
+}

--- a/integration-tests/fail/errors/E3038_void_return_type.ez
+++ b/integration-tests/fail/errors/E3038_void_return_type.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "omit return type"
+ */
+
+do main() {
+    test()
+}
+
+do test() -> void {  // Should fail: void cannot be used as return type
+    return
+}

--- a/integration-tests/fail/errors/E3038_void_struct_field.ez
+++ b/integration-tests/fail/errors/E3038_void_struct_field.ez
@@ -1,0 +1,10 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "struct field"
+ */
+
+const Foo struct {
+    x void  // Should fail: void cannot be struct field type
+}
+
+do main() {}

--- a/integration-tests/fail/errors/E3038_void_variable_type.ez
+++ b/integration-tests/fail/errors/E3038_void_variable_type.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E3038 - void-type-not-allowed
+ * Expected: "void" and "not a valid type"
+ */
+
+do main() {
+    temp x void  // Should fail: void cannot be used as variable type
+}

--- a/integration-tests/pass/core/void-functions.ez
+++ b/integration-tests/pass/core/void-functions.ez
@@ -1,0 +1,131 @@
+/*
+ * Test: Void functions
+ * Tests void function behavior including early return, ensure, and nesting
+ */
+
+import @std
+using std
+
+do main() {
+    // Test 1: Basic void function
+    basicVoid()
+
+    // Test 2: Void with early return
+    earlyReturn(true)
+    earlyReturn(false)
+
+    // Test 3: Void with ensure
+    withEnsure()
+
+    // Test 4: Void with ensure AND early return (bug #883)
+    ensureWithEarlyReturn(true)
+    ensureWithEarlyReturn(false)
+
+    // Test 5: Return in for loop
+    returnInLoop()
+
+    // Test 6: Return in when/is
+    returnInWhen(1)
+    returnInWhen(2)
+    returnInWhen(99)
+
+    // Test 7: Nested void calls
+    outer()
+
+    // Test 8: Multiple return paths
+    multipleReturns(1)
+    multipleReturns(2)
+    multipleReturns(3)
+
+    // Test 9: Return in as_long_as loop
+    returnInWhile()
+
+    // Test 10: Deeply nested return
+    deeplyNested(true)
+    deeplyNested(false)
+
+    println("PASS: void-functions")
+}
+
+do basicVoid() {
+    temp x int = 1
+}
+
+do earlyReturn(shouldReturn bool) {
+    if shouldReturn {
+        return
+    }
+    temp x int = 1
+}
+
+do withEnsure() {
+    ensure cleanup()
+    temp x int = 1
+}
+
+do ensureWithEarlyReturn(shouldReturn bool) {
+    ensure cleanup()
+    if shouldReturn {
+        return
+    }
+    temp x int = 1
+}
+
+do returnInLoop() {
+    for i in range(0, 3) {
+        if i == 1 {
+            return
+        }
+    }
+}
+
+do returnInWhen(val int) {
+    when val {
+        is 1 { return }
+        is 2 { return }
+        default { return }
+    }
+}
+
+do outer() {
+    inner()
+}
+
+do inner() {
+    return
+}
+
+do multipleReturns(path int) {
+    if path == 1 {
+        return
+    }
+    if path == 2 {
+        return
+    }
+}
+
+do returnInWhile() {
+    temp count int = 0
+    as_long_as count < 10 {
+        if count == 2 {
+            return
+        }
+        count++
+    }
+}
+
+do deeplyNested(flag bool) {
+    if flag {
+        for i in range(0, 3) {
+            if i == 1 {
+                return
+            }
+        }
+    } otherwise {
+        return
+    }
+}
+
+do cleanup() {
+    temp x int = 1
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -136,7 +136,7 @@ var (
 	E3035 = ErrorCode{"E3035", "not-all-paths-return", "not all code paths return a value"}
 	E3036 = ErrorCode{"E3036", "integer-out-of-range", "integer literal exceeds type range"}
 	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
-	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is a return type, not a value type"}
+	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is not a valid type"}
 	E3039 = ErrorCode{"E3039", "ensure-expects-call", "ensure expects a function call"}
 )
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3070,6 +3070,9 @@ func extendFunctionEnv(fn *Function, args []Object) *Environment {
 
 func unwrapReturnValue(obj Object) Object {
 	if returnValue, ok := obj.(*ReturnValue); ok {
+		if len(returnValue.Values) == 0 {
+			return NIL
+		}
 		if len(returnValue.Values) == 1 {
 			return returnValue.Values[0]
 		}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1141,6 +1141,15 @@ func (tc *TypeChecker) checkFunctionDeclaration(node *ast.FunctionDeclaration) {
 				node.Name.Token.Column,
 			)
 		}
+		// Check if 'void' type is used as return type (not allowed - just omit return type for void functions)
+		if returnType == "void" {
+			tc.addError(
+				errors.E3038,
+				fmt.Sprintf("'void' cannot be used as return type in function '%s'; omit return type for void functions", node.Name.Value),
+				node.Name.Token.Line,
+				node.Name.Token.Column,
+			)
+		}
 	}
 
 	tc.RegisterFunction(node.Name.Value, sig)


### PR DESCRIPTION
## Summary
- Fix bug #883: `ensure` + void function with explicit `return` exits program instead of returning to caller
- Prevent assignment of void function results to variables
- Reject `-> void` as explicit return type (just omit return type for void functions)
- Reject void in compound types: `[void]`, `map[K:void]`, struct fields
- Update E3038 error hint to be more accurate

## Changes
1. **Interpreter fix**: Handle empty `ReturnValue.Values` slice in `unwrapReturnValue`
2. **Typechecker fixes**:
   - Reject void function result assignment
   - Reject `-> void` return type
   - Add `containsVoidType` helper to catch void in nested types
   - Reject void in variable declarations, struct fields
3. **Error message**: Updated E3038 hint from misleading text to "'void' is not a valid type"

## Test plan
- [x] Added `void-functions.ez` pass test covering all void function scenarios
- [x] Added 8 fail tests for E3038 covering all void rejection cases
- [x] All integration tests pass (325 passed)
- [x] Unit tests pass

Closes #883