### PR TITLE
fix: Internal type representation leaks Go type names instead of EZ types

### DIFF
--- a/integration-tests/fail/errors/E3038_typeof_void.ez
+++ b/integration-tests/fail/errors/E3038_typeof_void.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3038 - typeof() with void function result
+ * Expected: "void" and "typeof"
+ */
+
+do main() {
+    typeof(voidFunc())  // Should fail: cannot use void as argument
+}
+
+do voidFunc() {
+    return
+}

--- a/integration-tests/fail/errors/E5008_typeof_wrong_args.ez
+++ b/integration-tests/fail/errors/E5008_typeof_wrong_args.ez
@@ -1,0 +1,8 @@
+/*
+ * Error Test: E5008 - typeof wrong argument count
+ * Expected: "typeof" and "1 argument"
+ */
+
+do main() {
+    temp x = typeof()  // Should fail: no arguments
+}

--- a/integration-tests/pass/core/typeof.ez
+++ b/integration-tests/pass/core/typeof.ez
@@ -1,0 +1,88 @@
+/*
+ * Test: typeof() builtin function
+ * Tests that typeof() returns correct EZ type names
+ */
+
+import @std
+using std
+
+const Color enum { RED, GREEN, BLUE }
+const Point struct {
+    x int
+    y int
+}
+
+do main() {
+    // Primitives
+    temp i int = 42
+    temp f float = 3.14
+    temp s string = "hello"
+    temp b bool = true
+
+    assert(typeof(i) == "int", "int variable should return 'int'")
+    assert(typeof(f) == "float", "float variable should return 'float'")
+    assert(typeof(s) == "string", "string variable should return 'string'")
+    assert(typeof(b) == "bool", "bool variable should return 'bool'")
+    assert(typeof(nil) == "nil", "nil should return 'nil'")
+
+    // Literals
+    assert(typeof(42) == "int", "int literal should return 'int'")
+    assert(typeof(3.14) == "float", "float literal should return 'float'")
+    assert(typeof("test") == "string", "string literal should return 'string'")
+    assert(typeof(true) == "bool", "bool literal should return 'bool'")
+
+    // Arrays with declared type
+    temp arr [int] = {1, 2, 3}
+    assert(typeof(arr) == "[int]", "array should return '[int]'")
+
+    temp strArr [string] = {"a", "b"}
+    assert(typeof(strArr) == "[string]", "string array should return '[string]'")
+
+    // Maps with declared type
+    temp m map[string:int] = {"a": 1}
+    assert(typeof(m) == "map[string:int]", "map should return 'map[string:int]'")
+
+    temp m2 map[int:string] = {1: "one"}
+    assert(typeof(m2) == "map[int:string]", "map should return 'map[int:string]'")
+
+    // Enums
+    temp c Color = Color.RED
+    assert(typeof(c) == "Color", "enum variable should return enum type name")
+    assert(typeof(Color.GREEN) == "Color", "enum member should return enum type name")
+
+    // Structs
+    temp p Point = Point{x: 10, y: 20}
+    assert(typeof(p) == "Point", "struct variable should return struct name")
+    assert(typeof(Point{x: 1, y: 2}) == "Point", "struct literal should return struct name")
+
+    // Range
+    assert(typeof(range(0, 5)) == "range", "range should return 'range'")
+
+    // Function returns
+    assert(typeof(returnsInt()) == "int", "function returning int")
+    assert(typeof(returnsString()) == "string", "function returning string")
+    assert(typeof(returnsBool()) == "bool", "function returning bool")
+    assert(typeof(returnsStruct()) == "Point", "function returning struct")
+
+    // Built-in returns
+    assert(typeof(len(arr)) == "int", "len() should return int")
+    assert(typeof(typeof(i)) == "string", "typeof() should return string")
+    assert(typeof(string(42)) == "string", "string() should return string")
+    assert(typeof(int("42")) == "int", "int() should return int")
+    assert(typeof(float(42)) == "float", "float() should return float")
+
+    // Expressions
+    assert(typeof(1 + 2) == "int", "arithmetic should return int")
+    assert(typeof(1 < 2) == "bool", "comparison should return bool")
+    assert(typeof("a" + "b") == "string", "string concat should return string")
+    assert(typeof(arr[0]) == "int", "array index should return element type")
+    assert(typeof(m["a"]) == "int", "map index should return value type")
+    assert(typeof(p.x) == "int", "struct field should return field type")
+
+    println("PASS: typeof")
+}
+
+do returnsInt() -> int { return 42 }
+do returnsString() -> string { return "hello" }
+do returnsBool() -> bool { return true }
+do returnsStruct() -> Point { return Point{x: 0, y: 0} }

--- a/integration-tests/pass/core/typeof.ez
+++ b/integration-tests/pass/core/typeof.ez
@@ -56,7 +56,7 @@ do main() {
     assert(typeof(Point{x: 1, y: 2}) == "Point", "struct literal should return struct name")
 
     // Range
-    assert(typeof(range(0, 5)) == "range", "range should return 'range'")
+    assert(typeof(range(0, 5)) == "Range<int>", "range should return 'Range<int>'")
 
     // Function returns
     assert(typeof(returnsInt()) == "int", "function returning int")

--- a/integration-tests/pass/core/typeof_stdlib.ez
+++ b/integration-tests/pass/core/typeof_stdlib.ez
@@ -1,0 +1,72 @@
+/*
+ * Test: typeof() for stdlib return types
+ * Tests that stdlib functions return correct EZ type names
+ * Related to issue #900: Internal type representation fix
+ */
+
+import @std
+import @random
+import @strings
+import @maps
+
+using std
+
+do main() {
+    // Test random module types
+    temp rf float = random.float()
+    assert(typeof(rf) == "float", "random.float() should return 'float'")
+
+    temp ri int = random.int(100)
+    assert(typeof(ri) == "int", "random.int() should return 'int'")
+
+    temp rb bool = random.bool()
+    assert(typeof(rb) == "bool", "random.bool() should return 'bool'")
+
+    temp rc byte = random.byte()
+    assert(typeof(rc) == "byte", "random.byte() should return 'byte'")
+
+    temp rchar char = random.char()
+    assert(typeof(rchar) == "char", "random.char() should return 'char'")
+
+    // Test random array functions preserve element types
+    temp arr [int] = {1, 2, 3, 4, 5}
+    temp shuffled = random.shuffle(arr)
+    assert(typeof(shuffled) == "[int]", "random.shuffle() should preserve '[int]' type")
+
+    temp sampled = random.sample(arr, 2)
+    assert(typeof(sampled) == "[int]", "random.sample() should preserve '[int]' type")
+
+    temp choice = random.choice(arr)
+    assert(typeof(choice) == "int", "random.choice() should return element type 'int'")
+
+    // Test with string array
+    temp strArr [string] = {"a", "b", "c"}
+    temp strShuffled = random.shuffle(strArr)
+    assert(typeof(strShuffled) == "[string]", "random.shuffle() should preserve '[string]' type")
+
+    // Test Range type
+    temp r = range(0, 10)
+    assert(typeof(r) == "Range<int>", "range() should return 'Range<int>'")
+
+    // Test string array from split
+    temp parts = strings.split("a,b,c", ",")
+    assert(typeof(parts) == "[string]", "strings.split() should return '[string]'")
+
+    // Test map types
+    temp m map[string:int] = {"a": 1, "b": 2}
+    temp keys = maps.keys(m)
+    assert(typeof(keys) == "[string]", "maps.keys() should return '[string]'")
+
+    temp values = maps.values(m)
+    assert(typeof(values) == "[int]", "maps.values() should return '[int]'")
+
+    // Test with different map types
+    temp m2 map[int:string] = {1: "one", 2: "two"}
+    temp keys2 = maps.keys(m2)
+    assert(typeof(keys2) == "[int]", "maps.keys() should return '[int]' for int keys")
+
+    temp values2 = maps.values(m2)
+    assert(typeof(values2) == "[string]", "maps.values() should return '[string]' for string values")
+
+    println("PASS: typeof_stdlib")
+}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3578,6 +3578,8 @@ func copyByDefault(val Object) Object {
 			newMap.Set(pair.Key, copyByDefault(pair.Value))
 		}
 		newMap.Mutable = v.Mutable
+		newMap.KeyType = v.KeyType
+		newMap.ValueType = v.ValueType
 		return newMap
 	default:
 		// Primitives and other types are returned as-is

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -928,7 +928,13 @@ func evalVariableDeclaration(node *ast.VariableDeclaration, env *Environment) Ob
 				if !ok {
 					// Special case: empty {} is parsed as empty Array, convert to empty Map
 					if arr, isArr := val.(*Array); isArr && len(arr.Elements) == 0 {
-						mapObj = &Map{Pairs: []*MapPair{}, Index: make(map[string]int), Mutable: node.Mutable}
+						mapObj = &Map{
+							Pairs:     []*MapPair{},
+							Index:     make(map[string]int),
+							Mutable:   node.Mutable,
+							KeyType:   extractMapKeyType(node.TypeName),
+							ValueType: extractMapValueType(node.TypeName),
+						}
 						val = mapObj
 					} else {
 						return newErrorWithLocation("E3019", node.Token.Line, node.Token.Column,
@@ -938,8 +944,10 @@ func evalVariableDeclaration(node *ast.VariableDeclaration, env *Environment) Ob
 							node.TypeName, getEZTypeName(val), node.TypeName)
 					}
 				} else {
-					// Set mutability based on temp vs const
+					// Set mutability and type info based on declaration
 					mapObj.Mutable = node.Mutable
+					mapObj.KeyType = extractMapKeyType(node.TypeName)
+					mapObj.ValueType = extractMapValueType(node.TypeName)
 				}
 			}
 
@@ -1047,7 +1055,13 @@ func validateAndConvertType(val Object, typeName string, mutable bool, line, col
 		mapObj, ok := val.(*Map)
 		if !ok {
 			if arr, isArr := val.(*Array); isArr && len(arr.Elements) == 0 {
-				mapObj = &Map{Pairs: []*MapPair{}, Index: make(map[string]int), Mutable: mutable}
+				mapObj = &Map{
+					Pairs:     []*MapPair{},
+					Index:     make(map[string]int),
+					Mutable:   mutable,
+					KeyType:   extractMapKeyType(typeName),
+					ValueType: extractMapValueType(typeName),
+				}
 				return mapObj, nil
 			}
 			return nil, newErrorWithLocation("E3019", line, col,
@@ -1055,6 +1069,8 @@ func validateAndConvertType(val Object, typeName string, mutable bool, line, col
 				typeName, getEZTypeName(val))
 		}
 		mapObj.Mutable = mutable
+		mapObj.KeyType = extractMapKeyType(typeName)
+		mapObj.ValueType = extractMapValueType(typeName)
 		return mapObj, nil
 	}
 
@@ -2921,6 +2937,52 @@ func isIntegerType(typeName string) bool {
 	return isSignedIntegerType(typeName) || isUnsignedIntegerType(typeName)
 }
 
+// extractMapKeyType extracts the key type from "map[keyType:valueType]"
+func extractMapKeyType(mapType string) string {
+	if !strings.HasPrefix(mapType, "map[") || !strings.HasSuffix(mapType, "]") {
+		return ""
+	}
+	inner := mapType[4 : len(mapType)-1] // Extract "keyType:valueType"
+	// Find the colon, respecting nested brackets
+	depth := 0
+	for i := 0; i < len(inner); i++ {
+		switch inner[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case ':':
+			if depth == 0 {
+				return inner[:i]
+			}
+		}
+	}
+	return ""
+}
+
+// extractMapValueType extracts the value type from "map[keyType:valueType]"
+func extractMapValueType(mapType string) string {
+	if !strings.HasPrefix(mapType, "map[") || !strings.HasSuffix(mapType, "]") {
+		return ""
+	}
+	inner := mapType[4 : len(mapType)-1] // Extract "keyType:valueType"
+	// Find the colon, respecting nested brackets
+	depth := 0
+	for i := 0; i < len(inner); i++ {
+		switch inner[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case ':':
+			if depth == 0 {
+				return inner[i+1:]
+			}
+		}
+	}
+	return ""
+}
+
 // typeMatches checks if an object matches an EZ type name
 // Implements signed/unsigned integer family compatibility rules:
 // - Signed family: i8, i16, i32, i64, i128, i256, int (all compatible with each other)
@@ -3209,7 +3271,13 @@ func evalStructValue(node *ast.StructValue, env *Environment) Object {
 		if arr, ok := val.(*Array); ok && len(arr.Elements) == 0 {
 			if fieldType, hasField := structDef.Fields[fieldName]; hasField {
 				if strings.HasPrefix(fieldType, "map[") {
-					val = &Map{Pairs: []*MapPair{}, Index: make(map[string]int), Mutable: true}
+					val = &Map{
+						Pairs:     []*MapPair{},
+						Index:     make(map[string]int),
+						Mutable:   true,
+						KeyType:   extractMapKeyType(fieldType),
+						ValueType: extractMapValueType(fieldType),
+					}
 				}
 			}
 		}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -412,9 +412,11 @@ type MapPair struct {
 
 // Map represents a map/dictionary with ordered key-value pairs
 type Map struct {
-	Pairs   []*MapPair     // Ordered pairs for iteration
-	Index   map[string]int // Maps key hash to index in Pairs for O(1) lookup
-	Mutable bool
+	Pairs     []*MapPair     // Ordered pairs for iteration
+	Index     map[string]int // Maps key hash to index in Pairs for O(1) lookup
+	Mutable   bool
+	KeyType   string // Type of map keys (e.g., "string", "int")
+	ValueType string // Type of map values (e.g., "int", "Task")
 }
 
 func (m *Map) Type() ObjectType { return MAP_OBJ }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -65,7 +65,8 @@ func (i *Integer) GetDeclaredType() string {
 
 // Float wraps float64
 type Float struct {
-	Value float64
+	Value        float64
+	DeclaredType string
 }
 
 func (f *Float) Type() ObjectType { return FLOAT_OBJ }
@@ -79,6 +80,13 @@ func (f *Float) Inspect() string {
 		s += ".0"
 	}
 	return s
+}
+
+func (f *Float) GetDeclaredType() string {
+	if f.DeclaredType == "" {
+		return "float"
+	}
+	return f.DeclaredType
 }
 
 // String wraps string

--- a/pkg/stdlib/binary.go
+++ b/pkg/stdlib/binary.go
@@ -1156,7 +1156,7 @@ var BinaryBuiltins = map[string]*object.Builtin{
 			bits := binary.LittleEndian.Uint32(data)
 			val := math.Float32frombits(bits)
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Float{Value: float64(val)},
+				&object.Float{Value: float64(val), DeclaredType: "f32"},
 				object.NIL,
 			}}
 		},
@@ -1199,7 +1199,7 @@ var BinaryBuiltins = map[string]*object.Builtin{
 			bits := binary.LittleEndian.Uint64(data)
 			val := math.Float64frombits(bits)
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Float{Value: val},
+				&object.Float{Value: val, DeclaredType: "f64"},
 				object.NIL,
 			}}
 		},
@@ -1246,7 +1246,7 @@ var BinaryBuiltins = map[string]*object.Builtin{
 			bits := binary.BigEndian.Uint32(data)
 			val := math.Float32frombits(bits)
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Float{Value: float64(val)},
+				&object.Float{Value: float64(val), DeclaredType: "f32"},
 				object.NIL,
 			}}
 		},
@@ -1289,7 +1289,7 @@ var BinaryBuiltins = map[string]*object.Builtin{
 			bits := binary.BigEndian.Uint64(data)
 			val := math.Float64frombits(bits)
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Float{Value: val},
+				&object.Float{Value: val, DeclaredType: "f64"},
 				object.NIL,
 			}}
 		},

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -110,6 +110,8 @@ func deepCopy(obj object.Object) object.Object {
 		}
 		// Copied maps are mutable by default to allow modification
 		newMap.Mutable = true
+		newMap.KeyType = v.KeyType
+		newMap.ValueType = v.ValueType
 		return newMap
 	case *object.Struct:
 		newFields := make(map[string]object.Object)

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -62,6 +62,8 @@ func getEZTypeName(obj object.Object) string {
 		return "enum"
 	case *object.Range:
 		return "range"
+	case *object.FileHandle:
+		return "File"
 	case *object.Nil:
 		return "nil"
 	case *object.Function:

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -64,6 +64,8 @@ func getEZTypeName(obj object.Object) string {
 		return "Range<int>"
 	case *object.FileHandle:
 		return "File"
+	case *object.Database:
+		return "Database"
 	case *object.Reference:
 		// Get the inner type by dereferencing
 		if inner, ok := v.Deref(); ok {

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -64,6 +64,12 @@ func getEZTypeName(obj object.Object) string {
 		return "range"
 	case *object.FileHandle:
 		return "File"
+	case *object.Reference:
+		// Get the inner type by dereferencing
+		if inner, ok := v.Deref(); ok {
+			return "Ref<" + getEZTypeName(inner) + ">"
+		}
+		return "Ref<unknown>"
 	case *object.Nil:
 		return "nil"
 	case *object.Function:

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -61,7 +61,7 @@ func getEZTypeName(obj object.Object) string {
 		}
 		return "enum"
 	case *object.Range:
-		return "range"
+		return "Range<int>"
 	case *object.FileHandle:
 		return "File"
 	case *object.Reference:

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -31,7 +31,7 @@ func getEZTypeName(obj object.Object) string {
 	case *object.Integer:
 		return v.GetDeclaredType()
 	case *object.Float:
-		return "float"
+		return v.GetDeclaredType()
 	case *object.String:
 		return "string"
 	case *object.Boolean:
@@ -81,7 +81,7 @@ func deepCopy(obj object.Object) object.Object {
 	case *object.Integer:
 		return &object.Integer{Value: v.Value, DeclaredType: v.DeclaredType}
 	case *object.Float:
-		return &object.Float{Value: v.Value}
+		return &object.Float{Value: v.Value, DeclaredType: v.DeclaredType}
 	case *object.String:
 		return &object.String{Value: v.Value}
 	case *object.Boolean:
@@ -898,7 +898,7 @@ var StdBuiltins = map[string]*object.Builtin{
 			}
 			// Convert to float32 and back to truncate precision
 			f32 := float32(val)
-			return &object.Float{Value: float64(f32)}
+			return &object.Float{Value: float64(f32), DeclaredType: "f32"}
 		},
 	},
 
@@ -912,7 +912,7 @@ var StdBuiltins = map[string]*object.Builtin{
 			if err != nil {
 				return err
 			}
-			return &object.Float{Value: val}
+			return &object.Float{Value: val, DeclaredType: "f64"}
 		},
 	},
 

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -25,6 +25,7 @@ var stdinReader = bufio.NewReader(os.Stdin)
 var stdinEOFReached = false
 
 // getEZTypeName returns the EZ language type name for an object
+// Returns the full type as it would appear in EZ code (e.g., "[int]", "map[string:int]")
 func getEZTypeName(obj object.Object) string {
 	switch v := obj.(type) {
 	case *object.Integer:
@@ -40,14 +41,31 @@ func getEZTypeName(obj object.Object) string {
 	case *object.Byte:
 		return "byte"
 	case *object.Array:
+		if v.ElementType != "" {
+			return "[" + v.ElementType + "]"
+		}
 		return "array"
+	case *object.Map:
+		if v.KeyType != "" && v.ValueType != "" {
+			return "map[" + v.KeyType + ":" + v.ValueType + "]"
+		}
+		return "map"
 	case *object.Struct:
 		if v.TypeName != "" {
 			return v.TypeName
 		}
 		return "struct"
+	case *object.EnumValue:
+		if v.EnumType != "" {
+			return v.EnumType
+		}
+		return "enum"
+	case *object.Range:
+		return "range"
 	case *object.Nil:
 		return "nil"
+	case *object.Function:
+		return "function"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/stdlib/bytes.go
+++ b/pkg/stdlib/bytes.go
@@ -388,7 +388,7 @@ var BytesBuiltins = map[string]*object.Builtin{
 				}
 				elements[i] = &object.Array{Elements: partElements, ElementType: "byte"}
 			}
-			return &object.Array{Elements: elements}
+			return &object.Array{Elements: elements, ElementType: "[byte]"}
 		},
 	},
 

--- a/pkg/stdlib/crypto.go
+++ b/pkg/stdlib/crypto.go
@@ -85,7 +85,7 @@ var CryptoBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7011", Message: "crypto.random_bytes() length cannot be negative"}
 			}
 			if n == 0 {
-				return &object.Array{Elements: []object.Object{}, Mutable: true}
+				return &object.Array{Elements: []object.Object{}, Mutable: true, ElementType: "byte"}
 			}
 
 			bytes := make([]byte, n)

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -308,6 +308,7 @@ var DBBuiltins = map[string]*object.Builtin{
 			}
 
 			var keys object.Array
+			keys.ElementType = "string"
 			for _, pair := range db.Store.Pairs {
 				keys.Elements = append(keys.Elements, pair.Key)
 			}
@@ -339,6 +340,7 @@ var DBBuiltins = map[string]*object.Builtin{
 			}
 
 			var keys object.Array
+			keys.ElementType = "string"
 			for _, pair := range db.Store.Pairs {
 				key, ok := pair.Key.(*object.String)
 				if ok && strings.HasPrefix(key.Value, prefix.Value) {

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -65,8 +65,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			headers := object.NewMap()
+			headers.KeyType = "string"
+			headers.ValueType = "[string]"
 			for key, vals := range res.Header {
-				values := &object.Array{}
+				values := &object.Array{ElementType: "string"}
 				for _, val := range vals {
 					values.Elements = append(values.Elements, &object.String{Value: val})
 				}
@@ -134,8 +136,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			headers := object.NewMap()
+			headers.KeyType = "string"
+			headers.ValueType = "[string]"
 			for key, vals := range res.Header {
-				values := &object.Array{}
+				values := &object.Array{ElementType: "string"}
 				for _, val := range vals {
 					values.Elements = append(values.Elements, &object.String{Value: val})
 				}
@@ -203,8 +207,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			headers := object.NewMap()
+			headers.KeyType = "string"
+			headers.ValueType = "[string]"
 			for key, vals := range res.Header {
-				values := &object.Array{}
+				values := &object.Array{ElementType: "string"}
 				for _, val := range vals {
 					values.Elements = append(values.Elements, &object.String{Value: val})
 				}
@@ -267,8 +273,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			headers := object.NewMap()
+			headers.KeyType = "string"
+			headers.ValueType = "[string]"
 			for key, vals := range res.Header {
-				values := &object.Array{}
+				values := &object.Array{ElementType: "string"}
 				for _, val := range vals {
 					values.Elements = append(values.Elements, &object.String{Value: val})
 				}
@@ -336,8 +344,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			headers := object.NewMap()
+			headers.KeyType = "string"
+			headers.ValueType = "[string]"
 			for key, vals := range res.Header {
-				values := &object.Array{}
+				values := &object.Array{ElementType: "string"}
 				for _, val := range vals {
 					values.Elements = append(values.Elements, &object.String{Value: val})
 				}
@@ -452,8 +462,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			headers := object.NewMap()
+			headers.KeyType = "string"
+			headers.ValueType = "[string]"
 			for key, vals := range res.Header {
-				values := &object.Array{}
+				values := &object.Array{ElementType: "string"}
 				for _, val := range vals {
 					values.Elements = append(values.Elements, &object.String{Value: val})
 				}

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -946,7 +946,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Array{Elements: elements, Mutable: false},
+				&object.Array{Elements: elements, Mutable: false, ElementType: "string"},
 				object.NIL,
 			}}
 		},
@@ -1611,7 +1611,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Array{Elements: elements, Mutable: true},
+				&object.Array{Elements: elements, Mutable: true, ElementType: "string"},
 				object.NIL,
 			}}
 		},
@@ -1657,7 +1657,7 @@ var IOBuiltins = map[string]*object.Builtin{
 			}
 
 			return &object.ReturnValue{Values: []object.Object{
-				&object.Array{Elements: elements, Mutable: true},
+				&object.Array{Elements: elements, Mutable: true, ElementType: "string"},
 				object.NIL,
 			}}
 		},

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -367,11 +367,11 @@ func convertToTypedValue(value interface{}, targetType string) object.Object {
 	case "float":
 		switch v := value.(type) {
 		case float64:
-			return &object.Float{Value: v}
+			return &object.Float{Value: v, DeclaredType: "float"}
 		case string:
 			// Strings stay as strings, can't auto-convert
 		}
-		return &object.Float{Value: 0.0}
+		return &object.Float{Value: 0.0, DeclaredType: "float"}
 
 	case "string":
 		switch v := value.(type) {
@@ -413,7 +413,7 @@ func zeroValueForType(typeName string) object.Object {
 	case "int":
 		return &object.Integer{Value: big.NewInt(0)}
 	case "float":
-		return &object.Float{Value: 0.0}
+		return &object.Float{Value: 0.0, DeclaredType: "float"}
 	case "string":
 		return &object.String{Value: ""}
 	case "bool":
@@ -445,7 +445,7 @@ func goValueToObject(value interface{}) object.Object {
 		if v == float64(int64(v)) {
 			return &object.Integer{Value: big.NewInt(int64(v))}
 		}
-		return &object.Float{Value: v}
+		return &object.Float{Value: v, DeclaredType: "float"}
 
 	case string:
 		return &object.String{Value: v}

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -158,7 +158,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			for i, pair := range m.Pairs {
 				keys[i] = pair.Key
 			}
-			return &object.Array{Elements: keys, Mutable: true}
+			return &object.Array{Elements: keys, Mutable: true, ElementType: m.KeyType}
 		},
 	},
 
@@ -175,7 +175,7 @@ var MapsBuiltins = map[string]*object.Builtin{
 			for i, pair := range m.Pairs {
 				values[i] = pair.Value
 			}
-			return &object.Array{Elements: values, Mutable: true}
+			return &object.Array{Elements: values, Mutable: true, ElementType: m.ValueType}
 		},
 	},
 
@@ -186,6 +186,11 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			// Create a new map with all entries from all input maps (non-destructive)
 			result := object.NewMap()
+			// Inherit type info from first map
+			if firstMap, ok := args[0].(*object.Map); ok {
+				result.KeyType = firstMap.KeyType
+				result.ValueType = firstMap.ValueType
+			}
 			for _, arg := range args {
 				m, ok := arg.(*object.Map)
 				if !ok {
@@ -417,6 +422,9 @@ var MapsBuiltins = map[string]*object.Builtin{
 			}
 			// Create new map with values as keys and keys as values
 			result := object.NewMap()
+			// Swap key and value types
+			result.KeyType = m.ValueType
+			result.ValueType = m.KeyType
 			for _, pair := range m.Pairs {
 				// Value must be hashable to become a key
 				if _, hashOk := object.HashKey(pair.Value); !hashOk {

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -107,6 +107,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	"os.env": {
 		Fn: func(args ...object.Object) object.Object {
 			envMap := object.NewMap()
+			envMap.KeyType = "string"
+			envMap.ValueType = "string"
 			for _, entry := range os.Environ() {
 				// Find the first = to split key and value
 				for i := 0; i < len(entry); i++ {
@@ -137,7 +139,7 @@ var OSBuiltins = map[string]*object.Builtin{
 			for i, arg := range sourceArgs {
 				elements[i] = &object.String{Value: arg}
 			}
-			return &object.Array{Elements: elements, Mutable: false}
+			return &object.Array{Elements: elements, Mutable: false, ElementType: "string"}
 		},
 	},
 

--- a/pkg/stdlib/random.go
+++ b/pkg/stdlib/random.go
@@ -17,7 +17,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 	"random.float": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
-				return &object.Float{Value: rand.Float64()}
+				return &object.Float{Value: rand.Float64(), DeclaredType: "float"}
 			} else if len(args) == 2 {
 				min, err := getRandomNumber(args[0])
 				if err != nil {
@@ -30,7 +30,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				if max <= min {
 					return &object.Error{Code: "E8006", Message: "random.float() max must be greater than min"}
 				}
-				return &object.Float{Value: min + rand.Float64()*(max-min)}
+				return &object.Float{Value: min + rand.Float64()*(max-min), DeclaredType: "float"}
 			}
 			return &object.Error{Code: "E7001", Message: "random.float() takes 0 or 2 arguments"}
 		},
@@ -168,7 +168,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				newElements[i], newElements[j] = newElements[j], newElements[i]
 			}
 
-			return &object.Array{Elements: newElements, Mutable: true}
+			return &object.Array{Elements: newElements, Mutable: true, ElementType: arr.ElementType}
 		},
 	},
 
@@ -212,7 +212,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				result[i] = arr.Elements[indices[i]]
 			}
 
-			return &object.Array{Elements: result, Mutable: true}
+			return &object.Array{Elements: result, Mutable: true, ElementType: arr.ElementType}
 		},
 	},
 }

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -91,7 +91,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			for i, p := range parts {
 				elements[i] = &object.String{Value: p}
 			}
-			return &object.Array{Elements: elements}
+			return &object.Array{Elements: elements, ElementType: "string"}
 		},
 	},
 
@@ -433,7 +433,7 @@ var StringsBuiltins = map[string]*object.Builtin{
 			for i, r := range runes {
 				elements[i] = &object.Char{Value: r}
 			}
-			return &object.Array{Elements: elements, Mutable: true}
+			return &object.Array{Elements: elements, Mutable: true, ElementType: "char"}
 		},
 	},
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -3279,8 +3279,9 @@ func (tc *TypeChecker) checkBuiltinTypeConversion(funcName string, call *ast.Cal
 		return true
 
 	case "string", "bool", "char", "byte",
-		"i8", "i16", "i32", "i64",
-		"u8", "u16", "u32", "u64":
+		"i8", "i16", "i32", "i64", "i128", "i256",
+		"u8", "u16", "u32", "u64", "u128", "u256",
+		"f32", "f64":
 		// These conversions are generally safe - but validate arg count
 		if len(call.Arguments) != 1 {
 			line, column := tc.getExpressionPosition(call.Function)
@@ -4307,6 +4308,8 @@ func (tc *TypeChecker) isBuiltinFunction(name string) bool {
 		"int": true, "float": true, "string": true, "bool": true, "char": true,
 		"i8": true, "i16": true, "i32": true, "i64": true,
 		"u8": true, "u16": true, "u32": true, "u64": true,
+		"i128": true, "i256": true, "u128": true, "u256": true,
+		"f32": true, "f64": true,
 		"byte": true,
 		// Core builtins
 		"len": true, "typeof": true, "input": true, "copy": true, "error": true,
@@ -5018,6 +5021,18 @@ func (tc *TypeChecker) inferBuiltinCallType(name string, args []ast.Expression) 
 		return "u32", true
 	case "u64":
 		return "u64", true
+	case "i128":
+		return "i128", true
+	case "i256":
+		return "i256", true
+	case "u128":
+		return "u128", true
+	case "u256":
+		return "u256", true
+	case "f32":
+		return "f32", true
+	case "f64":
+		return "f64", true
 	case "input":
 		return "string", true
 	case "read_int":

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -3310,12 +3310,21 @@ func (tc *TypeChecker) checkBuiltinTypeConversion(funcName string, call *ast.Cal
 		return true
 
 	case "typeof":
-		// typeof() requires exactly 1 argument (any type)
+		// typeof() requires exactly 1 argument (any type except void)
 		if len(call.Arguments) != 1 {
 			line, column := tc.getExpressionPosition(call.Function)
 			tc.addError(errors.E5008,
 				fmt.Sprintf("typeof() requires exactly 1 argument, got %d", len(call.Arguments)),
 				line, column)
+		} else {
+			// Check if argument is a void function call
+			argType, ok := tc.inferExpressionType(call.Arguments[0])
+			if ok && argType == "void" {
+				line, column := tc.getExpressionPosition(call.Arguments[0])
+				tc.addError(errors.E3038,
+					"cannot use void function result as argument to typeof()",
+					line, column)
+			}
 		}
 		return true
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4871,7 +4871,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		case "read_stdin":
 			return []string{"string", "error"}
 		case "open", "create":
-			return []string{"FileHandle", "error"}
+			return []string{"File", "error"}
 		case "fread", "fread_line", "fread_all":
 			return []string{"string", "error"}
 		case "fread_bytes":
@@ -5334,7 +5334,7 @@ func (tc *TypeChecker) inferIOCallType(funcName string, args []ast.Expression) (
 	case "file_size", "file_mod_time", "write", "seek", "tell":
 		return "int", true
 	case "open":
-		return "FileHandle", true
+		return "File", true
 	case "READ_ONLY", "WRITE_ONLY", "READ_WRITE", "APPEND",
 		"CREATE", "TRUNCATE", "EXCLUSIVE",
 		"SEEK_START", "SEEK_CURRENT", "SEEK_END":


### PR DESCRIPTION
## Summary

Fixes #900 - `typeof()` and other type-related functions were returning internal Go type names instead of user-facing EZ types.

### Changes

**Core type representation fixes:**
- Added `KeyType` and `ValueType` fields to Map struct for proper map type tracking
- Added `DeclaredType` support for Float (distinguishes `float`, `f32`, `f64`)
- Updated `getEZTypeName()` to return proper EZ type names for all types
- Special types now return PascalCase names: `File`, `Database`, `Range<int>`, `Ref<type>`

**Stdlib modules updated to preserve type information:**
- `@strings` - arrays return `[string]`, `[char]` element types
- `@maps` - keys/values preserve proper element types
- `@arrays` - all functions preserve `ElementType` through operations
- `@io` - file operations return `[string]` for directory listings, `File` for handles
- `@db` - returns `Database` type, arrays with `[string]` element type
- `@os` - `os.args` returns `[string]`, `os.env` returns `map[string:string]`
- `@random` - floats have `DeclaredType`, arrays preserve element types
- `@json` - parsed floats have proper `DeclaredType`
- `@crypto` - `random_bytes` returns `[byte]`
- `@bytes` - `split` returns `[[byte]]`
- `@binary` - float decode functions return proper `f32`/`f64` types
- `@http` - headers map has `map[string:[string]]` type

**Other fixes:**
- Typechecker now rejects `typeof()` on void function results
- `deepCopy` preserves Map `KeyType`/`ValueType`

### Type naming conventions

| Type | Example |
|------|---------|
| Primitives | `int`, `float`, `string`, `bool`, `byte`, `char` |
| Sized types | `i8`, `u16`, `f32`, `f64`, etc. |
| Arrays | `[int]`, `[string]`, `[[byte]]` |
| Maps | `map[string:int]`, `map[int:string]` |
| Special types | `File`, `Database`, `Range<int>`, `Ref<int>` |
| User types | `Point`, `Color` (struct/enum names) |

## Test plan

- [x] Unit tests pass: `go test ./pkg/stdlib/...`
- [x] Integration tests pass (329/331 - 2 pre-existing failures unrelated to this PR)
- [x] Updated `typeof.ez` test for `Range<int>`
- [x] Added new `typeof_stdlib.ez` test covering stdlib return types