### PR TITLE
feat(http): add HTTP status code constants

### DIFF
--- a/examples/http.ez
+++ b/examples/http.ez
@@ -8,6 +8,10 @@ do main() {
         println("Error: ${err.message}")
         return
     }
+    if resp.status != http.OK {
+        println("Request Failed: ${resp.status}")
+        return
+    }
     println("Status: ${resp.status}")
     println("Body: ${resp.body}")
 		temp content_type = resp.headers["Content-Type"][0]
@@ -18,6 +22,10 @@ do main() {
         "https://api.example.com/users",
         http.json_body({"name": "John", "email": "john@example.com"})
     )
+    if post_resp.status != http.CREATED {
+        println("Request Failed: ${post_err.message}")
+        return
+    }
 
     // Advanced request with custom headers
     temp headers map[string:string] = {
@@ -31,17 +39,17 @@ do main() {
         headers,
         60
     )
-		if adv_err != nil {
+    if adv_err != nil {
         println("Error: ${adv_err.message}")
         return
-		}
+    }
 
     // URL utilities
     temp encoded string = http.encode_url("hello world")  // "hello%20world"
-		temp decoded string, decode_err error = http.decode_url(encoded)
-		if decode_err != nil {
-			println("${decode_err}")
-			return
-		}
+    temp decoded string, decode_err error = http.decode_url(encoded)
+    if decode_err != nil {
+        println("${decode_err}")
+        return
+    }
     temp query string = http.build_query({"page": "1", "limit": "10"})  // "page=1&limit=10"
 }

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -12,9 +12,30 @@ import (
 )
 
 const DEFAULT_TIMEOUT = 30
+const (
+	OK                    int64 = 200
+	CREATED               int64 = 201
+	ACCEPTED              int64 = 202
+	NO_CONTENT            int64 = 204
+	MOVED_PERMANENTLY     int64 = 301
+	FOUND                 int64 = 302
+	NOT_MODIFIED          int64 = 304
+	TEMPORARY_REDIRECT    int64 = 307
+	PERMANENT_REDIRECT    int64 = 308
+	BAD_REQUEST           int64 = 400
+	UNAUTHORIZED          int64 = 401
+	PAYMENT_REQUIRED      int64 = 402
+	FORBIDDEN             int64 = 403
+	NOT_FOUND             int64 = 404
+	METHOD_NOT_ALLOWED    int64 = 405
+	CONFLICT              int64 = 409
+	INTERNAL_SERVER_ERROR int64 = 500
+	BAD_GATEWAY           int64 = 502
+	SERVICE_UNAVAILABLE   int64 = 503
+)
 
 var defaultClient = &http.Client{
-	Timeout: time.Duration(DEFAULT_TIMEOUT)*time.Second,
+	Timeout: time.Duration(DEFAULT_TIMEOUT) * time.Second,
 }
 
 var HttpBuiltins = map[string]*object.Builtin{
@@ -240,7 +261,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
-			
+
 			req, err := http.NewRequest(http.MethodDelete, urlArg.Value, nil)
 			if err != nil {
 				return &object.ReturnValue{
@@ -404,7 +425,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			client := http.Client{
-				Timeout: time.Duration(timeout)*time.Second,
+				Timeout: time.Duration(timeout) * time.Second,
 			}
 
 			var req *http.Request
@@ -425,7 +446,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			case "HEAD":
 				req, err = http.NewRequest(http.MethodHead, urlArg.Value, nil)
 			default:
-				return &object.Error{Code: "E14004", Message: "invalid HTTP method: `"+methodArg.Value+"`"}
+				return &object.Error{Code: "E14004", Message: "invalid HTTP method: `" + methodArg.Value + "`"}
 			}
 			if err != nil {
 				return &object.ReturnValue{
@@ -481,7 +502,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"http.encode_url":  {
+	"http.encode_url": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
 				return &object.Error{Code: "E7001", Message: "http.encode_url() takes exactly 1 arguments"}
@@ -498,7 +519,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"http.decode_url":  {
+	"http.decode_url": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
 				return &object.Error{Code: "E7001", Message: "http.decode_url() takes exactly 1 arguments"}
@@ -575,12 +596,126 @@ var HttpBuiltins = map[string]*object.Builtin{
 			return &object.String{Value: result}
 		},
 	},
-} 
+
+	"http.OK": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(OK)}
+		},
+	},
+
+	"http.CREATED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(CREATED)}
+		},
+	},
+
+	"http.ACCEPTED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(ACCEPTED)}
+		},
+	},
+
+	"http.NO_CONTENT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(NO_CONTENT)}
+		},
+	},
+
+	"http.MOVED_PERMANENTLY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(MOVED_PERMANENTLY)}
+		},
+	},
+
+	"http.FOUND": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(FOUND)}
+		},
+	},
+
+	"http.NOT_MODIFIED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(NOT_MODIFIED)}
+		},
+	},
+
+	"http.TEMPORARY_REDIRECT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(TEMPORARY_REDIRECT)}
+		},
+	},
+
+	"http.PERMANENT_REDIRECT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(PERMANENT_REDIRECT)}
+		},
+	},
+
+	"http.BAD_REQUEST": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(BAD_REQUEST)}
+		},
+	},
+
+	"http.UNAUTHORIZED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(UNAUTHORIZED)}
+		},
+	},
+
+	"http.PAYMENT_REQUIRED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(PAYMENT_REQUIRED)}
+		},
+	},
+
+	"http.FORBIDDEN": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(FORBIDDEN)}
+		},
+	},
+
+	"http.NOT_FOUND": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(NOT_FOUND)}
+		},
+	},
+
+	"http.METHOD_NOT_ALLOWED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(METHOD_NOT_ALLOWED)}
+		},
+	},
+
+	"http.CONFLICT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(CONFLICT)}
+		},
+	},
+
+	"http.INTERNAL_SERVER_ERROR": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(INTERNAL_SERVER_ERROR)}
+		},
+	},
+
+	"http.BAD_GATEWAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(BAD_GATEWAY)}
+		},
+	},
+
+	"http.SERVICE_UNAVAILABLE": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(SERVICE_UNAVAILABLE)}
+		},
+	},
+}
 
 func createHttpError(code, message string) *object.Struct {
 	return &object.Struct{
 		TypeName: "Error",
-		Mutable: false,
+		Mutable:  false,
 		Fields: map[string]object.Object{
 			"message": &object.String{Value: message},
 			"code":    &object.String{Value: code},
@@ -591,10 +726,10 @@ func createHttpError(code, message string) *object.Struct {
 func newHttpResponse(status int, body string, headers *object.Map) *object.Struct {
 	return &object.Struct{
 		TypeName: "HttpResponse",
-		Mutable: false,
+		Mutable:  false,
 		Fields: map[string]object.Object{
-			"status": &object.Integer{Value: big.NewInt(int64(status))},
-			"body": &object.String{Value: body},
+			"status":  &object.Integer{Value: big.NewInt(int64(status))},
+			"body":    &object.String{Value: body},
 			"headers": headers,
 		},
 	}


### PR DESCRIPTION
# Summary

Resolve #901 - Add user-facing HTTP status code constants

Add HTTP status code constants to allow more readable status code comparisons, usage instead of hard-coded integres.

---

# Changes

## Implemented constants
2xx: `OK`, `CREATED`, `ACCEPTED`, `NO_CONTENT`
3xx: `MOVED_PERMANENTLY`, `FOUND`, `NOT_MODIFIED`, `TEMPORARY_REDIRECT`, `PERMANENT_REDIRECT`
4xx: `BAD_REQUEST`, `UNAUTHORIZED`, `PAYMENT_REQUIRED`, `FORBIDDEN`, `NOT_FOUND`, `METHOD_NOT_ALLOWED`, `CONFLICT`
5xx: `INTERNAL_SERVER_ERROR`, `BAD_GATEWAY`, `SERVICE_UNAVAILABLE`

## Example

In `http.ez`, Added some use HTTP status code use cases
```ez
...
if resp.status != http.OK {
        println("Request Failed: ${resp.status}")
        return
}
...
if post_resp.status != http.CREATED {
        println("Request Failed: ${post_err.message}")
        return
}
...
```

---

# Test Results

## Manual tests
<img width="646" height="883" alt="스크린샷 2026-01-05 221808" src="https://github.com/user-attachments/assets/2f06490a-9254-4c80-83db-aad18a3fb55e" />

## Unit tests
<img width="514" height="253" alt="스크린샷 2026-01-05 221843" src="https://github.com/user-attachments/assets/caf2daf7-2cf7-4ee1-85f5-f83aecb22abb" />

## Integration tests
<img width="600" height="165" alt="스크린샷 2026-01-05 221857" src="https://github.com/user-attachments/assets/ea209586-6352-43cd-a45e-65f81e41b394" />

# Formatting
<img width="424" height="39" alt="스크린샷 2026-01-05 221955" src="https://github.com/user-attachments/assets/c5f95b26-bfea-47e2-8ca8-110c000b9080" />
