### PR TITLE
feat: added `{:}` syntax for empty map literals

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2882,6 +2882,22 @@ func (p *Parser) parseNilValue() Expression {
 func (p *Parser) parseArrayValue() Expression {
 	startToken := p.currentToken
 
+	// Check if this is an empty map literal {:}
+	if p.peekTokenMatches(COLON) {
+		// Save lexer state for speculative lookahead
+		savedState := p.l.SaveState()
+		// Get the token after : (peekToken is currently :)
+		afterColon := p.l.NextToken()
+		// Restore lexer state
+		p.l.RestoreState(savedState)
+		// If colon is followed by }, this is {:}
+		if afterColon.Type == RBRACE {
+			p.nextToken() // consume :
+			p.nextToken() // consume }
+			return &MapValue{Token: startToken, Pairs: []*MapPair{}}
+		}
+	}
+
 	// Check if this is an empty literal {} - treat as empty array
 	if p.peekTokenMatches(RBRACE) {
 		p.nextToken()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -315,16 +315,28 @@ func TestArrayLiterals(t *testing.T) {
 }
 
 func TestMapLiterals(t *testing.T) {
-	input := `temp m map[string:int] = {"a": 1, "b": 2}`
-	program := parseProgram(t, input)
-	stmt := program.Statements[0].(*VariableDeclaration)
-
-	mapVal, ok := stmt.Value.(*MapValue)
-	if !ok {
-		t.Fatalf("not MapValue, got %T", stmt.Value)
+	tests := []struct {
+		name      string
+		input     string
+		expectedPairs int
+	}{
+		{"non-empty map", `temp m map[string:int] = {"a": 1, "b": 2}`, 2},
+		{"empty map", `temp m map[string:int] = {:}`, 0},
 	}
-	if len(mapVal.Pairs) != 2 {
-		t.Errorf("expected 2 pairs, got %d", len(mapVal.Pairs))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program := parseProgram(t, tt.input)
+			stmt := program.Statements[0].(*VariableDeclaration)
+
+			mapVal, ok := stmt.Value.(*MapValue)
+			if !ok {
+				t.Fatalf("not MapValue, got %T", stmt.Value)
+			}
+			if len(mapVal.Pairs) != tt.expectedPairs {
+				t.Errorf("expected %d pairs, got %d", tt.expectedPairs, len(mapVal.Pairs))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
I have updated parser.go and parser_test.go and it should be now working like:
When the parser sees `{`, it calls `parseArrayValue()` , it checks if the next token is `:`. If yes, it saves `lexer` state, peeks at the token after `:`, then restores state and if that token is `}`, it consumes `:` and `}`, and returns an empty `MapValue`. Otherwise, it just continues with normal parsing.

- closes #894 