### PR TITLE
feat(time): add time constants for weekdays, months, and durations

### DIFF
--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -648,6 +648,132 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: float64(elapsed) / 1e6}
 		},
 	},
+
+	// Weekday Constants
+	"time.SUNDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(0)}
+		},
+	},
+	"time.MONDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(1)}
+		},
+	},
+	"time.TUESDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(2)}
+		},
+	},
+	"time.WEDNESDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(3)}
+		},
+	},
+	"time.THURSDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(4)}
+		},
+	},
+	"time.FRIDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(5)}
+		},
+	},
+	"time.SATURDAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(6)}
+		},
+	},
+
+	// Month Constants
+	"time.JANUARY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(1)}
+		},
+	},
+	"time.FEBRUARY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(2)}
+		},
+	},
+	"time.MARCH": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(3)}
+		},
+	},
+	"time.APRIL": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(4)}
+		},
+	},
+	"time.MAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(5)}
+		},
+	},
+	"time.JUNE": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(6)}
+		},
+	},
+	"time.JULY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(7)}
+		},
+	},
+	"time.AUGUST": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(8)}
+		},
+	},
+	"time.SEPTEMBER": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(9)}
+		},
+	},
+	"time.OCTOBER": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(10)}
+		},
+	},
+	"time.NOVEMBER": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(11)}
+		},
+	},
+	"time.DECEMBER": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(12)}
+		},
+	},
+
+	// Duration Constants (in seconds)
+	"time.SECOND": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(1)}
+		},
+	},
+	"time.MINUTE": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(60)}
+		},
+	},
+	"time.HOUR": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(3600)}
+		},
+	},
+	"time.DAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(86400)}
+		},
+	},
+	"time.WEEK": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(604800)}
+		},
+	},
 }
 
 // Helper to get time from args (current time if no args)


### PR DESCRIPTION
# Summary
Resolve #902 - Add user-facing time constants for better code readability.

This PR adds constants to the @time library to allow more intuitive time-related comparisons and arithmetic, avoiding the use of hard-coded magic numbers.

# Constants
### Weekday Constants (matching Go's time.Weekday)
time.SUNDAY (0)
time.MONDAY (1)
time.TUESDAY (2)
time.WEDNESDAY (3)
time.THURSDAY (4)
time.FRIDAY (5)
time.SATURDAY (6)

### Month Constants
time.JANUARY (1)
time.FEBRUARY (2)
time.MARCH (3)
time.APRIL (4)
time.MAY (5)
time.JUNE (6)
time.JULY (7)
time.AUGUST (8)
time.SEPTEMBER (9)
time.OCTOBER (10)
time.NOVEMBER (11)
time.DECEMBER (12)

### Duration Constants (in seconds, for use with timestamps)
time.SECOND (1)
time.MINUTE (60)
time.HOUR (3600)
time.DAY (86400)
time.WEEK (604800)

# Test
<img width="928" height="1300" alt="image" src="https://github.com/user-attachments/assets/73a2143f-1cde-45f9-b905-01710eda6d5c" />
<img width="640" height="616" alt="image" src="https://github.com/user-attachments/assets/faa662ce-66b8-401e-8e85-f25f2b81484b" />
