### PR TITLE
chore: improve type mismatch error for char/string assignment #913

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1830,7 +1830,7 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 						decl.Name.Token.Line,
 						decl.Name.Token.Column,
 						sourceLine,
-						fmt.Sprintf("use single quotes for char literals: '%s'", decl.Name.Value),
+						fmt.Sprintf("use single quotes for char literals: '%s'", decl.Value.TokenLiteral()),
 					)
 					tc.errors.AddError(mismatchError)
 				} else {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1819,12 +1819,29 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 
 			// Check for type mismatch
 			if !tc.typesCompatible(declaredType, actualType) {
-				tc.addError(
-					errors.E3001,
-					fmt.Sprintf("type mismatch: cannot assign %s to %s", actualType, declaredType),
-					decl.Name.Token.Line,
-					decl.Name.Token.Column,
-				)
+
+				if declaredType == "char" && actualType == "string" {
+					sourceLine := errors.GetSourceLine(tc.source, decl.Name.Token.Line)
+
+					mismatchError := errors.NewErrorWithHelp(
+						errors.E3001,
+						fmt.Sprintf("type mismatch: cannot assign %s to %s", actualType, declaredType),
+						decl.Name.Token.File,
+						decl.Name.Token.Line,
+						decl.Name.Token.Column,
+						sourceLine,
+						fmt.Sprintf("use single quotes for char literals: '%s'", decl.Name.Value),
+					)
+					tc.errors.AddError(mismatchError)
+				} else {
+					tc.addError(
+						errors.E3001,
+						fmt.Sprintf("type mismatch: cannot assign %s to %s", actualType, declaredType),
+						decl.Name.Token.Line,
+						decl.Name.Token.Column,
+					)
+				}
+
 				return
 			}
 


### PR DESCRIPTION
### Overview


This PR addresses issue #913 by enhancing the error messages that shows up when a `string` is assigned to a variable of type `char`. It now provides a hint suggesting the use of single quotes, making it easier to identify the syntax error.

### Changes


- Updated the type checker to detect specific `char` vs `string` mismatches.
- Added a help hint message that suggests the single-quote alternative.
- Integrated `NewErrorWithHelp` to maintain consistency with compiler's format.

### Output
Before:
```text
error[E3001]: type mismatch: cannot assign string to char
  --> file.ez:5:10
   |
5  |     temp x char = "x"
   |          ^ types do not match
```
   
After:
```text
error[E3001]: type mismatch: cannot assign string to char
  --> file.ez:5:10
   |
5  |     temp x char = "x"
   |          ^ types do not match
   |
   = help: use single quotes for char literals: 'x'
```   
   
   
### Testing

- [x] Verified that the specific help message triggers only for char vs string mismatches.
- [x] Confirmed that standard type mismatch errors remain unaffected.
- [x] Passed all local tests.

Closes #913