### PR TITLE
chore: update contributors in README and workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -98,11 +98,13 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit changes
+      - name: Create Pull Request
         if: steps.check.outputs.changed == 'true'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add README.md
-          git commit -m "chore: update contributors in README"
-          git push
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update contributors in README"
+          title: "chore: update contributors in README"
+          body: "Auto-generated PR to add new contributors to README."
+          branch: chore/auto-update-contributors
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -156,3 +156,5 @@ Thank you to everyone who has contributed to EZ!
 <a href="https://github.com/jaideepkathiresan"><img src="https://github.com/jaideepkathiresan.png" width="50" height="50" alt="jaideepkathiresan"/></a>
 <a href="https://github.com/Abhishek022001"><img src="https://github.com/Abhishek022001.png" width="50" height="50" alt="Abhishek022001"/></a>
 <a href="https://github.com/Scanf-s"><img src="https://github.com/Scanf-s.png" width="50" height="50" alt="Scanf-s"/></a>
+<a href="https://github.com/HCH1212"><img src="https://github.com/HCH1212.png" width="50" height="50" alt="HCH1212"/></a>
+<a href="https://github.com/elect0"><img src="https://github.com/elect0.png" width="50" height="50" alt="elect0"/></a>


### PR DESCRIPTION
## Summary
- Update contributors list
- Fix update-contributors workflow to create PRs instead of pushing directly to protected main branch

The workflow was failing because `main` is protected and requires PRs. Now it uses `peter-evans/create-pull-request` action.