### PR TITLE
fix(cli): exit original process after sudo completes

### DIFF
--- a/cmd/ez/update.go
+++ b/cmd/ez/update.go
@@ -637,7 +637,13 @@ func downloadAndInstall(url string) error {
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		return cmd.Run()
+
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("failed to run with sudo: %w", err)
+		}
+
+		os.Exit(0)
 	}
 
 	return doInstall(url, execPath)


### PR DESCRIPTION
This PR implements the change described in the issue. 

**Summary**

- Replaces bare `return cmd.Run()` with explicit error handling and process exit

Fixes #922 