### PR TITLE
ci: add pull-requests permission to contributors workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `peter-evans/create-pull-request` action requires `pull-requests: write` permission to create PRs.

This fixes the workflow failure:
```
Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```