### PR TITLE
fix(interpreter): allow arbitrary precision arithmetic for int/uint types

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -62,15 +62,19 @@ func init() {
 }
 
 // getTypeBounds returns the min and max values for a given integer type
+// Returns nil, nil for arbitrary precision types (int, uint) that have no bounds
 func getTypeBounds(typeName string) (min, max *big.Int) {
 	switch typeName {
+	case "int", "uint":
+		// Arbitrary precision - no bounds
+		return nil, nil
 	case "i8":
 		return minInt8, maxInt8
 	case "i16":
 		return minInt16, maxInt16
 	case "i32":
 		return minInt32, maxInt32
-	case "i64", "int", "":
+	case "i64", "":
 		return minInt64, maxInt64
 	case "i128":
 		return minInt128, maxInt128
@@ -82,7 +86,7 @@ func getTypeBounds(typeName string) (min, max *big.Int) {
 		return zero, maxUint16
 	case "u32":
 		return zero, maxUint32
-	case "u64", "uint":
+	case "u64":
 		return zero, maxUint64
 	case "u128":
 		return zero, maxUint128
@@ -95,8 +99,13 @@ func getTypeBounds(typeName string) (min, max *big.Int) {
 }
 
 // checkOverflow checks if a value is within bounds for a given type
+// Returns false for arbitrary precision types (int, uint) that have no bounds
 func checkOverflow(result *big.Int, typeName string) bool {
 	min, max := getTypeBounds(typeName)
+	if min == nil || max == nil {
+		// Arbitrary precision type - no overflow possible
+		return false
+	}
 	return result.Cmp(min) < 0 || result.Cmp(max) > 0
 }
 

--- a/pkg/interpreter/evaluator_test.go
+++ b/pkg/interpreter/evaluator_test.go
@@ -4132,7 +4132,7 @@ func TestPostfixOverflowDetection(t *testing.T) {
 		{
 			name: "increment overflow",
 			input: `
-temp i int = 9223372036854775807
+temp i i64 = 9223372036854775807
 i++
 `,
 			expectError: true,
@@ -4141,7 +4141,7 @@ i++
 		{
 			name: "decrement underflow",
 			input: `
-temp i int = -9223372036854775808
+temp i i64 = -9223372036854775808
 i--
 `,
 			expectError: true,
@@ -4276,8 +4276,8 @@ func TestLargeIntegerOverflow(t *testing.T) {
 			"E5006",
 		},
 		{
-			"int overflow still works",
-			"temp max int = 9223372036854775807\ntemp r int = max + 1",
+			"i64 overflow still works",
+			"temp max i64 = 9223372036854775807\ntemp r i64 = max + 1",
 			"E5005",
 		},
 	}


### PR DESCRIPTION
## Summary
- Fixes #917
- The `int` and `uint` types are backed by `big.Int` but arithmetic operations were incorrectly capping at i64/u64 bounds
- Now these types have no overflow limits, matching their arbitrary precision storage

## Changes
- `getTypeBounds()` returns `nil, nil` for `int`/`uint` (arbitrary precision)
- `checkOverflow()` returns `false` when bounds are `nil`
- Updated tests to use `i64` instead of `int` for overflow detection tests

## Test plan
- [x] Verified large integer arithmetic works: `999999999999999999999999999999 + 999999999999999999999999999999`
- [x] Verified `uint` works beyond u64 max
- [x] All existing tests pass