### PR TITLE
chore(ci): add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
Adds Dependabot configuration for automated dependency updates.

## What's included
- **Go modules**: Weekly checks for Cobra and transitive dependencies
- **GitHub Actions**: Weekly checks for CI workflow updates

## Configuration
- Weekly schedule
- Max 5 open PRs per ecosystem
- `chore(deps)` commit prefix
- Auto-labels: `dependencies`, `ci`