### PR TITLE
fix(lexer,parser): add explicit `0o` octal prefix, treat leading zeros as decimal

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -198,6 +198,45 @@ func TestIntegerLiterals(t *testing.T) {
 	}
 }
 
+func TestIntegerLiteralBases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		// Hex literals
+		{"temp x int = 0xFF", 255},
+		{"temp x int = 0x10", 16},
+		{"temp x int = 0XFF", 255},
+		// Binary literals
+		{"temp x int = 0b1010", 10},
+		{"temp x int = 0B1111", 15},
+		{"temp x int = 0b0", 0},
+		// Octal literals with explicit 0o prefix
+		{"temp x int = 0o123", 83},
+		{"temp x int = 0O777", 511},
+		{"temp x int = 0o0", 0},
+		// Leading zeros should be decimal (not octal)
+		{"temp x int = 0123", 123},
+		{"temp x int = 09", 9},
+		{"temp x int = 007", 7},
+		{"temp x int = 00123", 123},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			program := parseProgram(t, tt.input)
+			if len(program.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+			}
+			stmt, ok := program.Statements[0].(*VariableDeclaration)
+			if !ok {
+				t.Fatalf("not VariableDeclaration, got %T", program.Statements[0])
+			}
+			testIntegerLiteral(t, stmt.Value, tt.expected)
+		})
+	}
+}
+
 func TestFloatLiterals(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
## Summary
- Added support for `0o`/`0O` prefix for explicit octal literals
- Changed parser to explicitly handle bases instead of auto-detection
- Leading zeros without prefix are now treated as decimal (not octal)
- `0123` is now `123` (decimal), use `0o123` for octal `83`
- `09` is now valid as decimal `9`

## Test plan
- [x] `0o123` = 83 (octal)
- [x] `0o777` = 511 (octal)
- [x] `0123` = 123 (decimal, not octal)
- [x] `09` = 9 (decimal, no longer an error)
- [x] `0xFF` = 255 (hex still works)
- [x] `0b1010` = 10 (binary still works)
- [x] Added lexer tests for octal literals
- [x] Added parser tests for all numeric bases
- [x] All existing tests pass

Fixes #915