### PR TITLE
fix(interpreter): add Map case to objectTypeToEZ function

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3225,6 +3225,12 @@ func objectTypeToEZ(obj Object) string {
 			types[i] = objectTypeToEZ(val)
 		}
 		return "(" + strings.Join(types, ", ") + ")"
+	case *Map:
+		// Return typed map format if key/value types are known
+		if v.KeyType != "" && v.ValueType != "" {
+			return "map[" + v.KeyType + ":" + v.ValueType + "]"
+		}
+		return "map"
 	default:
 		return string(obj.Type())
 	}


### PR DESCRIPTION
## Summary
- Added missing `*Map` case to `objectTypeToEZ` function
- Error messages now show `map[keyType:valueType]` instead of `MAP`

## Before
```
error[E5012]: return type mismatch: expected map[string:string], got MAP
```

## After
```
error[E3012]: return type mismatch: expected string, got map[string:string]
```

## Test plan
- [x] Verified error messages show proper map type format
- [x] All existing tests pass

Fixes #945