### PR TITLE
fix(interpreter,stdlib): replace `.Type()` with helper functions in error messages

### DIFF
--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -23,6 +23,7 @@ func init() {
 
 // getEZTypeName returns the EZ language type name for an object
 // For integers, returns the declared type (e.g., "u64", "i32") instead of generic "INTEGER"
+// For arrays and maps, returns the typed format (e.g., "[string]", "map[string:int]")
 func getEZTypeName(obj Object) string {
 	switch v := obj.(type) {
 	case *Integer:
@@ -38,8 +39,14 @@ func getEZTypeName(obj Object) string {
 	case *Byte:
 		return "byte"
 	case *Array:
+		if v.ElementType != "" {
+			return "[" + v.ElementType + "]"
+		}
 		return "array"
 	case *Map:
+		if v.KeyType != "" && v.ValueType != "" {
+			return "map[" + v.KeyType + ":" + v.ValueType + "]"
+		}
 		return "map"
 	case *Struct:
 		if v.TypeName != "" {

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -658,7 +658,7 @@ func Eval(node ast.Node, env *Environment) Object {
 			// Validate that the key is hashable
 			if _, hashOk := HashKey(index); !hashOk {
 				return newErrorWithLocation("E12001", node.Token.Line, node.Token.Column,
-					"unusable as map key: %s", index.Type())
+					"unusable as map key: %s", objectTypeToEZ(index))
 			}
 			value, exists := mapObj.Get(index)
 			if !exists {
@@ -681,7 +681,7 @@ func Eval(node ast.Node, env *Environment) Object {
 		idx, ok := index.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E9003", node.Token.Line, node.Token.Column,
-				"index must be an integer, got %s", index.Type())
+				"index must be an integer, got %s", objectTypeToEZ(index))
 		}
 
 		switch obj := left.(type) {
@@ -718,7 +718,7 @@ func Eval(node ast.Node, env *Environment) Object {
 
 		default:
 			return newErrorWithLocation("E5015", node.Token.Line, node.Token.Column,
-				"index operator not supported for %s", left.Type())
+				"index operator not supported for %s", objectTypeToEZ(left))
 		}
 
 	case *ast.MemberExpression:
@@ -1156,7 +1156,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 						// ok
 					default:
 						return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-							"cannot assign %s to byte variable", unpackedVal.Type())
+							"cannot assign %s to byte variable", objectTypeToEZ(unpackedVal))
 					}
 				}
 			}
@@ -1213,7 +1213,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 								// ok
 							default:
 								return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-									"cannot assign %s to byte variable", val.Type())
+									"cannot assign %s to byte variable", objectTypeToEZ(val))
 							}
 					}
 				}
@@ -1249,7 +1249,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 					// already a byte - fine
 				default:
 					return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-						"cannot assign %s to byte variable", val.Type())
+						"cannot assign %s to byte variable", objectTypeToEZ(val))
 				}
 			}
 		}
@@ -1294,7 +1294,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			index, ok := idx.(*Integer)
 			if !ok {
 				return newErrorWithLocation("E3003", node.Token.Line, node.Token.Column,
-					"array index must be integer, got %s", idx.Type())
+					"array index must be integer, got %s", objectTypeToEZ(idx))
 			}
 			arrLen := big.NewInt(int64(len(obj.Elements)))
 			if index.Value.Sign() < 0 || index.Value.Cmp(arrLen) >= 0 {
@@ -1332,7 +1332,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 					// okay
 				default:
 					return newErrorWithLocation("E3026", node.Token.Line, node.Token.Column,
-						"cannot assign %s to byte array element", val.Type())
+						"cannot assign %s to byte array element", objectTypeToEZ(val))
 				}
 			}
 
@@ -1342,13 +1342,13 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			index, ok := idx.(*Integer)
 			if !ok {
 				return newErrorWithLocation("E3003", node.Token.Line, node.Token.Column,
-					"string index must be integer, got %s", idx.Type())
+					"string index must be integer, got %s", objectTypeToEZ(idx))
 			}
 			// String mutation - verify the value is a character
 			charObj, ok := val.(*Char)
 			if !ok {
 				return newErrorWithLocation("E3004", node.Token.Line, node.Token.Column,
-					"can only assign character to string index, got %s", val.Type())
+					"can only assign character to string index, got %s", objectTypeToEZ(val))
 			}
 			// Convert string to rune slice for proper UTF-8 character indexing
 			runes := []rune(obj.Value)
@@ -1372,7 +1372,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			// Validate that the key is hashable
 			if _, ok := HashKey(idx); !ok {
 				return newErrorWithLocation("E12001", node.Token.Line, node.Token.Column,
-					"map key must be a hashable type, got %s", idx.Type())
+					"map key must be a hashable type, got %s", objectTypeToEZ(idx))
 			}
 
 			// Check if map is mutable
@@ -1409,7 +1409,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 						// ok
 					default:
 						return newErrorWithLocation("E3026", node.Token.Line, node.Token.Column,
-							"cannot assign %s to byte map element", val.Type())
+							"cannot assign %s to byte map element", objectTypeToEZ(val))
 					}
 				}
 			}
@@ -1417,7 +1417,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 
 		default:
 			return newErrorWithLocation("E3016", node.Token.Line, node.Token.Column,
-				"index operator not supported: %s", container.Type())
+				"index operator not supported: %s", objectTypeToEZ(container))
 		}
 
 	case *ast.MemberExpression:
@@ -1448,7 +1448,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 		structObj, ok := obj.(*Struct)
 		if !ok {
 			return newErrorWithLocation("E4011", node.Token.Line, node.Token.Column,
-				"member access not supported: %s", obj.Type())
+				"member access not supported: %s", objectTypeToEZ(obj))
 		}
 
 		// Check if struct is mutable
@@ -1493,7 +1493,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 					// ok
 				default:
 					return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-						"cannot assign %s to byte field", val.Type())
+						"cannot assign %s to byte field", objectTypeToEZ(val))
 				}
 			}
 		}
@@ -1752,7 +1752,7 @@ func evalRangeExpression(node *ast.RangeExpression, env *Environment) Object {
 		startInt, ok := startObj.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E5013", line, col,
-				"range start must be integer, got %s", startObj.Type())
+				"range start must be integer, got %s", objectTypeToEZ(startObj))
 		}
 		start = new(big.Int).Set(startInt.Value)
 	}
@@ -1765,7 +1765,7 @@ func evalRangeExpression(node *ast.RangeExpression, env *Environment) Object {
 	endInt, ok := endObj.(*Integer)
 	if !ok {
 		return newErrorWithLocation("E5014", line, col,
-			"range end must be integer, got %s", endObj.Type())
+			"range end must be integer, got %s", objectTypeToEZ(endObj))
 	}
 	end := new(big.Int).Set(endInt.Value)
 
@@ -1779,7 +1779,7 @@ func evalRangeExpression(node *ast.RangeExpression, env *Environment) Object {
 		stepInt, ok := stepObj.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E5019", line, col,
-				"range step must be integer, got %s", stepObj.Type())
+				"range step must be integer, got %s", objectTypeToEZ(stepObj))
 		}
 		step = new(big.Int).Set(stepInt.Value)
 		if step.Sign() == 0 {
@@ -1818,7 +1818,7 @@ func evalArrayCast(value Object, elementType string, line, col int) Object {
 	arr, ok := value.(*Array)
 	if !ok {
 		return newErrorWithLocation("E3001", line, col,
-			"cast to array type requires array value, got %s", value.Type())
+			"cast to array type requires array value, got %s", objectTypeToEZ(value))
 	}
 
 	newElements := make([]Object, len(arr.Elements))
@@ -2009,7 +2009,7 @@ func evalForEachStatement(node *ast.ForEachStatement, env *Environment) Object {
 	}
 
 	return newErrorWithLocation("E3017", node.Token.Line, node.Token.Column,
-		"for_each requires array or string, got %s", collection.Type())
+		"for_each requires array or string, got %s", objectTypeToEZ(collection))
 }
 
 func evalEnumDeclaration(node *ast.EnumDeclaration, env *Environment) Object {
@@ -2220,7 +2220,7 @@ func evalPrefixExpression(operator string, right Object) Object {
 	case "-":
 		return evalMinusPrefixOperator(right)
 	default:
-		return newError("unknown operator: %s%s", operator, right.Type())
+		return newError("unknown operator: %s%s", operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2254,7 +2254,7 @@ func evalMinusPrefixOperator(right Object) Object {
 	case *Float:
 		return &Float{Value: -obj.Value}
 	default:
-		return newError("unknown operator: -%s", right.Type())
+		return newError("unknown operator: -%s", objectTypeToEZ(right))
 	}
 }
 
@@ -2317,7 +2317,7 @@ func evalInfixExpression(operator string, left, right Object, line, col int) Obj
 	case operator == "||":
 		return nativeBoolToBooleanObject(isTruthy(left) || isTruthy(right))
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2381,7 +2381,7 @@ func evalIntegerInfixExpression(operator string, left, right Object, line, col i
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal.Cmp(rightVal) != 0)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2443,7 +2443,7 @@ func evalFloatInfixExpression(operator string, left, right Object, line, col int
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2459,7 +2459,7 @@ func evalStringInfixExpression(operator string, left, right Object) Object {
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newError("unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2481,7 +2481,7 @@ func evalCharInfixExpression(operator string, left, right Object, line, col int)
 	case ">=":
 		return nativeBoolToBooleanObject(leftVal >= rightVal)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2533,7 +2533,7 @@ func evalByteInfixExpression(operator string, left, right Object, line, col int)
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2585,7 +2585,7 @@ func evalByteIntegerInfixExpression(operator string, left, right Object, line, c
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal.Cmp(rightVal) != 0)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2596,7 +2596,7 @@ func evalInOperator(left, right Object, line, col int) Object {
 		leftInt, ok := left.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E5020", line, col,
-				"left operand of 'in range()' must be integer, got %s", left.Type())
+				"left operand of 'in range()' must be integer, got %s", objectTypeToEZ(left))
 		}
 		if r.Contains(leftInt.Value) {
 			return TRUE
@@ -2608,7 +2608,7 @@ func evalInOperator(left, right Object, line, col int) Object {
 	arr, ok := right.(*Array)
 	if !ok {
 		return newErrorWithLocation("E3014", line, col,
-			"right operand of 'in' must be array or range, got %s", right.Type())
+			"right operand of 'in' must be array or range, got %s", objectTypeToEZ(right))
 	}
 
 	for _, elem := range arr.Elements {
@@ -2665,7 +2665,7 @@ func evalPostfixExpression(node *ast.PostfixExpression, env *Environment) Object
 	intVal, ok := val.(*Integer)
 	if !ok {
 		return newErrorWithLocation("E5023", node.Token.Line, node.Token.Column,
-			"postfix operator %s requires integer operand, got %s", node.Operator, val.Type())
+			"postfix operator %s requires integer operand, got %s", node.Operator, objectTypeToEZ(val))
 	}
 
 	var newVal *big.Int
@@ -2969,7 +2969,7 @@ func applyFunction(fn Object, args []Object, line, col int) Object {
 		return result
 
 	default:
-		return newErrorWithLocation("E3015", line, col, "not a function: %s", fn.Type())
+		return newErrorWithLocation("E3015", line, col, "not a function: %s", objectTypeToEZ(fn))
 	}
 }
 
@@ -3283,7 +3283,7 @@ func evalMapLiteral(node *ast.MapValue, env *Environment) Object {
 
 		// Validate that the key is hashable
 		if _, ok := HashKey(key); !ok {
-			return newError("unusable as map key: %s", key.Type())
+			return newError("unusable as map key: %s", objectTypeToEZ(key))
 		}
 
 		value := Eval(pair.Value, env)
@@ -3645,7 +3645,7 @@ func evalMemberExpression(node *ast.MemberExpression, env *Environment) Object {
 	}
 
 	return newErrorWithLocation("E4011", node.Token.Line, node.Token.Column,
-		"member access not supported on type %s", obj.Type())
+		"member access not supported on type %s", objectTypeToEZ(obj))
 }
 
 func nativeBoolToBooleanObject(input bool) *Boolean {

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -344,7 +344,7 @@ var StdBuiltins = map[string]*object.Builtin{
 			case *object.Map:
 				return &object.Integer{Value: big.NewInt(int64(len(arg.Pairs)))}
 			default:
-				return &object.Error{Code: "E7015", Message: fmt.Sprintf("len() not supported for %s", args[0].Type())}
+				return &object.Error{Code: "E7015", Message: fmt.Sprintf("len() not supported for %s", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -469,7 +469,7 @@ var StdBuiltins = map[string]*object.Builtin{
 							"    len(myArray)  // returns the number of elements",
 					}
 				}
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to int", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to int", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -513,7 +513,7 @@ var StdBuiltins = map[string]*object.Builtin{
 							"    len(myArray)  // returns the number of elements",
 					}
 				}
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to float", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to float", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -567,7 +567,7 @@ var StdBuiltins = map[string]*object.Builtin{
 				}
 				return &object.Char{Value: runes[0]}
 			default:
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to char", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to char", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -631,7 +631,7 @@ var StdBuiltins = map[string]*object.Builtin{
 				}
 				return &object.Byte{Value: uint8(val)}
 			default:
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to byte", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to byte", getEZTypeName(args[0]))}
 			}
 		},
 	},

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -238,7 +238,7 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 			if !ok {
 				return nil, &jsonError{
 					code:    "E13003",
-					message: fmt.Sprintf("JSON object keys must be strings, got %s", pair.Key.Type()),
+					message: fmt.Sprintf("JSON object keys must be strings, got %s", getEZTypeName(pair.Key)),
 				}
 			}
 			val, err := objectToGoValue(pair.Value, seen)
@@ -297,7 +297,7 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 	default:
 		return nil, &jsonError{
 			code:    "E13002",
-			message: fmt.Sprintf("type %s cannot be converted to JSON", obj.Type()),
+			message: fmt.Sprintf("type %s cannot be converted to JSON", getEZTypeName(obj)),
 		}
 	}
 }

--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -943,7 +943,7 @@ func getNumber(obj object.Object) (float64, *object.Error) {
 	case *object.Float:
 		return v.Value, nil
 	default:
-		return 0, &object.Error{Code: "E7005", Message: fmt.Sprintf("expected number, got %s", obj.Type())}
+		return 0, &object.Error{Code: "E7005", Message: fmt.Sprintf("expected number, got %s", getEZTypeName(obj))}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replaced ~40 direct `.Type()` calls in error messages with `objectTypeToEZ()` or `getEZTypeName()`
- Updated `getEZTypeName()` in interpreter/builtins.go to include typed arrays and maps
- Prevents internal Go type names from leaking into user-facing errors

## Before
```
error: index must be an integer, got STRING_OBJ
error: unknown operator: INTEGER_OBJ + MAP_OBJ
error: len() not supported for ARRAY_OBJ
```

## After
```
error: index must be an integer, got string
error: return type mismatch: expected string, got map[string:int]
error: return type mismatch: expected string, got [string]
```

## Files Changed
- `pkg/interpreter/evaluator.go` - ~30 instances
- `pkg/interpreter/builtins.go` - updated getEZTypeName() for typed arrays/maps
- `pkg/stdlib/builtins.go` - 5 instances
- `pkg/stdlib/math.go` - 1 instance
- `pkg/stdlib/json.go` - 2 instances

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Verified error messages show correct types:
  - `string` instead of `STRING_OBJ`
  - `int` instead of `INTEGER_OBJ`
  - `[string]` instead of `ARRAY_OBJ`
  - `map[string:int]` instead of `MAP_OBJ`

Fixes #948