### PR TITLE
fix(typechecker): require type argument for `json.decode` (#947)

### DIFF
--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -340,6 +340,7 @@ var (
 	E13001 = ErrorCode{"E13001", "json-syntax-error", "invalid JSON syntax"}
 	E13002 = ErrorCode{"E13002", "json-unsupported-type", "type cannot be converted to JSON"}
 	E13003 = ErrorCode{"E13003", "json-invalid-map-key", "JSON object keys must be strings"}
+	E13004 = ErrorCode{"E13004", "json-decode-requires-type", "json.decode() requires a type argument"}
 )
 
 // =============================================================================

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4945,17 +4945,14 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		case "encode", "pretty":
 			return []string{"string", "error"}
 		case "decode":
-			// If a type argument is provided, return that type instead of "any"
+			// Type argument is required - extract the type from the second argument
 			if len(args) >= 2 {
 				if label, ok := args[1].(*ast.Label); ok {
 					return []string{label.Value, "error"}
 				}
 			}
-			return []string{"any", "error"}
-		case "parse", "parse_file":
-			return []string{"any", "error"}
-		case "stringify":
-			return []string{"string", "error"}
+			// If no type argument, return empty (error will be caught by checkJsonModuleCall)
+			return nil
 		}
 	case "os":
 		switch funcName {
@@ -5427,13 +5424,14 @@ func (tc *TypeChecker) inferJSONCallType(funcName string, args []ast.Expression)
 	case "encode", "pretty":
 		return "string", true
 	case "decode":
-		// If a type argument is provided, return that type instead of "any"
+		// Type argument is required - extract the type from the second argument
 		if len(args) >= 2 {
 			if label, ok := args[1].(*ast.Label); ok {
 				return label.Value, true
 			}
 		}
-		return "any", true
+		// If no type argument, return false (error will be caught by checkJsonModuleCall)
+		return "", false
 	case "is_valid":
 		return "bool", true
 	default:
@@ -7543,8 +7541,8 @@ func (tc *TypeChecker) checkJsonModuleCall(funcName string, call *ast.CallExpres
 	signatures := map[string]StdlibFuncSig{
 		// json.encode(value)
 		"encode": {1, 1, []string{"any"}, "tuple"},
-		// json.decode(text) or json.decode(text, Type)
-		"decode": {1, 2, []string{"string", "any"}, "tuple"},
+		// json.decode(text, Type) - Type argument is REQUIRED
+		"decode": {2, 2, []string{"string", "any"}, "tuple"},
 		// json.pretty(value, indent)
 		"pretty": {2, 2, []string{"any", "string"}, "tuple"},
 		// json.is_valid(text)
@@ -7553,6 +7551,17 @@ func (tc *TypeChecker) checkJsonModuleCall(funcName string, call *ast.CallExpres
 
 	sig, exists := signatures[funcName]
 	if !exists {
+		return
+	}
+
+	// Special error message for json.decode missing type argument
+	if funcName == "decode" && len(call.Arguments) == 1 {
+		tc.addError(
+			errors.E13004,
+			"json.decode() requires a type argument: json.decode(text, Type)",
+			line,
+			column,
+		)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Make `json.decode()` require a type argument at compile time
- Previously, calling `json.decode(text)` without a type would return an internal 'any' type that users couldn't actually use in their code
- Add new error code E13004 for clear error messaging

## Test plan
- [x] Verify `json.decode(text)` without type produces error E13004
- [x] Verify `json.decode(text, Type)` with type still works correctly
- [x] Run all typechecker tests
- [x] Run all stdlib JSON tests
- [x] Run JSON integration tests

Closes #947