### PR TITLE
fix(interpreter): update type name functions with missing types (#946)

### DIFF
--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -59,6 +59,17 @@ func getEZTypeName(obj Object) string {
 		return "nil"
 	case *Function:
 		return "function"
+	case *Range:
+		return "Range<int>"
+	case *FileHandle:
+		return "File"
+	case *Database:
+		return "Database"
+	case *Reference:
+		if inner, ok := v.Deref(); ok {
+			return "Ref<" + getEZTypeName(inner) + ">"
+		}
+		return "Ref"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3195,6 +3195,10 @@ func objectTypeToEZ(obj Object) string {
 		return "string"
 	case *Boolean:
 		return "bool"
+	case *Char:
+		return "char"
+	case *Byte:
+		return "byte"
 	case *Array:
 		// Return typed array format if element type is known
 		if v.ElementType != "" {
@@ -3231,6 +3235,17 @@ func objectTypeToEZ(obj Object) string {
 			return "map[" + v.KeyType + ":" + v.ValueType + "]"
 		}
 		return "map"
+	case *Range:
+		return "Range<int>"
+	case *FileHandle:
+		return "File"
+	case *Database:
+		return "Database"
+	case *Reference:
+		if inner, ok := v.Deref(); ok {
+			return "Ref<" + objectTypeToEZ(inner) + ">"
+		}
+		return "Ref"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -43,6 +43,8 @@ type (
 	Reference       = object.Reference
 	Range           = object.Range
 	TypeValue       = object.TypeValue
+	FileHandle      = object.FileHandle
+	Database        = object.Database
 )
 
 // Re-export constants
@@ -69,6 +71,8 @@ const (
 	REFERENCE_OBJ    = object.REFERENCE_OBJ
 	RANGE_OBJ        = object.RANGE_OBJ
 	TYPE_OBJ         = object.TYPE_OBJ
+	FILE_HANDLE_OBJ  = object.FILE_HANDLE_OBJ
+	DATABASE_OBJ     = object.DATABASE_OBJ
 
 	// Visibility constants
 	VisibilityPublic  = object.VisibilityPublic


### PR DESCRIPTION
## Summary
- Update `getEZTypeName` in `pkg/interpreter/builtins.go` with missing type cases
- Update `objectTypeToEZ` in `pkg/interpreter/evaluator.go` with missing type cases
- Export `FileHandle` and `Database` type aliases from interpreter package

Both functions now properly handle:
- Range → `"Range<int>"`
- FileHandle → `"File"`
- Database → `"Database"`
- Reference → `"Ref<innerType>"` (with recursive type resolution)
- Char → `"char"` (added to objectTypeToEZ)
- Byte → `"byte"` (added to objectTypeToEZ)

## Test plan
- [x] Build passes
- [x] All interpreter tests pass
- [x] All unit tests pass

Closes #946