### PR TITLE
Bugfixes 1-9-2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -322,6 +322,7 @@ JSON module errors
 | E13001 | json-syntax-error | invalid JSON syntax |
 | E13002 | json-unsupported-type | type cannot be converted to JSON |
 | E13003 | json-invalid-map-key | JSON object keys must be strings |
+| E13004 | json-decode-requires-type | json.decode() requires a type argument |
 
 ## Code Style Warnings (W1xxx)
 
@@ -373,4 +374,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 255 error/warning codes
+**Total:** 256 error/warning codes

--- a/cmd/ez/repl.go
+++ b/cmd/ez/repl.go
@@ -54,8 +54,10 @@ func startREPL() {
 		}
 
 		// Handle REPL commands
-		if newEnv := handleReplCommand(line, env); newEnv != nil {
-			env = newEnv
+		if newEnv, handled := handleReplCommand(line, env); handled {
+			if newEnv != nil {
+				env = newEnv
+			}
 			continue
 		}
 
@@ -73,18 +75,18 @@ func startREPL() {
 }
 
 // handleReplCommand handles special REPL commands
-// Returns a new environment if the environment should be reset, nil otherwise
-func handleReplCommand(line string, env *interpreter.Environment) *interpreter.Environment {
+// Returns (new environment if reset, whether command was handled)
+func handleReplCommand(line string, env *interpreter.Environment) (*interpreter.Environment, bool) {
 	switch line {
 	case "exit", "quit":
 		fmt.Println("Goodbye!")
 		os.Exit(0)
-		return nil
+		return nil, true
 
 	case "clear":
 		// Clear the terminal screen only
 		fmt.Print("\033[H\033[2J")
-		return nil
+		return nil, true
 
 	case "reset":
 		// Clear the terminal screen AND reset the environment
@@ -92,14 +94,14 @@ func handleReplCommand(line string, env *interpreter.Environment) *interpreter.E
 		fmt.Printf("EZ Language REPL %s\n", Version)
 		fmt.Println("Type 'help' for commands, 'exit' or 'quit' to exit")
 		fmt.Println()
-		return interpreter.NewEnvironment()
+		return interpreter.NewEnvironment(), true
 
 	case "help":
 		printReplHelp()
-		return nil
+		return nil, true
 	}
 
-	return nil
+	return nil, false
 }
 
 // printReplHelp prints REPL help information

--- a/integration-tests/fail/errors/E5005_integer_overflow_add.ez
+++ b/integration-tests/fail/errors/E5005_integer_overflow_add.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp max int = 9223372036854775807  // max int64
-    temp result int = max + 1  // Overflow
+    temp max i64 = 9223372036854775807  // max i64
+    temp result i64 = max + 1  // Overflow
 }

--- a/integration-tests/fail/errors/E5006_integer_overflow_sub.ez
+++ b/integration-tests/fail/errors/E5006_integer_overflow_sub.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp min int = -9223372036854775808  // min int64
-    temp result int = min - 1  // Underflow
+    temp min i64 = -9223372036854775808  // min i64
+    temp result i64 = min - 1  // Underflow
 }

--- a/integration-tests/fail/errors/E5007_integer_overflow_mul.ez
+++ b/integration-tests/fail/errors/E5007_integer_overflow_mul.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp max int = 9223372036854775807  // max int64
-    temp result int = max * 2  // Overflow
+    temp max i64 = 9223372036854775807  // max i64
+    temp result i64 = max * 2  // Overflow
 }

--- a/integration-tests/fail/errors/E5008_postfix_increment_overflow.ez
+++ b/integration-tests/fail/errors/E5008_postfix_increment_overflow.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp max int = 9223372036854775807  // max int64
+    temp max i64 = 9223372036854775807  // max i64
     max++  // Overflow
 }

--- a/integration-tests/fail/errors/E5009_postfix_decrement_overflow.ez
+++ b/integration-tests/fail/errors/E5009_postfix_decrement_overflow.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp min int = -9223372036854775808  // min int64
+    temp min i64 = -9223372036854775808  // min i64
     min--  // Underflow
 }

--- a/integration-tests/pass/stdlib/os.ez
+++ b/integration-tests/pass/stdlib/os.ez
@@ -14,22 +14,22 @@ do main() {
     println("  -- Environment Variables --")
 
     // Test 1: get_env for PATH (should exist on all systems)
-    temp path_value = os.get_env("PATH")
-    if path_value != nil && len(path_value) > 0 {
+    temp path_value, path_err = os.get_env("PATH")
+    if path_err == nil && len(path_value) > 0 {
         println("  [PASS] os.get_env('PATH') exists")
         passed += 1
     } otherwise {
-        println("  [FAIL] os.get_env('PATH'): expected non-nil")
+        println("  [FAIL] os.get_env('PATH'): expected to exist")
         failed += 1
     }
 
     // Test 2: get_env for non-existent variable
-    temp nonexistent = os.get_env("EZ_NONEXISTENT_VAR_12345")
-    if nonexistent == nil {
-        println("  [PASS] os.get_env(nonexistent) = nil")
+    temp nonexistent, nonexistent_err = os.get_env("EZ_NONEXISTENT_VAR_12345")
+    if nonexistent_err != nil {
+        println("  [PASS] os.get_env(nonexistent) returns error")
         passed += 1
     } otherwise {
-        println("  [FAIL] os.get_env(nonexistent): expected nil")
+        println("  [FAIL] os.get_env(nonexistent): expected error")
         failed += 1
     }
 
@@ -44,8 +44,8 @@ do main() {
     }
 
     // Test 4: verify set_env worked
-    temp verify_value = os.get_env("EZ_TEST_VAR")
-    if verify_value == "test_value_123" {
+    temp verify_value, verify_err = os.get_env("EZ_TEST_VAR")
+    if verify_err == nil && verify_value == "test_value_123" {
         println("  [PASS] os.get_env() verified set value")
         passed += 1
     } otherwise {
@@ -64,8 +64,8 @@ do main() {
     }
 
     // Test 6: verify unset worked
-    temp after_unset = os.get_env("EZ_TEST_VAR")
-    if after_unset == nil {
+    temp after_unset, after_unset_err = os.get_env("EZ_TEST_VAR")
+    if after_unset_err != nil {
         println("  [PASS] variable correctly unset")
         passed += 1
     } otherwise {

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -106,6 +106,33 @@ for dir in "$SCRIPT_DIR"/pass/multi-file/*/; do
     fi
 done
 
+# Warning tests (should produce specific warnings when checked)
+if [ -d "$SCRIPT_DIR/pass/warnings" ]; then
+    echo ""
+    echo "Running WARNING tests (expecting specific warnings)..."
+    echo "----------------------------------------"
+
+    for test_file in "$SCRIPT_DIR"/pass/warnings/*.ez; do
+        if [ -f "$test_file" ]; then
+            test_name=$(basename "$test_file" .ez)
+            # Extract expected warning code from filename (e.g., W2010_something.ez -> W2010)
+            expected_warning=$(echo "$test_name" | grep -oE '^W[0-9]+')
+            printf "  warnings/%s... " "$test_name"
+
+            # Run ez check (not full execution) to get warnings
+            output=$("$EZ_BIN" check "$test_file" 2>&1) || true
+
+            if echo "$output" | grep -q "warning\[$expected_warning\]"; then
+                echo -e "${GREEN}PASS${NC}"
+                ((PASS_COUNT++))
+            else
+                echo -e "${RED}FAIL${NC} (expected warning $expected_warning not found)"
+                ((FAIL_COUNT++))
+            fi
+        fi
+    done
+fi
+
 echo ""
 echo "Running FAIL tests (expecting errors)..."
 echo "----------------------------------------"

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -340,6 +340,7 @@ var (
 	E13001 = ErrorCode{"E13001", "json-syntax-error", "invalid JSON syntax"}
 	E13002 = ErrorCode{"E13002", "json-unsupported-type", "type cannot be converted to JSON"}
 	E13003 = ErrorCode{"E13003", "json-invalid-map-key", "JSON object keys must be strings"}
+	E13004 = ErrorCode{"E13004", "json-decode-requires-type", "json.decode() requires a type argument"}
 )
 
 // =============================================================================

--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -23,6 +23,7 @@ func init() {
 
 // getEZTypeName returns the EZ language type name for an object
 // For integers, returns the declared type (e.g., "u64", "i32") instead of generic "INTEGER"
+// For arrays and maps, returns the typed format (e.g., "[string]", "map[string:int]")
 func getEZTypeName(obj Object) string {
 	switch v := obj.(type) {
 	case *Integer:
@@ -38,8 +39,14 @@ func getEZTypeName(obj Object) string {
 	case *Byte:
 		return "byte"
 	case *Array:
+		if v.ElementType != "" {
+			return "[" + v.ElementType + "]"
+		}
 		return "array"
 	case *Map:
+		if v.KeyType != "" && v.ValueType != "" {
+			return "map[" + v.KeyType + ":" + v.ValueType + "]"
+		}
 		return "map"
 	case *Struct:
 		if v.TypeName != "" {

--- a/pkg/interpreter/builtins.go
+++ b/pkg/interpreter/builtins.go
@@ -59,6 +59,17 @@ func getEZTypeName(obj Object) string {
 		return "nil"
 	case *Function:
 		return "function"
+	case *Range:
+		return "Range<int>"
+	case *FileHandle:
+		return "File"
+	case *Database:
+		return "Database"
+	case *Reference:
+		if inner, ok := v.Deref(); ok {
+			return "Ref<" + getEZTypeName(inner) + ">"
+		}
+		return "Ref"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3195,6 +3195,10 @@ func objectTypeToEZ(obj Object) string {
 		return "string"
 	case *Boolean:
 		return "bool"
+	case *Char:
+		return "char"
+	case *Byte:
+		return "byte"
 	case *Array:
 		// Return typed array format if element type is known
 		if v.ElementType != "" {
@@ -3231,6 +3235,17 @@ func objectTypeToEZ(obj Object) string {
 			return "map[" + v.KeyType + ":" + v.ValueType + "]"
 		}
 		return "map"
+	case *Range:
+		return "Range<int>"
+	case *FileHandle:
+		return "File"
+	case *Database:
+		return "Database"
+	case *Reference:
+		if inner, ok := v.Deref(); ok {
+			return "Ref<" + objectTypeToEZ(inner) + ">"
+		}
+		return "Ref"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -658,7 +658,7 @@ func Eval(node ast.Node, env *Environment) Object {
 			// Validate that the key is hashable
 			if _, hashOk := HashKey(index); !hashOk {
 				return newErrorWithLocation("E12001", node.Token.Line, node.Token.Column,
-					"unusable as map key: %s", index.Type())
+					"unusable as map key: %s", objectTypeToEZ(index))
 			}
 			value, exists := mapObj.Get(index)
 			if !exists {
@@ -681,7 +681,7 @@ func Eval(node ast.Node, env *Environment) Object {
 		idx, ok := index.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E9003", node.Token.Line, node.Token.Column,
-				"index must be an integer, got %s", index.Type())
+				"index must be an integer, got %s", objectTypeToEZ(index))
 		}
 
 		switch obj := left.(type) {
@@ -718,7 +718,7 @@ func Eval(node ast.Node, env *Environment) Object {
 
 		default:
 			return newErrorWithLocation("E5015", node.Token.Line, node.Token.Column,
-				"index operator not supported for %s", left.Type())
+				"index operator not supported for %s", objectTypeToEZ(left))
 		}
 
 	case *ast.MemberExpression:
@@ -1156,7 +1156,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 						// ok
 					default:
 						return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-							"cannot assign %s to byte variable", unpackedVal.Type())
+							"cannot assign %s to byte variable", objectTypeToEZ(unpackedVal))
 					}
 				}
 			}
@@ -1213,7 +1213,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 								// ok
 							default:
 								return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-									"cannot assign %s to byte variable", val.Type())
+									"cannot assign %s to byte variable", objectTypeToEZ(val))
 							}
 					}
 				}
@@ -1249,7 +1249,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 					// already a byte - fine
 				default:
 					return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-						"cannot assign %s to byte variable", val.Type())
+						"cannot assign %s to byte variable", objectTypeToEZ(val))
 				}
 			}
 		}
@@ -1294,7 +1294,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			index, ok := idx.(*Integer)
 			if !ok {
 				return newErrorWithLocation("E3003", node.Token.Line, node.Token.Column,
-					"array index must be integer, got %s", idx.Type())
+					"array index must be integer, got %s", objectTypeToEZ(idx))
 			}
 			arrLen := big.NewInt(int64(len(obj.Elements)))
 			if index.Value.Sign() < 0 || index.Value.Cmp(arrLen) >= 0 {
@@ -1332,7 +1332,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 					// okay
 				default:
 					return newErrorWithLocation("E3026", node.Token.Line, node.Token.Column,
-						"cannot assign %s to byte array element", val.Type())
+						"cannot assign %s to byte array element", objectTypeToEZ(val))
 				}
 			}
 
@@ -1342,13 +1342,13 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			index, ok := idx.(*Integer)
 			if !ok {
 				return newErrorWithLocation("E3003", node.Token.Line, node.Token.Column,
-					"string index must be integer, got %s", idx.Type())
+					"string index must be integer, got %s", objectTypeToEZ(idx))
 			}
 			// String mutation - verify the value is a character
 			charObj, ok := val.(*Char)
 			if !ok {
 				return newErrorWithLocation("E3004", node.Token.Line, node.Token.Column,
-					"can only assign character to string index, got %s", val.Type())
+					"can only assign character to string index, got %s", objectTypeToEZ(val))
 			}
 			// Convert string to rune slice for proper UTF-8 character indexing
 			runes := []rune(obj.Value)
@@ -1372,7 +1372,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 			// Validate that the key is hashable
 			if _, ok := HashKey(idx); !ok {
 				return newErrorWithLocation("E12001", node.Token.Line, node.Token.Column,
-					"map key must be a hashable type, got %s", idx.Type())
+					"map key must be a hashable type, got %s", objectTypeToEZ(idx))
 			}
 
 			// Check if map is mutable
@@ -1409,7 +1409,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 						// ok
 					default:
 						return newErrorWithLocation("E3026", node.Token.Line, node.Token.Column,
-							"cannot assign %s to byte map element", val.Type())
+							"cannot assign %s to byte map element", objectTypeToEZ(val))
 					}
 				}
 			}
@@ -1417,7 +1417,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 
 		default:
 			return newErrorWithLocation("E3016", node.Token.Line, node.Token.Column,
-				"index operator not supported: %s", container.Type())
+				"index operator not supported: %s", objectTypeToEZ(container))
 		}
 
 	case *ast.MemberExpression:
@@ -1448,7 +1448,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 		structObj, ok := obj.(*Struct)
 		if !ok {
 			return newErrorWithLocation("E4011", node.Token.Line, node.Token.Column,
-				"member access not supported: %s", obj.Type())
+				"member access not supported: %s", objectTypeToEZ(obj))
 		}
 
 		// Check if struct is mutable
@@ -1493,7 +1493,7 @@ func evalAssignment(node *ast.AssignmentStatement, env *Environment) Object {
 					// ok
 				default:
 					return newErrorWithLocation("E3025", node.Token.Line, node.Token.Column,
-						"cannot assign %s to byte field", val.Type())
+						"cannot assign %s to byte field", objectTypeToEZ(val))
 				}
 			}
 		}
@@ -1752,7 +1752,7 @@ func evalRangeExpression(node *ast.RangeExpression, env *Environment) Object {
 		startInt, ok := startObj.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E5013", line, col,
-				"range start must be integer, got %s", startObj.Type())
+				"range start must be integer, got %s", objectTypeToEZ(startObj))
 		}
 		start = new(big.Int).Set(startInt.Value)
 	}
@@ -1765,7 +1765,7 @@ func evalRangeExpression(node *ast.RangeExpression, env *Environment) Object {
 	endInt, ok := endObj.(*Integer)
 	if !ok {
 		return newErrorWithLocation("E5014", line, col,
-			"range end must be integer, got %s", endObj.Type())
+			"range end must be integer, got %s", objectTypeToEZ(endObj))
 	}
 	end := new(big.Int).Set(endInt.Value)
 
@@ -1779,7 +1779,7 @@ func evalRangeExpression(node *ast.RangeExpression, env *Environment) Object {
 		stepInt, ok := stepObj.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E5019", line, col,
-				"range step must be integer, got %s", stepObj.Type())
+				"range step must be integer, got %s", objectTypeToEZ(stepObj))
 		}
 		step = new(big.Int).Set(stepInt.Value)
 		if step.Sign() == 0 {
@@ -1818,7 +1818,7 @@ func evalArrayCast(value Object, elementType string, line, col int) Object {
 	arr, ok := value.(*Array)
 	if !ok {
 		return newErrorWithLocation("E3001", line, col,
-			"cast to array type requires array value, got %s", value.Type())
+			"cast to array type requires array value, got %s", objectTypeToEZ(value))
 	}
 
 	newElements := make([]Object, len(arr.Elements))
@@ -2009,7 +2009,7 @@ func evalForEachStatement(node *ast.ForEachStatement, env *Environment) Object {
 	}
 
 	return newErrorWithLocation("E3017", node.Token.Line, node.Token.Column,
-		"for_each requires array or string, got %s", collection.Type())
+		"for_each requires array or string, got %s", objectTypeToEZ(collection))
 }
 
 func evalEnumDeclaration(node *ast.EnumDeclaration, env *Environment) Object {
@@ -2220,7 +2220,7 @@ func evalPrefixExpression(operator string, right Object) Object {
 	case "-":
 		return evalMinusPrefixOperator(right)
 	default:
-		return newError("unknown operator: %s%s", operator, right.Type())
+		return newError("unknown operator: %s%s", operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2254,7 +2254,7 @@ func evalMinusPrefixOperator(right Object) Object {
 	case *Float:
 		return &Float{Value: -obj.Value}
 	default:
-		return newError("unknown operator: -%s", right.Type())
+		return newError("unknown operator: -%s", objectTypeToEZ(right))
 	}
 }
 
@@ -2317,7 +2317,7 @@ func evalInfixExpression(operator string, left, right Object, line, col int) Obj
 	case operator == "||":
 		return nativeBoolToBooleanObject(isTruthy(left) || isTruthy(right))
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2381,7 +2381,7 @@ func evalIntegerInfixExpression(operator string, left, right Object, line, col i
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal.Cmp(rightVal) != 0)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2443,7 +2443,7 @@ func evalFloatInfixExpression(operator string, left, right Object, line, col int
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2459,7 +2459,7 @@ func evalStringInfixExpression(operator string, left, right Object) Object {
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newError("unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2481,7 +2481,7 @@ func evalCharInfixExpression(operator string, left, right Object, line, col int)
 	case ">=":
 		return nativeBoolToBooleanObject(leftVal >= rightVal)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2533,7 +2533,7 @@ func evalByteInfixExpression(operator string, left, right Object, line, col int)
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2585,7 +2585,7 @@ func evalByteIntegerInfixExpression(operator string, left, right Object, line, c
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal.Cmp(rightVal) != 0)
 	default:
-		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
+		return newErrorWithLocation("E3014", line, col, "unknown operator: %s %s %s", objectTypeToEZ(left), operator, objectTypeToEZ(right))
 	}
 }
 
@@ -2596,7 +2596,7 @@ func evalInOperator(left, right Object, line, col int) Object {
 		leftInt, ok := left.(*Integer)
 		if !ok {
 			return newErrorWithLocation("E5020", line, col,
-				"left operand of 'in range()' must be integer, got %s", left.Type())
+				"left operand of 'in range()' must be integer, got %s", objectTypeToEZ(left))
 		}
 		if r.Contains(leftInt.Value) {
 			return TRUE
@@ -2608,7 +2608,7 @@ func evalInOperator(left, right Object, line, col int) Object {
 	arr, ok := right.(*Array)
 	if !ok {
 		return newErrorWithLocation("E3014", line, col,
-			"right operand of 'in' must be array or range, got %s", right.Type())
+			"right operand of 'in' must be array or range, got %s", objectTypeToEZ(right))
 	}
 
 	for _, elem := range arr.Elements {
@@ -2665,7 +2665,7 @@ func evalPostfixExpression(node *ast.PostfixExpression, env *Environment) Object
 	intVal, ok := val.(*Integer)
 	if !ok {
 		return newErrorWithLocation("E5023", node.Token.Line, node.Token.Column,
-			"postfix operator %s requires integer operand, got %s", node.Operator, val.Type())
+			"postfix operator %s requires integer operand, got %s", node.Operator, objectTypeToEZ(val))
 	}
 
 	var newVal *big.Int
@@ -2969,7 +2969,7 @@ func applyFunction(fn Object, args []Object, line, col int) Object {
 		return result
 
 	default:
-		return newErrorWithLocation("E3015", line, col, "not a function: %s", fn.Type())
+		return newErrorWithLocation("E3015", line, col, "not a function: %s", objectTypeToEZ(fn))
 	}
 }
 
@@ -3283,7 +3283,7 @@ func evalMapLiteral(node *ast.MapValue, env *Environment) Object {
 
 		// Validate that the key is hashable
 		if _, ok := HashKey(key); !ok {
-			return newError("unusable as map key: %s", key.Type())
+			return newError("unusable as map key: %s", objectTypeToEZ(key))
 		}
 
 		value := Eval(pair.Value, env)
@@ -3645,7 +3645,7 @@ func evalMemberExpression(node *ast.MemberExpression, env *Environment) Object {
 	}
 
 	return newErrorWithLocation("E4011", node.Token.Line, node.Token.Column,
-		"member access not supported on type %s", obj.Type())
+		"member access not supported on type %s", objectTypeToEZ(obj))
 }
 
 func nativeBoolToBooleanObject(input bool) *Boolean {

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3225,6 +3225,12 @@ func objectTypeToEZ(obj Object) string {
 			types[i] = objectTypeToEZ(val)
 		}
 		return "(" + strings.Join(types, ", ") + ")"
+	case *Map:
+		// Return typed map format if key/value types are known
+		if v.KeyType != "" && v.ValueType != "" {
+			return "map[" + v.KeyType + ":" + v.ValueType + "]"
+		}
+		return "map"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/interpreter/object.go
+++ b/pkg/interpreter/object.go
@@ -43,6 +43,8 @@ type (
 	Reference       = object.Reference
 	Range           = object.Range
 	TypeValue       = object.TypeValue
+	FileHandle      = object.FileHandle
+	Database        = object.Database
 )
 
 // Re-export constants
@@ -69,6 +71,8 @@ const (
 	REFERENCE_OBJ    = object.REFERENCE_OBJ
 	RANGE_OBJ        = object.RANGE_OBJ
 	TYPE_OBJ         = object.TYPE_OBJ
+	FILE_HANDLE_OBJ  = object.FILE_HANDLE_OBJ
+	DATABASE_OBJ     = object.DATABASE_OBJ
 
 	// Visibility constants
 	VisibilityPublic  = object.VisibilityPublic

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -198,6 +198,45 @@ func TestIntegerLiterals(t *testing.T) {
 	}
 }
 
+func TestIntegerLiteralBases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		// Hex literals
+		{"temp x int = 0xFF", 255},
+		{"temp x int = 0x10", 16},
+		{"temp x int = 0XFF", 255},
+		// Binary literals
+		{"temp x int = 0b1010", 10},
+		{"temp x int = 0B1111", 15},
+		{"temp x int = 0b0", 0},
+		// Octal literals with explicit 0o prefix
+		{"temp x int = 0o123", 83},
+		{"temp x int = 0O777", 511},
+		{"temp x int = 0o0", 0},
+		// Leading zeros should be decimal (not octal)
+		{"temp x int = 0123", 123},
+		{"temp x int = 09", 9},
+		{"temp x int = 007", 7},
+		{"temp x int = 00123", 123},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			program := parseProgram(t, tt.input)
+			if len(program.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+			}
+			stmt, ok := program.Statements[0].(*VariableDeclaration)
+			if !ok {
+				t.Fatalf("not VariableDeclaration, got %T", program.Statements[0])
+			}
+			testIntegerLiteral(t, stmt.Value, tt.expected)
+		})
+	}
+}
+
 func TestFloatLiterals(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -344,7 +344,7 @@ var StdBuiltins = map[string]*object.Builtin{
 			case *object.Map:
 				return &object.Integer{Value: big.NewInt(int64(len(arg.Pairs)))}
 			default:
-				return &object.Error{Code: "E7015", Message: fmt.Sprintf("len() not supported for %s", args[0].Type())}
+				return &object.Error{Code: "E7015", Message: fmt.Sprintf("len() not supported for %s", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -469,7 +469,7 @@ var StdBuiltins = map[string]*object.Builtin{
 							"    len(myArray)  // returns the number of elements",
 					}
 				}
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to int", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to int", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -513,7 +513,7 @@ var StdBuiltins = map[string]*object.Builtin{
 							"    len(myArray)  // returns the number of elements",
 					}
 				}
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to float", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to float", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -567,7 +567,7 @@ var StdBuiltins = map[string]*object.Builtin{
 				}
 				return &object.Char{Value: runes[0]}
 			default:
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to char", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to char", getEZTypeName(args[0]))}
 			}
 		},
 	},
@@ -631,7 +631,7 @@ var StdBuiltins = map[string]*object.Builtin{
 				}
 				return &object.Byte{Value: uint8(val)}
 			default:
-				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to byte", args[0].Type())}
+				return &object.Error{Code: "E7014", Message: fmt.Sprintf("cannot convert %s to byte", getEZTypeName(args[0]))}
 			}
 		},
 	},

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -238,7 +238,7 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 			if !ok {
 				return nil, &jsonError{
 					code:    "E13003",
-					message: fmt.Sprintf("JSON object keys must be strings, got %s", pair.Key.Type()),
+					message: fmt.Sprintf("JSON object keys must be strings, got %s", getEZTypeName(pair.Key)),
 				}
 			}
 			val, err := objectToGoValue(pair.Value, seen)
@@ -297,7 +297,7 @@ func objectToGoValue(obj object.Object, seen map[uintptr]bool) (interface{}, *js
 	default:
 		return nil, &jsonError{
 			code:    "E13002",
-			message: fmt.Sprintf("type %s cannot be converted to JSON", obj.Type()),
+			message: fmt.Sprintf("type %s cannot be converted to JSON", getEZTypeName(obj)),
 		}
 	}
 }

--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -943,7 +943,7 @@ func getNumber(obj object.Object) (float64, *object.Error) {
 	case *object.Float:
 		return v.Value, nil
 	default:
-		return 0, &object.Error{Code: "E7005", Message: fmt.Sprintf("expected number, got %s", obj.Type())}
+		return 0, &object.Error{Code: "E7005", Message: fmt.Sprintf("expected number, got %s", getEZTypeName(obj))}
 	}
 }
 

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -26,7 +26,7 @@ var OSBuiltins = map[string]*object.Builtin{
 	// ============================================================================
 
 	// Gets an environment variable by name
-	// Returns the value as a string, or nil if not set
+	// Returns (value, error) tuple - error is non-nil if variable is not set
 	"os.get_env": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -39,9 +39,15 @@ var OSBuiltins = map[string]*object.Builtin{
 
 			value, exists := os.LookupEnv(name.Value)
 			if !exists {
-				return object.NIL
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7035", fmt.Sprintf("environment variable '%s' is not set", name.Value)),
+				}}
 			}
-			return &object.String{Value: value}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: value},
+				object.NIL,
+			}}
 		},
 	},
 

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -24,20 +24,37 @@ func TestOSGetEnv(t *testing.T) {
 	os.Setenv("EZ_TEST_VAR", "test_value")
 	defer os.Unsetenv("EZ_TEST_VAR")
 
-	// Test getting existing variable
+	// Test getting existing variable - returns (string, nil)
 	result := fn.Fn(&object.String{Value: "EZ_TEST_VAR"})
-	strResult, ok := result.(*object.String)
+	retVal, ok := result.(*object.ReturnValue)
 	if !ok {
-		t.Fatalf("Expected String, got %T", result)
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String as first value, got %T", retVal.Values[0])
 	}
 	if strResult.Value != "test_value" {
 		t.Errorf("Expected 'test_value', got '%s'", strResult.Value)
 	}
+	if retVal.Values[1] != object.NIL {
+		t.Errorf("Expected NIL as second value for existing var, got %T", retVal.Values[1])
+	}
 
-	// Test getting non-existent variable
+	// Test getting non-existent variable - returns ("", error)
 	result = fn.Fn(&object.String{Value: "EZ_NONEXISTENT_VAR_12345"})
-	if result != object.NIL {
-		t.Errorf("Expected NIL for non-existent var, got %T", result)
+	retVal, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+	if retVal.Values[1] == object.NIL {
+		t.Errorf("Expected error as second value for non-existent var, got NIL")
 	}
 
 	// Test wrong argument count

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4945,17 +4945,14 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		case "encode", "pretty":
 			return []string{"string", "error"}
 		case "decode":
-			// If a type argument is provided, return that type instead of "any"
+			// Type argument is required - extract the type from the second argument
 			if len(args) >= 2 {
 				if label, ok := args[1].(*ast.Label); ok {
 					return []string{label.Value, "error"}
 				}
 			}
-			return []string{"any", "error"}
-		case "parse", "parse_file":
-			return []string{"any", "error"}
-		case "stringify":
-			return []string{"string", "error"}
+			// If no type argument, return empty (error will be caught by checkJsonModuleCall)
+			return nil
 		}
 	case "os":
 		switch funcName {
@@ -5427,13 +5424,14 @@ func (tc *TypeChecker) inferJSONCallType(funcName string, args []ast.Expression)
 	case "encode", "pretty":
 		return "string", true
 	case "decode":
-		// If a type argument is provided, return that type instead of "any"
+		// Type argument is required - extract the type from the second argument
 		if len(args) >= 2 {
 			if label, ok := args[1].(*ast.Label); ok {
 				return label.Value, true
 			}
 		}
-		return "any", true
+		// If no type argument, return false (error will be caught by checkJsonModuleCall)
+		return "", false
 	case "is_valid":
 		return "bool", true
 	default:
@@ -7543,8 +7541,8 @@ func (tc *TypeChecker) checkJsonModuleCall(funcName string, call *ast.CallExpres
 	signatures := map[string]StdlibFuncSig{
 		// json.encode(value)
 		"encode": {1, 1, []string{"any"}, "tuple"},
-		// json.decode(text) or json.decode(text, Type)
-		"decode": {1, 2, []string{"string", "any"}, "tuple"},
+		// json.decode(text, Type) - Type argument is REQUIRED
+		"decode": {2, 2, []string{"string", "any"}, "tuple"},
 		// json.pretty(value, indent)
 		"pretty": {2, 2, []string{"any", "string"}, "tuple"},
 		// json.is_valid(text)
@@ -7553,6 +7551,17 @@ func (tc *TypeChecker) checkJsonModuleCall(funcName string, call *ast.CallExpres
 
 	sig, exists := signatures[funcName]
 	if !exists {
+		return
+	}
+
+	// Special error message for json.decode missing type argument
+	if funcName == "decode" && len(call.Arguments) == 1 {
+		tc.addError(
+			errors.E13004,
+			"json.decode() requires a type argument: json.decode(text, Type)",
+			line,
+			column,
+		)
 		return
 	}
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4911,8 +4911,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 			return []string{"bool", "error"}
 		case "create_dir", "remove", "remove_dir", "rename", "copy_file":
 			return []string{"bool", "error"}
-		case "exists", "is_dir", "is_file":
-			return []string{"bool", "error"}
+		// Note: exists, is_dir, is_file return single bool (not tuple)
 		case "file_size":
 			return []string{"int", "error"}
 		case "list_dir", "read_dir":
@@ -4956,6 +4955,8 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		}
 	case "os":
 		switch funcName {
+		case "get_env":
+			return []string{"string", "error"}
 		case "exec":
 			return []string{"int", "error"}
 		case "exec_output":

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2974,7 +2974,7 @@ import @os
 using os
 
 do main() {
-	temp value string = os.get_env("HOME")
+	temp value string, err error = os.get_env("HOME")
 }
 `
 	tc := typecheck(t, input)


### PR DESCRIPTION
## Summary
Batch of bug fixes from January 9, 2026.

### Fixes included:
- **#890** - fix(repl): prevent E4001 error when running REPL commands
- **#915** - fix(lexer,parser): add explicit 0o octal prefix, treat leading zeros as decimal
- **#945** - fix(interpreter): add Map case to objectTypeToEZ function
- **#948** - fix(interpreter,stdlib): replace .Type() with helper functions in error messages
- **#947** - fix(typechecker): require type argument for json.decode
- **#946** - fix(interpreter): update type name functions with missing types
- **#952** - fix(interpreter, typechecker, tests): fix failing integration tests

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Each fix tested individually before merge into parent branch