### PR TITLE
fix(typechecker,stdlib): fix integration test failures (#952)

### DIFF
--- a/integration-tests/fail/errors/E5005_integer_overflow_add.ez
+++ b/integration-tests/fail/errors/E5005_integer_overflow_add.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp max int = 9223372036854775807  // max int64
-    temp result int = max + 1  // Overflow
+    temp max i64 = 9223372036854775807  // max i64
+    temp result i64 = max + 1  // Overflow
 }

--- a/integration-tests/fail/errors/E5006_integer_overflow_sub.ez
+++ b/integration-tests/fail/errors/E5006_integer_overflow_sub.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp min int = -9223372036854775808  // min int64
-    temp result int = min - 1  // Underflow
+    temp min i64 = -9223372036854775808  // min i64
+    temp result i64 = min - 1  // Underflow
 }

--- a/integration-tests/fail/errors/E5007_integer_overflow_mul.ez
+++ b/integration-tests/fail/errors/E5007_integer_overflow_mul.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp max int = 9223372036854775807  // max int64
-    temp result int = max * 2  // Overflow
+    temp max i64 = 9223372036854775807  // max i64
+    temp result i64 = max * 2  // Overflow
 }

--- a/integration-tests/fail/errors/E5008_postfix_increment_overflow.ez
+++ b/integration-tests/fail/errors/E5008_postfix_increment_overflow.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp max int = 9223372036854775807  // max int64
+    temp max i64 = 9223372036854775807  // max i64
     max++  // Overflow
 }

--- a/integration-tests/fail/errors/E5009_postfix_decrement_overflow.ez
+++ b/integration-tests/fail/errors/E5009_postfix_decrement_overflow.ez
@@ -4,6 +4,6 @@
  */
 
 do main() {
-    temp min int = -9223372036854775808  // min int64
+    temp min i64 = -9223372036854775808  // min i64
     min--  // Underflow
 }

--- a/integration-tests/pass/stdlib/os.ez
+++ b/integration-tests/pass/stdlib/os.ez
@@ -14,22 +14,22 @@ do main() {
     println("  -- Environment Variables --")
 
     // Test 1: get_env for PATH (should exist on all systems)
-    temp path_value = os.get_env("PATH")
-    if path_value != nil && len(path_value) > 0 {
+    temp path_value, path_err = os.get_env("PATH")
+    if path_err == nil && len(path_value) > 0 {
         println("  [PASS] os.get_env('PATH') exists")
         passed += 1
     } otherwise {
-        println("  [FAIL] os.get_env('PATH'): expected non-nil")
+        println("  [FAIL] os.get_env('PATH'): expected to exist")
         failed += 1
     }
 
     // Test 2: get_env for non-existent variable
-    temp nonexistent = os.get_env("EZ_NONEXISTENT_VAR_12345")
-    if nonexistent == nil {
-        println("  [PASS] os.get_env(nonexistent) = nil")
+    temp nonexistent, nonexistent_err = os.get_env("EZ_NONEXISTENT_VAR_12345")
+    if nonexistent_err != nil {
+        println("  [PASS] os.get_env(nonexistent) returns error")
         passed += 1
     } otherwise {
-        println("  [FAIL] os.get_env(nonexistent): expected nil")
+        println("  [FAIL] os.get_env(nonexistent): expected error")
         failed += 1
     }
 
@@ -44,8 +44,8 @@ do main() {
     }
 
     // Test 4: verify set_env worked
-    temp verify_value = os.get_env("EZ_TEST_VAR")
-    if verify_value == "test_value_123" {
+    temp verify_value, verify_err = os.get_env("EZ_TEST_VAR")
+    if verify_err == nil && verify_value == "test_value_123" {
         println("  [PASS] os.get_env() verified set value")
         passed += 1
     } otherwise {
@@ -64,8 +64,8 @@ do main() {
     }
 
     // Test 6: verify unset worked
-    temp after_unset = os.get_env("EZ_TEST_VAR")
-    if after_unset == nil {
+    temp after_unset, after_unset_err = os.get_env("EZ_TEST_VAR")
+    if after_unset_err != nil {
         println("  [PASS] variable correctly unset")
         passed += 1
     } otherwise {

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -106,6 +106,33 @@ for dir in "$SCRIPT_DIR"/pass/multi-file/*/; do
     fi
 done
 
+# Warning tests (should produce specific warnings when checked)
+if [ -d "$SCRIPT_DIR/pass/warnings" ]; then
+    echo ""
+    echo "Running WARNING tests (expecting specific warnings)..."
+    echo "----------------------------------------"
+
+    for test_file in "$SCRIPT_DIR"/pass/warnings/*.ez; do
+        if [ -f "$test_file" ]; then
+            test_name=$(basename "$test_file" .ez)
+            # Extract expected warning code from filename (e.g., W2010_something.ez -> W2010)
+            expected_warning=$(echo "$test_name" | grep -oE '^W[0-9]+')
+            printf "  warnings/%s... " "$test_name"
+
+            # Run ez check (not full execution) to get warnings
+            output=$("$EZ_BIN" check "$test_file" 2>&1) || true
+
+            if echo "$output" | grep -q "warning\[$expected_warning\]"; then
+                echo -e "${GREEN}PASS${NC}"
+                ((PASS_COUNT++))
+            else
+                echo -e "${RED}FAIL${NC} (expected warning $expected_warning not found)"
+                ((FAIL_COUNT++))
+            fi
+        fi
+    done
+fi
+
 echo ""
 echo "Running FAIL tests (expecting errors)..."
 echo "----------------------------------------"

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -26,7 +26,7 @@ var OSBuiltins = map[string]*object.Builtin{
 	// ============================================================================
 
 	// Gets an environment variable by name
-	// Returns the value as a string, or nil if not set
+	// Returns (value, error) tuple - error is non-nil if variable is not set
 	"os.get_env": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -39,9 +39,15 @@ var OSBuiltins = map[string]*object.Builtin{
 
 			value, exists := os.LookupEnv(name.Value)
 			if !exists {
-				return object.NIL
+				return &object.ReturnValue{Values: []object.Object{
+					&object.String{Value: ""},
+					createOSError("E7035", fmt.Sprintf("environment variable '%s' is not set", name.Value)),
+				}}
 			}
-			return &object.String{Value: value}
+			return &object.ReturnValue{Values: []object.Object{
+				&object.String{Value: value},
+				object.NIL,
+			}}
 		},
 	},
 

--- a/pkg/stdlib/os_test.go
+++ b/pkg/stdlib/os_test.go
@@ -24,20 +24,37 @@ func TestOSGetEnv(t *testing.T) {
 	os.Setenv("EZ_TEST_VAR", "test_value")
 	defer os.Unsetenv("EZ_TEST_VAR")
 
-	// Test getting existing variable
+	// Test getting existing variable - returns (string, nil)
 	result := fn.Fn(&object.String{Value: "EZ_TEST_VAR"})
-	strResult, ok := result.(*object.String)
+	retVal, ok := result.(*object.ReturnValue)
 	if !ok {
-		t.Fatalf("Expected String, got %T", result)
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+	strResult, ok := retVal.Values[0].(*object.String)
+	if !ok {
+		t.Fatalf("Expected String as first value, got %T", retVal.Values[0])
 	}
 	if strResult.Value != "test_value" {
 		t.Errorf("Expected 'test_value', got '%s'", strResult.Value)
 	}
+	if retVal.Values[1] != object.NIL {
+		t.Errorf("Expected NIL as second value for existing var, got %T", retVal.Values[1])
+	}
 
-	// Test getting non-existent variable
+	// Test getting non-existent variable - returns ("", error)
 	result = fn.Fn(&object.String{Value: "EZ_NONEXISTENT_VAR_12345"})
-	if result != object.NIL {
-		t.Errorf("Expected NIL for non-existent var, got %T", result)
+	retVal, ok = result.(*object.ReturnValue)
+	if !ok {
+		t.Fatalf("Expected ReturnValue, got %T", result)
+	}
+	if len(retVal.Values) != 2 {
+		t.Fatalf("Expected 2 return values, got %d", len(retVal.Values))
+	}
+	if retVal.Values[1] == object.NIL {
+		t.Errorf("Expected error as second value for non-existent var, got NIL")
 	}
 
 	// Test wrong argument count

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4911,8 +4911,7 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 			return []string{"bool", "error"}
 		case "create_dir", "remove", "remove_dir", "rename", "copy_file":
 			return []string{"bool", "error"}
-		case "exists", "is_dir", "is_file":
-			return []string{"bool", "error"}
+		// Note: exists, is_dir, is_file return single bool (not tuple)
 		case "file_size":
 			return []string{"int", "error"}
 		case "list_dir", "read_dir":
@@ -4956,6 +4955,8 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		}
 	case "os":
 		switch funcName {
+		case "get_env":
+			return []string{"string", "error"}
 		case "exec":
 			return []string{"int", "error"}
 		case "exec_output":

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2974,7 +2974,7 @@ import @os
 using os
 
 do main() {
-	temp value string = os.get_env("HOME")
+	temp value string, err error = os.get_env("HOME")
 }
 `
 	tc := typecheck(t, input)


### PR DESCRIPTION
## Summary
- Fix io.exists/is_dir/is_file return type mismatch in typechecker
- Change os.get_env to return (string, error) tuple for proper type checking
- Fix overflow tests to use i64 instead of int (arbitrary precision)
- Add warning tests section to test runner

## Test plan
- [x] All 332 integration tests pass
- [x] All Go unit tests pass

Closes #952