### PR TITLE
fix(ci): create wasm directory before copying files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -155,6 +155,7 @@ jobs:
 
       - name: Update WASM files
         run: |
+          mkdir -p website/public/wasm
           cp cmd/wasm/ez.wasm website/public/wasm/
           cp cmd/wasm/wasm_exec.js website/public/wasm/
 


### PR DESCRIPTION
The update-playground workflow failed because the `public/wasm/` directory doesn't exist in the website repo's main branch yet. This adds `mkdir -p` to create it if needed.