### PR TITLE
fix(ci): use EZ_DOCS_SYNC token for website repo access

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: SchoolyB/language.ez
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.EZ_DOCS_SYNC }}
           path: website
 
       - name: Update WASM files
@@ -161,7 +161,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.EZ_DOCS_SYNC }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           cd website


### PR DESCRIPTION
Use the correct token secret for pushing to the language.ez repo.