### PR TITLE
fix: Typechecker modification to resolve "using directive" bug

### DIFF
--- a/examples/http.ez
+++ b/examples/http.ez
@@ -8,6 +8,10 @@ do main() {
         println("Error: ${err.message}")
         return
     }
+    if resp.status != http.OK {
+        println("Request Failed: ${resp.status}")
+        return
+    }
     println("Status: ${resp.status}")
     println("Body: ${resp.body}")
 		temp content_type = resp.headers["Content-Type"][0]
@@ -18,6 +22,10 @@ do main() {
         "https://api.example.com/users",
         http.json_body({"name": "John", "email": "john@example.com"})
     )
+    if post_resp.status != http.CREATED {
+        println("Request Failed: ${post_err.message}")
+        return
+    }
 
     // Advanced request with custom headers
     temp headers map[string:string] = {
@@ -31,17 +39,17 @@ do main() {
         headers,
         60
     )
-		if adv_err != nil {
+    if adv_err != nil {
         println("Error: ${adv_err.message}")
         return
-		}
+    }
 
     // URL utilities
     temp encoded string = http.encode_url("hello world")  // "hello%20world"
-		temp decoded string, decode_err error = http.decode_url(encoded)
-		if decode_err != nil {
-			println("${decode_err}")
-			return
-		}
+    temp decoded string, decode_err error = http.decode_url(encoded)
+    if decode_err != nil {
+        println("${decode_err}")
+        return
+    }
     temp query string = http.build_query({"page": "1", "limit": "10"})  // "page=1&limit=10"
 }

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -51,8 +51,8 @@ var DBBuiltins = map[string]*object.Builtin{
 
 				return &object.ReturnValue{Values: []object.Object{
 					&object.Database{
-						Path: *path,
-						Store: *object.NewMap(),
+						Path:     *path,
+						Store:    *object.NewMap(),
 						IsClosed: object.Boolean{Value: false},
 					},
 					object.NIL,
@@ -88,8 +88,8 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			return &object.ReturnValue{Values: []object.Object{
 				&object.Database{
-					Path: *path,
-					Store: *dbContent,
+					Path:     *path,
+					Store:    *dbContent,
 					IsClosed: object.Boolean{Value: false},
 				},
 				object.NIL,
@@ -127,7 +127,7 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			db.IsClosed = object.Boolean{Value: true}
 
-			return	&object.Nil{}
+			return &object.Nil{}
 		},
 	},
 
@@ -313,7 +313,7 @@ var DBBuiltins = map[string]*object.Builtin{
 				keys.Elements = append(keys.Elements, pair.Key)
 			}
 
-			return	&keys
+			return &keys
 		},
 	},
 
@@ -576,6 +576,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: keys alphabetically Z-A
@@ -583,6 +584,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: values alphabetically A-Z
@@ -590,6 +592,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: values alphabetically Z-A
@@ -597,6 +600,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: shortest keys first
@@ -604,6 +608,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(4)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: longest keys first
@@ -611,6 +616,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(5)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: shortest values first
@@ -618,6 +624,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(6)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: longest values first
@@ -625,6 +632,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(7)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: keys numerically ascending
@@ -632,6 +640,7 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(8)}
 		},
+		IsConstant: true,
 	},
 
 	// Sort order: keys numerically descending
@@ -639,5 +648,6 @@ var DBBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(9)}
 		},
+		IsConstant: true,
 	},
 }

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -12,9 +12,30 @@ import (
 )
 
 const DEFAULT_TIMEOUT = 30
+const (
+	OK                    int64 = 200
+	CREATED               int64 = 201
+	ACCEPTED              int64 = 202
+	NO_CONTENT            int64 = 204
+	MOVED_PERMANENTLY     int64 = 301
+	FOUND                 int64 = 302
+	NOT_MODIFIED          int64 = 304
+	TEMPORARY_REDIRECT    int64 = 307
+	PERMANENT_REDIRECT    int64 = 308
+	BAD_REQUEST           int64 = 400
+	UNAUTHORIZED          int64 = 401
+	PAYMENT_REQUIRED      int64 = 402
+	FORBIDDEN             int64 = 403
+	NOT_FOUND             int64 = 404
+	METHOD_NOT_ALLOWED    int64 = 405
+	CONFLICT              int64 = 409
+	INTERNAL_SERVER_ERROR int64 = 500
+	BAD_GATEWAY           int64 = 502
+	SERVICE_UNAVAILABLE   int64 = 503
+)
 
 var defaultClient = &http.Client{
-	Timeout: time.Duration(DEFAULT_TIMEOUT)*time.Second,
+	Timeout: time.Duration(DEFAULT_TIMEOUT) * time.Second,
 }
 
 var HttpBuiltins = map[string]*object.Builtin{
@@ -240,7 +261,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			if _, err := url.ParseRequestURI(urlArg.Value); err != nil {
 				return &object.Error{Code: "E14001", Message: "invalid url"}
 			}
-			
+
 			req, err := http.NewRequest(http.MethodDelete, urlArg.Value, nil)
 			if err != nil {
 				return &object.ReturnValue{
@@ -404,7 +425,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			}
 
 			client := http.Client{
-				Timeout: time.Duration(timeout)*time.Second,
+				Timeout: time.Duration(timeout) * time.Second,
 			}
 
 			var req *http.Request
@@ -425,7 +446,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 			case "HEAD":
 				req, err = http.NewRequest(http.MethodHead, urlArg.Value, nil)
 			default:
-				return &object.Error{Code: "E14004", Message: "invalid HTTP method: `"+methodArg.Value+"`"}
+				return &object.Error{Code: "E14004", Message: "invalid HTTP method: `" + methodArg.Value + "`"}
 			}
 			if err != nil {
 				return &object.ReturnValue{
@@ -481,7 +502,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"http.encode_url":  {
+	"http.encode_url": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
 				return &object.Error{Code: "E7001", Message: "http.encode_url() takes exactly 1 arguments"}
@@ -498,7 +519,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"http.decode_url":  {
+	"http.decode_url": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
 				return &object.Error{Code: "E7001", Message: "http.decode_url() takes exactly 1 arguments"}
@@ -575,12 +596,126 @@ var HttpBuiltins = map[string]*object.Builtin{
 			return &object.String{Value: result}
 		},
 	},
-} 
+
+	"http.OK": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(OK)}
+		},
+	},
+
+	"http.CREATED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(CREATED)}
+		},
+	},
+
+	"http.ACCEPTED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(ACCEPTED)}
+		},
+	},
+
+	"http.NO_CONTENT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(NO_CONTENT)}
+		},
+	},
+
+	"http.MOVED_PERMANENTLY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(MOVED_PERMANENTLY)}
+		},
+	},
+
+	"http.FOUND": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(FOUND)}
+		},
+	},
+
+	"http.NOT_MODIFIED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(NOT_MODIFIED)}
+		},
+	},
+
+	"http.TEMPORARY_REDIRECT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(TEMPORARY_REDIRECT)}
+		},
+	},
+
+	"http.PERMANENT_REDIRECT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(PERMANENT_REDIRECT)}
+		},
+	},
+
+	"http.BAD_REQUEST": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(BAD_REQUEST)}
+		},
+	},
+
+	"http.UNAUTHORIZED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(UNAUTHORIZED)}
+		},
+	},
+
+	"http.PAYMENT_REQUIRED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(PAYMENT_REQUIRED)}
+		},
+	},
+
+	"http.FORBIDDEN": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(FORBIDDEN)}
+		},
+	},
+
+	"http.NOT_FOUND": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(NOT_FOUND)}
+		},
+	},
+
+	"http.METHOD_NOT_ALLOWED": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(METHOD_NOT_ALLOWED)}
+		},
+	},
+
+	"http.CONFLICT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(CONFLICT)}
+		},
+	},
+
+	"http.INTERNAL_SERVER_ERROR": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(INTERNAL_SERVER_ERROR)}
+		},
+	},
+
+	"http.BAD_GATEWAY": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(BAD_GATEWAY)}
+		},
+	},
+
+	"http.SERVICE_UNAVAILABLE": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Integer{Value: big.NewInt(SERVICE_UNAVAILABLE)}
+		},
+	},
+}
 
 func createHttpError(code, message string) *object.Struct {
 	return &object.Struct{
 		TypeName: "Error",
-		Mutable: false,
+		Mutable:  false,
 		Fields: map[string]object.Object{
 			"message": &object.String{Value: message},
 			"code":    &object.String{Value: code},
@@ -591,10 +726,10 @@ func createHttpError(code, message string) *object.Struct {
 func newHttpResponse(status int, body string, headers *object.Map) *object.Struct {
 	return &object.Struct{
 		TypeName: "HttpResponse",
-		Mutable: false,
+		Mutable:  false,
 		Fields: map[string]object.Object{
-			"status": &object.Integer{Value: big.NewInt(int64(status))},
-			"body": &object.String{Value: body},
+			"status":  &object.Integer{Value: big.NewInt(int64(status))},
+			"body":    &object.String{Value: body},
 			"headers": headers,
 		},
 	}

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -597,118 +597,141 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// HTTP Status Code Constants
+	// ============================================================================
+
 	"http.OK": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(OK)}
 		},
+		IsConstant: true,
 	},
 
 	"http.CREATED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(CREATED)}
 		},
+		IsConstant: true,
 	},
 
 	"http.ACCEPTED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(ACCEPTED)}
 		},
+		IsConstant: true,
 	},
 
 	"http.NO_CONTENT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(NO_CONTENT)}
 		},
+		IsConstant: true,
 	},
 
 	"http.MOVED_PERMANENTLY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(MOVED_PERMANENTLY)}
 		},
+		IsConstant: true,
 	},
 
 	"http.FOUND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(FOUND)}
 		},
+		IsConstant: true,
 	},
 
 	"http.NOT_MODIFIED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(NOT_MODIFIED)}
 		},
+		IsConstant: true,
 	},
 
 	"http.TEMPORARY_REDIRECT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(TEMPORARY_REDIRECT)}
 		},
+		IsConstant: true,
 	},
 
 	"http.PERMANENT_REDIRECT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(PERMANENT_REDIRECT)}
 		},
+		IsConstant: true,
 	},
 
 	"http.BAD_REQUEST": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(BAD_REQUEST)}
 		},
+		IsConstant: true,
 	},
 
 	"http.UNAUTHORIZED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(UNAUTHORIZED)}
 		},
+		IsConstant: true,
 	},
 
 	"http.PAYMENT_REQUIRED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(PAYMENT_REQUIRED)}
 		},
+		IsConstant: true,
 	},
 
 	"http.FORBIDDEN": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(FORBIDDEN)}
 		},
+		IsConstant: true,
 	},
 
 	"http.NOT_FOUND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(NOT_FOUND)}
 		},
+		IsConstant: true,
 	},
 
 	"http.METHOD_NOT_ALLOWED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(METHOD_NOT_ALLOWED)}
 		},
+		IsConstant: true,
 	},
 
 	"http.CONFLICT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(CONFLICT)}
 		},
+		IsConstant: true,
 	},
 
 	"http.INTERNAL_SERVER_ERROR": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(INTERNAL_SERVER_ERROR)}
 		},
+		IsConstant: true,
 	},
 
 	"http.BAD_GATEWAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(BAD_GATEWAY)}
 		},
+		IsConstant: true,
 	},
 
 	"http.SERVICE_UNAVAILABLE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(SERVICE_UNAVAILABLE)}
 		},
+		IsConstant: true,
 	},
 }
 

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -1167,36 +1167,43 @@ var IOBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_RDONLY))}
 		},
+		IsConstant: true,
 	},
 	"io.WRITE_ONLY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_WRONLY))}
 		},
+		IsConstant: true,
 	},
 	"io.READ_WRITE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_RDWR))}
 		},
+		IsConstant: true,
 	},
 	"io.APPEND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_APPEND))}
 		},
+		IsConstant: true,
 	},
 	"io.CREATE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_CREATE))}
 		},
+		IsConstant: true,
 	},
 	"io.TRUNCATE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_TRUNC))}
 		},
+		IsConstant: true,
 	},
 	"io.EXCLUSIVE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_EXCL))}
 		},
+		IsConstant: true,
 	},
 
 	// Seek whence constants
@@ -1204,16 +1211,19 @@ var IOBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(io.SeekStart))}
 		},
+		IsConstant: true,
 	},
 	"io.SEEK_CURRENT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(io.SeekCurrent))}
 		},
+		IsConstant: true,
 	},
 	"io.SEEK_END": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(io.SeekEnd))}
 		},
+		IsConstant: true,
 	},
 
 	// ============================================================================

--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -639,46 +639,55 @@ var MathBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Pi}
 		},
+		IsConstant: true,
 	},
 	"math.E": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.E}
 		},
+		IsConstant: true,
 	},
 	"math.PHI": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Phi}
 		},
+		IsConstant: true,
 	},
 	"math.SQRT2": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Sqrt2}
 		},
+		IsConstant: true,
 	},
 	"math.LN2": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Ln2}
 		},
+		IsConstant: true,
 	},
 	"math.LN10": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Ln10}
 		},
+		IsConstant: true,
 	},
 	"math.TAU": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: 2 * math.Pi}
 		},
+		IsConstant: true,
 	},
 	"math.INF": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Inf(1)}
 		},
+		IsConstant: true,
 	},
 	"math.NEG_INF": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Inf(-1)}
 		},
+		IsConstant: true,
 	},
 
 	// Special value checks

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -292,16 +292,19 @@ var OSBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
 		},
+		IsConstant: true,
 	},
 	"os.LINUX": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
+		IsConstant: true,
 	},
 	"os.WINDOWS": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
 		},
+		IsConstant: true,
 	},
 
 	// Returns the current OS as a constant (matches os.MAC_OS, os.LINUX, or os.WINDOWS)
@@ -318,6 +321,7 @@ var OSBuiltins = map[string]*object.Builtin{
 				return &object.Integer{Value: big.NewInt(-1)} // Unknown
 			}
 		},
+		IsConstant: true,
 	},
 
 	// Returns the operating system name as a string
@@ -386,6 +390,7 @@ var OSBuiltins = map[string]*object.Builtin{
 			}
 			return &object.String{Value: "\n"}
 		},
+		IsConstant: true,
 	},
 
 	// Returns the null device path for the current platform
@@ -397,6 +402,7 @@ var OSBuiltins = map[string]*object.Builtin{
 			}
 			return &object.String{Value: "/dev/null"}
 		},
+		IsConstant: true,
 	},
 
 	// ============================================================================

--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -654,36 +654,43 @@ var TimeBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
 		},
+		IsConstant: true,
 	},
 	"time.MONDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
+		IsConstant: true,
 	},
 	"time.TUESDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
 		},
+		IsConstant: true,
 	},
 	"time.WEDNESDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3)}
 		},
+		IsConstant: true,
 	},
 	"time.THURSDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(4)}
 		},
+		IsConstant: true,
 	},
 	"time.FRIDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(5)}
 		},
+		IsConstant: true,
 	},
 	"time.SATURDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(6)}
 		},
+		IsConstant: true,
 	},
 
 	// Month Constants
@@ -691,61 +698,73 @@ var TimeBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
+		IsConstant: true,
 	},
 	"time.FEBRUARY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
 		},
+		IsConstant: true,
 	},
 	"time.MARCH": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3)}
 		},
+		IsConstant: true,
 	},
 	"time.APRIL": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(4)}
 		},
+		IsConstant: true,
 	},
 	"time.MAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(5)}
 		},
+		IsConstant: true,
 	},
 	"time.JUNE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(6)}
 		},
+		IsConstant: true,
 	},
 	"time.JULY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(7)}
 		},
+		IsConstant: true,
 	},
 	"time.AUGUST": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(8)}
 		},
+		IsConstant: true,
 	},
 	"time.SEPTEMBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(9)}
 		},
+		IsConstant: true,
 	},
 	"time.OCTOBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(10)}
 		},
+		IsConstant: true,
 	},
 	"time.NOVEMBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(11)}
 		},
+		IsConstant: true,
 	},
 	"time.DECEMBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(12)}
 		},
+		IsConstant: true,
 	},
 
 	// Duration Constants (in seconds)
@@ -753,26 +772,31 @@ var TimeBuiltins = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
+		IsConstant: true,
 	},
 	"time.MINUTE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(60)}
 		},
+		IsConstant: true,
 	},
 	"time.HOUR": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3600)}
 		},
+		IsConstant: true,
 	},
 	"time.DAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(86400)}
 		},
+		IsConstant: true,
 	},
 	"time.WEEK": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(604800)}
 		},
+		IsConstant: true,
 	},
 }
 

--- a/pkg/stdlib/uuid.go
+++ b/pkg/stdlib/uuid.go
@@ -78,6 +78,7 @@ var UUIDBuiltins = map[string]*object.Builtin{
 			}
 			return &object.String{Value: "00000000-0000-0000-0000-000000000000"}
 		},
+		IsConstant: true,
 	},
 }
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4371,7 +4371,9 @@ func (tc *TypeChecker) isStdlibConstant(moduleName, constName string) bool {
 		"std": {
 			"EXIT_SUCCESS": true, "EXIT_FAILURE": true,
 		},
-		"db": {},
+		"db": {
+			"ALPHA": true,
+		},
 		"http": {
 			"OK": true, "CREATED": true, "ACCEPTED": true,
 			"NO_CONTENT": true, "MOVED_PERMANENTLY": true, "FOUND": true,
@@ -4381,8 +4383,12 @@ func (tc *TypeChecker) isStdlibConstant(moduleName, constName string) bool {
 			"CONFLICT": true, "INTERNAL_SERVER_ERROR": true, "BAD_GATEWAY": true,
 			"SERVICE_UNAVAILABLE": true,
 		},
-		"io":   {},
-		"math": {},
+		"io": {},
+		"math": {
+			"PI": true, "E": true, "PHI": true,
+			"SQRT2": true, "LN2": true, "LN10": true,
+			"TAU": true, "INF": true, "NEG_INF": true,
+		},
 		"os": {
 			"MAC_OS": true, "LINUX": true, "WINDOWS": true,
 			"CURRENT_OS": true, "line_separator": true, "dev_null": true,

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4386,7 +4386,12 @@ func (tc *TypeChecker) isStdlibConstant(moduleName, constName string) bool {
 			"CONFLICT": true, "INTERNAL_SERVER_ERROR": true, "BAD_GATEWAY": true,
 			"SERVICE_UNAVAILABLE": true,
 		},
-		"io": {},
+		"io": {
+			"READ_ONLY": true, "WRITE_ONLY": true, "READ_WRITE": true,
+			"APPEND": true, "CREATE": true, "TRUNCATE": true,
+			"EXCLUSIVE": true, "SEEK_START": true, "SEEK_CURRENT": true,
+			"SEEK_END": true,
+		},
 		"math": {
 			"PI": true, "E": true, "PHI": true,
 			"SQRT2": true, "LN2": true, "LN10": true,

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4372,7 +4372,10 @@ func (tc *TypeChecker) isStdlibConstant(moduleName, constName string) bool {
 			"EXIT_SUCCESS": true, "EXIT_FAILURE": true,
 		},
 		"db": {
-			"ALPHA": true,
+			"ALPHA": true, "ALPHA_DESC": true, "VALUE_ALPHA": true,
+			"VALUE_ALPHA_DESC": true, "KEY_LEN": true, "KEY_LEN_DESC": true,
+			"VALUE_LEN": true, "VALUE_LEN_DESC": true, "NUMERIC": true,
+			"NUMERIC_DESC": true,
 		},
 		"http": {
 			"OK": true, "CREATED": true, "ACCEPTED": true,

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4401,7 +4401,16 @@ func (tc *TypeChecker) isStdlibConstant(moduleName, constName string) bool {
 			"MAC_OS": true, "LINUX": true, "WINDOWS": true,
 			"CURRENT_OS": true, "line_separator": true, "dev_null": true,
 		},
-		"time": {},
+		"time": {
+			"SUNDAY": true, "MONDAY": true, "TUESDAY": true,
+			"WEDNESDAY": true, "THURSDAY": true, "FRIDAY": true,
+			"SATURDAY": true, "JANUARY": true, "FEBRUARY": true,
+			"MARCH": true, "APRIL": true, "MAY": true,
+			"JUNE": true, "JULY": true, "AUGUST": true,
+			"SEPTEMBER": true, "OCTOBER": true, "NOVEMBER": true,
+			"DECEMBER": true, "SECOND": true, "MINUTE": true,
+			"HOUR": true, "DAY": true, "WEEK": true,
+		},
 		"uuid": {
 			"NIL": true,
 		},

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1743,6 +1743,37 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
+func TestHttpModuleConstantWithoutModuleNamespace(t *testing.T) {
+	input := `
+import @http
+using http
+
+do main() {
+	const status_200 int = OK
+	const status_201 int = CREATED
+	const status_202 int = ACCEPTED
+	const status_204 int = NO_CONTENT
+	const status_301 int = MOVED_PERMANENTLY
+	const status_302 int = FOUND
+	const status_304 int = NOT_MODIFIED
+	const status_307 int = TEMPORARY_REDIRECT
+	const status_308 int = PERMANENT_REDIRECT
+	const status_400 int = BAD_REQUEST
+	const status_401 int = UNAUTHORIZED
+	const status_402 int = PAYMENT_REQUIRED
+	const status_403 int = FORBIDDEN
+	const status_404 int = NOT_FOUND
+	const status_405 int = METHOD_NOT_ALLOWED
+	const status_409 int = CONFLICT
+	const status_500 int = INTERNAL_SERVER_ERROR
+	const status_502 int = BAD_GATEWAY
+	const status_503 int = SERVICE_UNAVAILABLE
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
 // ============================================================================
 // Prefix Expression Tests
 // ============================================================================

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1700,21 +1700,14 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestMathConstantsWithUsing(t *testing.T) {
+func TestStdlibConstantsWithUsing(t *testing.T) {
 	input := `
-import @math
-using math
+import @std
+using std
 
 do main() {
-	const pi_val float = PI
-	const e_val float = E
-	const phi_val float = PHI
-	const sqrt2_val float = SQRT2
-	const ln2_val float = LN2
-	const ln10_val float = LN10
-	const tau_val float = TAU
-	const inf_val float = INF
-	const neg_inf_val float = NEG_INF
+	const exit_success_val int = EXIT_SUCCESS
+	const exit_failure_val int = EXIT_FAILURE
 }
 `
 	tc := typecheck(t, input)
@@ -1768,6 +1761,49 @@ do main() {
 	const status_500 int = INTERNAL_SERVER_ERROR
 	const status_502 int = BAD_GATEWAY
 	const status_503 int = SERVICE_UNAVAILABLE
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestIOConstantsWithUsing(t *testing.T) {
+	input := `
+import @io
+using io
+
+do main() {
+	const read_only_val int = READ_ONLY
+	const write_only_val int = WRITE_ONLY
+	const read_write_val int = READ_WRITE
+	const append_val int = APPEND
+	const create_val int = CREATE
+	const truncate_val int = TRUNCATE
+	const exclusive_val int = EXCLUSIVE
+	const seek_start_val int = SEEK_START
+	const seek_current_val int = SEEK_CURRENT
+	const seek_end_val int = SEEK_END
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestMathConstantsWithUsing(t *testing.T) {
+	input := `
+import @math
+using math
+
+do main() {
+	const pi_val float = PI
+	const e_val float = E
+	const phi_val float = PHI
+	const sqrt2_val float = SQRT2
+	const ln2_val float = LN2
+	const ln10_val float = LN10
+	const tau_val float = TAU
+	const inf_val float = INF
+	const neg_inf_val float = NEG_INF
 }
 `
 	tc := typecheck(t, input)

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1810,6 +1810,76 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
+func TestOSConstantsWithUsing(t *testing.T) {
+	input := `
+import @os
+using os
+
+do main() {
+	const mac_os_val int = MAC_OS
+	const linux_val int = LINUX
+	const windows_val int = WINDOWS
+	const current_os_val int = CURRENT_OS
+	const line_sep_val string = line_separator
+	const dev_null_val string = dev_null
+}
+`
+
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestTimeConstantsWithUsing(t *testing.T) {
+	input := `
+import @time
+using time
+
+do main() {
+	const sunday_val int = SUNDAY
+	const monday_val int = MONDAY
+	const tuesday_val int = TUESDAY
+	const wednesday_val int = WEDNESDAY
+	const thursday_val int = THURSDAY
+	const friday_val int = FRIDAY
+	const saturday_val int = SATURDAY
+	const january_val int = JANUARY
+	const february_val int = FEBRUARY
+	const march_val int = MARCH
+	const april_val int = APRIL
+	const may_val int = MAY
+	const june_val int = JUNE
+	const july_val int = JULY
+	const august_val int = AUGUST
+	const september_val int = SEPTEMBER
+	const october_val int = OCTOBER
+	const november_val int = NOVEMBER
+	const december_val int = DECEMBER
+	const second_val int = SECOND
+	const minute_val int = MINUTE
+	const hour_val int = HOUR
+	const day_val int = DAY
+	const week_val int = WEEK
+}
+`
+
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestUUIDConstantsWithUsing(t *testing.T) {
+	input := `
+import @uuid
+using uuid
+
+do main() {
+	const nil_val string = NIL
+}
+`
+
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
 // ============================================================================
 // Prefix Expression Tests
 // ============================================================================

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1564,6 +1564,27 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
+func TestMathModuleConstantWithoutModuleNamespace(t *testing.T) {
+	input := `
+import @math
+using math
+
+do main() {
+	const var1 float = PI
+	const var2 float = E
+	const var3 float = PHI
+	const var4 float = SQRT2
+	const var5 float = LN2
+	const var6 float = LN10
+	const var7 float = TAU
+	const var8 float = INF
+	const var9 float = NEG_INF
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
 func TestArraysModuleCall(t *testing.T) {
 	input := `
 import @arrays

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1700,50 +1700,50 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestMathModuleConstantWithoutModuleNamespace(t *testing.T) {
+func TestMathConstantsWithUsing(t *testing.T) {
 	input := `
 import @math
 using math
 
 do main() {
-	const var1 float = PI
-	const var2 float = E
-	const var3 float = PHI
-	const var4 float = SQRT2
-	const var5 float = LN2
-	const var6 float = LN10
-	const var7 float = TAU
-	const var8 float = INF
-	const var9 float = NEG_INF
+	const pi_val float = PI
+	const e_val float = E
+	const phi_val float = PHI
+	const sqrt2_val float = SQRT2
+	const ln2_val float = LN2
+	const ln10_val float = LN10
+	const tau_val float = TAU
+	const inf_val float = INF
+	const neg_inf_val float = NEG_INF
 }
 `
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
 
-func TestDBModuleConstantWithoutModuleNamespace(t *testing.T) {
+func TestDbConstantsWithUsing(t *testing.T) {
 	input := `
 import @db
 using db
 
 do main() {
-	const var1 int = ALPHA
-	const var2 int = ALPHA_DESC
-	const var3 int = VALUE_ALPHA
-	const var4 int = VALUE_ALPHA_DESC
-	const var5 int = KEY_LEN
-	const var6 int = KEY_LEN_DESC
-	const var7 int = VALUE_LEN
-	const var8 int = VALUE_LEN_DESC
-	const var9 int = NUMERIC
-	const var10 int = NUMERIC_DESC
+	const alpha_val int = ALPHA
+	const alpha_desc_val int = ALPHA_DESC
+	const value_alpha_val int = VALUE_ALPHA
+	const value_alpha_desc_val int = VALUE_ALPHA_DESC
+	const key_len_val int = KEY_LEN
+	const key_len_desc_val int = KEY_LEN_DESC
+	const value_len_val int = VALUE_LEN
+	const value_len_desc_val int = VALUE_LEN_DESC
+	const numeric_val int = NUMERIC
+	const numberic_desc_val int = NUMERIC_DESC
 }
 `
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
 
-func TestHttpModuleConstantWithoutModuleNamespace(t *testing.T) {
+func TestHttpConstantsWithUsing(t *testing.T) {
 	input := `
 import @http
 using http

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1564,27 +1564,6 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestMathModuleConstantWithoutModuleNamespace(t *testing.T) {
-	input := `
-import @math
-using math
-
-do main() {
-	const var1 float = PI
-	const var2 float = E
-	const var3 float = PHI
-	const var4 float = SQRT2
-	const var5 float = LN2
-	const var6 float = LN10
-	const var7 float = TAU
-	const var8 float = INF
-	const var9 float = NEG_INF
-}
-`
-	tc := typecheck(t, input)
-	assertNoErrors(t, tc)
-}
-
 func TestArraysModuleCall(t *testing.T) {
 	input := `
 import @arrays
@@ -1715,6 +1694,49 @@ import @maps
 do main() {
 	temp m map[string:int] = {"a": 1}
 	temp values [int] = {1, 2, 3}
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestMathModuleConstantWithoutModuleNamespace(t *testing.T) {
+	input := `
+import @math
+using math
+
+do main() {
+	const var1 float = PI
+	const var2 float = E
+	const var3 float = PHI
+	const var4 float = SQRT2
+	const var5 float = LN2
+	const var6 float = LN10
+	const var7 float = TAU
+	const var8 float = INF
+	const var9 float = NEG_INF
+}
+`
+	tc := typecheck(t, input)
+	assertNoErrors(t, tc)
+}
+
+func TestDBModuleConstantWithoutModuleNamespace(t *testing.T) {
+	input := `
+import @db
+using db
+
+do main() {
+	const var1 int = ALPHA
+	const var2 int = ALPHA_DESC
+	const var3 int = VALUE_ALPHA
+	const var4 int = VALUE_ALPHA_DESC
+	const var5 int = KEY_LEN
+	const var6 int = KEY_LEN_DESC
+	const var7 int = VALUE_LEN
+	const var8 int = VALUE_LEN_DESC
+	const var9 int = NUMERIC
+	const var10 int = NUMERIC_DESC
 }
 `
 	tc := typecheck(t, input)


### PR DESCRIPTION
# Summary

Resolve #909 - The using directive now correctly brings stdlib module constants into scope, not just functions. Previously, constants like http.OK or os.MAC_OS required the full module prefix even after declaring using http or using os.

---

# Changes

## Typecheker
- Added `isStdlibConstant()` function that maps module names to their exported constants
- Updated `isKnownIdentifier()` to recognize stdlib constants accessible via using directives

## Stdlib `IsConstant`
> Added `IsConstant=true` on below constants
- http: OK, CREATED, NOT_FOUND, BAD_REQUEST, INTERNAL_SERVER_ERROR, etc
- os:  MAC_OS, LINUX, WINDOWS, CURRENT_OS, line_separator, dev_null
- math: PI, E, PHI, SQRT2, TAU, INF, NEG_INF, etc
- time: SUNDAY-SATURDAY, JANUARY-DECEMBER, SECOND, MINUTE, HOUR, DAY, WEEK
- io: READ_ONLY, WRITE_ONLY, READ_WRITE, APPEND, etc
- db: ALPHA, ALPHA_DESC, NUMERIC, KEY_LEN, VALUE_LEN, etc
- uuid: NIL

## Some unit tests
Added typechecker tests for constants from all affected modules
- TestStdlibConstantsWithUsing
- TestDbConstantsWithUsing
- TestHttpConstantsWithUsing
- TestIOConstantsWithUsing
- TestMathConstantsWithUsing
- TestOSConstantsWithUsing
- TestTimeConstantsWithUsing
- TestUUIDConstantsWithUsin

---

# Test Results

## Unit tests
All passed 👍

## Integration tests
All passed individually, but please check this issue #978