### PR TITLE
fix: resolve integration test failures on Linux

### DIFF
--- a/integration-tests/pass/stdlib/db.ez
+++ b/integration-tests/pass/stdlib/db.ez
@@ -2,7 +2,7 @@
  * db.ez - Test @db standard library with PROPER ASSERTIONS
  */
 
-import @std, @db, @json
+import @std, @db, @json, @io
 using std
 
 const User struct {
@@ -381,6 +381,14 @@ do main() {
         failed += 1
     }
 
+    // ==================== CLEANUP ====================
+    println("  -- Cleanup --")
+
+    // Clean up test database files created during tests
+    temp _, _ = io.remove("mydb.ezdb")
+    temp _, _ = io.remove("rename_test.ezdb")
+    temp _, _ = io.remove("sort_test.ezdb")
+    println("   [INFO] Cleaned up test database files")
 
     // ==================== Summary ====================
     println("")

--- a/integration-tests/run_tests.sh
+++ b/integration-tests/run_tests.sh
@@ -52,14 +52,14 @@ for test_file in "$SCRIPT_DIR"/pass/core/*.ez; do
         if output=$("$EZ_BIN" "$test_file" 2>&1); then
             if echo "$output" | grep -q "SOME TESTS FAILED"; then
                 echo -e "${RED}FAIL${NC} (test assertions failed)"
-                ((FAIL_COUNT++))
+                ((++FAIL_COUNT))
             else
                 echo -e "${GREEN}PASS${NC}"
-                ((PASS_COUNT++))
+                ((++PASS_COUNT))
             fi
         else
             echo -e "${RED}FAIL${NC} (execution error)"
-            ((FAIL_COUNT++))
+            ((++FAIL_COUNT))
         fi
     fi
 done
@@ -73,14 +73,14 @@ for test_file in "$SCRIPT_DIR"/pass/stdlib/*.ez; do
         if output=$("$EZ_BIN" "$test_file" 2>&1); then
             if echo "$output" | grep -q "SOME TESTS FAILED"; then
                 echo -e "${RED}FAIL${NC} (test assertions failed)"
-                ((FAIL_COUNT++))
+                ((++FAIL_COUNT))
             else
                 echo -e "${GREEN}PASS${NC}"
-                ((PASS_COUNT++))
+                ((++PASS_COUNT))
             fi
         else
             echo -e "${RED}FAIL${NC} (execution error)"
-            ((FAIL_COUNT++))
+            ((++FAIL_COUNT))
         fi
     fi
 done
@@ -97,10 +97,10 @@ for dir in "$SCRIPT_DIR"/pass/multi-file/*/; do
 
             if output=$("$EZ_BIN" "$main_file" 2>&1); then
                 echo -e "${GREEN}PASS${NC}"
-                ((PASS_COUNT++))
+                ((++PASS_COUNT))
             else
                 echo -e "${RED}FAIL${NC} (execution error)"
-                ((FAIL_COUNT++))
+                ((++FAIL_COUNT))
             fi
         fi
     fi
@@ -124,10 +124,10 @@ if [ -d "$SCRIPT_DIR/pass/warnings" ]; then
 
             if echo "$output" | grep -q "warning\[$expected_warning\]"; then
                 echo -e "${GREEN}PASS${NC}"
-                ((PASS_COUNT++))
+                ((++PASS_COUNT))
             else
                 echo -e "${RED}FAIL${NC} (expected warning $expected_warning not found)"
-                ((FAIL_COUNT++))
+                ((++FAIL_COUNT))
             fi
         fi
     done
@@ -145,10 +145,10 @@ for test_file in "$SCRIPT_DIR"/fail/errors/*.ez; do
 
         if "$EZ_BIN" "$test_file" >/dev/null 2>&1; then
             echo -e "${RED}FAIL${NC} (expected error, got success)"
-            ((FAIL_COUNT++))
+            ((++FAIL_COUNT))
         else
             echo -e "${GREEN}PASS${NC}"
-            ((PASS_COUNT++))
+            ((++PASS_COUNT))
         fi
     fi
 done
@@ -164,10 +164,10 @@ for test_file in "$SCRIPT_DIR"/fail/multi-file/*.ez; do
 
         if "$EZ_BIN" "$test_file" >/dev/null 2>&1; then
             echo -e "${RED}FAIL${NC} (expected error, got success)"
-            ((FAIL_COUNT++))
+            ((++FAIL_COUNT))
         else
             echo -e "${GREEN}PASS${NC}"
-            ((PASS_COUNT++))
+            ((++PASS_COUNT))
         fi
     fi
 done
@@ -183,10 +183,10 @@ for dir in "$SCRIPT_DIR"/fail/multi-file/*/; do
 
             if "$EZ_BIN" "$main_file" >/dev/null 2>&1; then
                 echo -e "${RED}FAIL${NC} (expected error, got success)"
-                ((FAIL_COUNT++))
+                ((++FAIL_COUNT))
             else
                 echo -e "${GREEN}PASS${NC}"
-                ((PASS_COUNT++))
+                ((++PASS_COUNT))
             fi
         fi
     fi


### PR DESCRIPTION
## Summary

Resolves #978 - Integration tests fail on Linux due to two issues:

1. **Bash arithmetic with `set -e`**: Post-increment `((PASS_COUNT++))` returns exit code 1 when the counter is 0, causing the script to terminate immediately after the first passing test.

2. **Leftover `.ezdb` files**: The `db.ez` test creates database files that persist between runs, causing `db.keys()` to find unexpected keys on subsequent runs.

## Changes

### `integration-tests/run_tests.sh`
- Changed all `((PASS_COUNT++))` to `((++PASS_COUNT))`
- Changed all `((FAIL_COUNT++))` to `((++FAIL_COUNT))`

### `integration-tests/pass/stdlib/db.ez`
- Added `@io` to imports
- Added cleanup section to remove test database files:
  - `mydb.ezdb`
  - `rename_test.ezdb`
  - `sort_test.ezdb`

## Test Results

- All 332 integration tests pass
- `db.ez` passes on consecutive runs
- No leftover `.ezdb` files after test completion