### PR TITLE
fix(cli):Allow command line arguments for programs

### DIFF
--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -99,6 +99,8 @@ var rootCmd = &cobra.Command{
 		programArgs := []string{os.Args[0], args[0]}
 		if cmd.ArgsLenAtDash() > 0 {
 			programArgs = slices.Concat(programArgs, args[cmd.ArgsLenAtDash():])
+		} else if len(args) > 1 {
+			programArgs = slices.Concat(programArgs, args[1:])
 		}
 		stdlib.CommandLineArgs = programArgs
 
@@ -109,7 +111,6 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd, versionCmd)
-	rootCmd.Flags().Bool("confirm", false, "Skip confirmation prompt")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		CheckForUpdateAsync()
 	}

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -98,7 +98,7 @@ var rootCmd = &cobra.Command{
 
 		programArgs := []string{os.Args[0], args[0]}
 		if cmd.ArgsLenAtDash() > 0 {
-			programArgs = slices.Concat(programArgs, args[len(args)-cmd.ArgsLenAtDash():])
+			programArgs = slices.Concat(programArgs, args[cmd.ArgsLenAtDash():])
 		}
 		stdlib.CommandLineArgs = programArgs
 

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
+	"slices"
 	"strings"
 
+	"github.com/marshallburns/ez/pkg/stdlib"
 	"github.com/spf13/cobra"
 )
 
@@ -83,19 +86,30 @@ var rootCmd = &cobra.Command{
 	Use:     "ez [file.ez]",
 	Short:   "EZ Language Interpreter",
 	Long:    "A simple, interpreted, statically-typed programming language designed for clarity and ease of use.",
-	Args:    cobra.MaximumNArgs(1),
+	Args:    cobra.ArbitraryArgs,
 	Version: getVersionString(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 1 && strings.HasSuffix(args[0], ".ez") {
-			runFile(args[0])
-			return nil
+		if len(args) == 0 {
+			return cmd.Help()
 		}
-		return cmd.Help()
+		if !strings.HasSuffix(args[0], ".ez") {
+			return cmd.Help()
+		}
+
+		programArgs := []string{os.Args[0], args[0]}
+		if cmd.ArgsLenAtDash() > 0 {
+			programArgs = slices.Concat(programArgs, args[len(args)-cmd.ArgsLenAtDash():])
+		}
+		stdlib.CommandLineArgs = programArgs
+
+		runFile(args[0])
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(replCmd, updateCmd, checkCmd, lexCmd, parseCmd, versionCmd)
+	rootCmd.Flags().Bool("confirm", false, "Skip confirmation prompt")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		CheckForUpdateAsync()
 	}

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -136,13 +136,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	"os.args": {
 		Fn: func(args ...object.Object) object.Object {
 			// Use CommandLineArgs if set, otherwise fall back to os.Args
-			sourceArgs := CommandLineArgs
-			if len(sourceArgs) == 0 {
-				sourceArgs = os.Args
-			}
-
-			elements := make([]object.Object, len(sourceArgs))
-			for i, arg := range sourceArgs {
+			elements := make([]object.Object, len(CommandLineArgs))
+			for i, arg := range CommandLineArgs {
 				elements[i] = &object.String{Value: arg}
 			}
 			return &object.Array{Elements: elements, Mutable: false, ElementType: "string"}


### PR DESCRIPTION
# Summary
- Allows for command line arguments following dashes to be passed to the program
```sh
$ ez main.ez -- hello world --verbose
Args: {"ez", "main.ez", "hello", "world", "--verbose"}
``` 
- Consumes flags sets before dashes, prior to passing arguments to the program
```sh
$ ez main.ez --dummy -- hello world --verbose
Args: {"ez", "main.ez", "hello", "world", "--verbose"}
```
- Changed `os.args` method in `@os` module to use arguments set by `CommandLineArgs` in `cmd/ez/commands.go` 

# Test Results
- [x] All unit tests pass
- [x] All integration tests pass

CLOSES #967 