### PR TITLE
fix: Prevent RETURN_VALUE type leak for multi-return functions

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -138,6 +138,7 @@ Type system errors
 | E3037 | invalid-private-usage | private modifier cannot be used here |
 | E3038 | void-type-not-allowed | 'void' is not a valid type |
 | E3039 | ensure-expects-call | ensure expects a function call |
+| E3040 | multi-return-to-single-var | cannot assign multiple return values to single variable |
 
 ## Reference Errors (E4xxx)
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -375,4 +375,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 256 error/warning codes
+**Total:** 257 error/warning codes

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -138,6 +138,7 @@ var (
 	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
 	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is not a valid type"}
 	E3039 = ErrorCode{"E3039", "ensure-expects-call", "ensure expects a function call"}
+	E3040 = ErrorCode{"E3040", "multi-return-to-single-var", "cannot assign multiple return values to single variable"}
 )
 
 // =============================================================================

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -76,6 +76,20 @@ func getEZTypeName(obj object.Object) string {
 		return "nil"
 	case *object.Function:
 		return "function"
+	case *object.ReturnValue:
+		// Handle multi-return values - show tuple type
+		if len(v.Values) == 0 {
+			return "void"
+		}
+		if len(v.Values) == 1 {
+			return getEZTypeName(v.Values[0])
+		}
+		// Multiple values - show as tuple
+		types := make([]string, len(v.Values))
+		for i, val := range v.Values {
+			types[i] = getEZTypeName(val)
+		}
+		return "(" + strings.Join(types, ", ") + ")"
 	default:
 		return string(obj.Type())
 	}


### PR DESCRIPTION
## Summary

- Fixes the `RETURN_VALUE` type leak when multi-return functions are misused
- Three-layer defense: typechecker, interpreter, and typeof handling

## Changes

### 1. Typechecker Fix (`typechecker.go`)
Moved `isMultiReturnCall` check to run **before** type inference. The previous implementation (from PR #951) only caught stdlib calls because `inferCallType` returns the first type for user-defined multi-return functions.

### 2. Interpreter Fix (`evaluator.go`)  
Added defensive runtime check in `evalVariableDeclaration` that throws E5012 if a multi-value return somehow bypasses the typechecker.

### 3. getEZTypeName Fix (`builtins.go`)
Handle `ReturnValue` objects properly in typeof():
- `typeof(returns_two())` now shows `(int, string)` instead of `RETURN_VALUE`
- Single value → returns that value's type
- Multiple values → returns `(type1, type2, ...)`

## Test Results

```
332 passed, 0 failed
ALL TESTS PASSED!
```

## Test Plan

- [x] `temp x = multi_return()` throws E3040 at compile time
- [x] `typeof(multi_return())` shows `(int, string)` not `RETURN_VALUE`
- [x] All 332 integration tests pass
- [x] Stdlib functions handled correctly

Fixes #986