### PR TITLE
fix: Error on bare function/type names as statements

### DIFF
--- a/integration-tests/fail/errors/E3031_bare_function_name.ez
+++ b/integration-tests/fail/errors/E3031_bare_function_name.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3031 - function-as-value
+ * Expected: "function" and "cannot be used as a value"
+ */
+
+do some_function() {
+    // Some function
+}
+
+do main() {
+    some_function
+}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2513,6 +2513,10 @@ func (tc *TypeChecker) checkExpressionStatement(exprStmt *ast.ExpressionStatemen
 		return
 	}
 
+	// Check for bare identifiers that have no effect as statements
+	// A bare function name or type name as a statement does nothing
+	tc.checkValueExpression(exprStmt.Expression)
+
 	// Validate the entire expression tree
 	tc.checkExpression(exprStmt.Expression)
 }


### PR DESCRIPTION
## Summary
- Add validation in `checkExpressionStatement` to catch bare identifiers that reference functions or types
- These have no effect as statements and are likely mistakes (missing parentheses for function calls)
- Uses existing error code E3031 (function-as-value) and E3030 (type-as-value)

## Test plan
- [x] All 334 integration tests pass
- [x] New test case `E3031_bare_function_name.ez` verifies error detection
- [x] Bare type names (structs, enums) also produce appropriate errors

Closes #985