### PR TITLE
Bugfixes 1-11-2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -376,4 +376,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 257 error/warning codes
+**Total:** 258 error/warning codes

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -92,6 +92,7 @@ Syntax and parsing errors
 | E2054 | when-strict-non-enum-case | #strict when requires explicit enum member values in cases |
 | E2055 | strict-invalid-target | #strict can only be applied to when statements |
 | E2056 | executable-at-file-scope | executable statement not allowed at file scope |
+| E2057 | invalid-interpolation-syntax | invalid string interpolation syntax |
 
 ## Type Errors (E3xxx)
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -138,6 +138,7 @@ Type system errors
 | E3037 | invalid-private-usage | private modifier cannot be used here |
 | E3038 | void-type-not-allowed | 'void' is not a valid type |
 | E3039 | ensure-expects-call | ensure expects a function call |
+| E3040 | multi-return-to-single-var | cannot assign multiple return values to single variable |
 
 ## Reference Errors (E4xxx)
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -375,4 +375,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 256 error/warning codes
+**Total:** 257 error/warning codes

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
+	"slices"
 	"strings"
 
+	"github.com/marshallburns/ez/pkg/stdlib"
 	"github.com/spf13/cobra"
 )
 
@@ -83,14 +86,26 @@ var rootCmd = &cobra.Command{
 	Use:     "ez [file.ez]",
 	Short:   "EZ Language Interpreter",
 	Long:    "A simple, interpreted, statically-typed programming language designed for clarity and ease of use.",
-	Args:    cobra.MaximumNArgs(1),
+	Args:    cobra.ArbitraryArgs,
 	Version: getVersionString(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 1 && strings.HasSuffix(args[0], ".ez") {
-			runFile(args[0])
-			return nil
+		if len(args) == 0 {
+			return cmd.Help()
 		}
-		return cmd.Help()
+		if !strings.HasSuffix(args[0], ".ez") {
+			return cmd.Help()
+		}
+
+		programArgs := []string{os.Args[0], args[0]}
+		if cmd.ArgsLenAtDash() > 0 {
+			programArgs = slices.Concat(programArgs, args[cmd.ArgsLenAtDash():])
+		} else if len(args) > 1 {
+			programArgs = slices.Concat(programArgs, args[1:])
+		}
+		stdlib.CommandLineArgs = programArgs
+
+		runFile(args[0])
+		return nil
 	},
 }
 

--- a/integration-tests/fail/errors/E2057_invalid_interpolation_syntax.ez
+++ b/integration-tests/fail/errors/E2057_invalid_interpolation_syntax.ez
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E2057 - invalid-interpolation-syntax
+ * Expected: "invalid interpolation syntax" or "$identifier"
+ */
+
+do main() {
+    temp file string = "test.ez"
+    temp s string = "$File: something"
+}

--- a/integration-tests/fail/errors/E3031_bare_function_name.ez
+++ b/integration-tests/fail/errors/E3031_bare_function_name.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3031 - function-as-value
+ * Expected: "function" and "cannot be used as a value"
+ */
+
+do some_function() {
+    // Some function
+}
+
+do main() {
+    some_function
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -138,6 +138,7 @@ var (
 	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
 	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is not a valid type"}
 	E3039 = ErrorCode{"E3039", "ensure-expects-call", "ensure expects a function call"}
+	E3040 = ErrorCode{"E3040", "multi-return-to-single-var", "cannot assign multiple return values to single variable"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -93,6 +93,7 @@ var (
 	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "#strict when requires explicit enum member values in cases"}
 	E2055 = ErrorCode{"E2055", "strict-invalid-target", "#strict can only be applied to when statements"}
 	E2056 = ErrorCode{"E2056", "executable-at-file-scope", "executable statement not allowed at file scope"}
+	E2057 = ErrorCode{"E2057", "invalid-interpolation-syntax", "invalid string interpolation syntax"}
 )
 
 // =============================================================================
@@ -349,11 +350,11 @@ var (
 // These are errors unique to HTTP operations
 // =============================================================================
 var (
-	E14001 = ErrorCode{"E14001", "http-invalid-url",					"invalid URL"}
-	E14002 = ErrorCode{"E14002", "http-failed-request",       "request failed (network error)"}
-	E14003 = ErrorCode{"E14003", "http-timeout",							"timeout exceeded"}
-	E14004 = ErrorCode{"E14004", "http-invalid-method",				"invalid HTTP method"}
-	E14005 = ErrorCode{"E14005", "http-failed-url-decode",		"URL decode failed"}
+	E14001 = ErrorCode{"E14001", "http-invalid-url", "invalid URL"}
+	E14002 = ErrorCode{"E14002", "http-failed-request", "request failed (network error)"}
+	E14003 = ErrorCode{"E14003", "http-timeout", "timeout exceeded"}
+	E14004 = ErrorCode{"E14004", "http-invalid-method", "invalid HTTP method"}
+	E14005 = ErrorCode{"E14005", "http-failed-url-decode", "URL decode failed"}
 	E14006 = ErrorCode{"E14006", "http-failed-json-encoding", "JSON encoding failed"}
 )
 

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -76,6 +76,20 @@ func getEZTypeName(obj object.Object) string {
 		return "nil"
 	case *object.Function:
 		return "function"
+	case *object.ReturnValue:
+		// Handle multi-return values - show tuple type
+		if len(v.Values) == 0 {
+			return "void"
+		}
+		if len(v.Values) == 1 {
+			return getEZTypeName(v.Values[0])
+		}
+		// Multiple values - show as tuple
+		types := make([]string, len(v.Values))
+		for i, val := range v.Values {
+			types[i] = getEZTypeName(val)
+		}
+		return "(" + strings.Join(types, ", ") + ")"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -136,13 +136,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	"os.args": {
 		Fn: func(args ...object.Object) object.Object {
 			// Use CommandLineArgs if set, otherwise fall back to os.Args
-			sourceArgs := CommandLineArgs
-			if len(sourceArgs) == 0 {
-				sourceArgs = os.Args
-			}
-
-			elements := make([]object.Object, len(sourceArgs))
-			for i, arg := range sourceArgs {
+			elements := make([]object.Object, len(CommandLineArgs))
+			for i, arg := range CommandLineArgs {
 				elements[i] = &object.String{Value: arg}
 			}
 			return &object.Array{Elements: elements, Mutable: false, ElementType: "string"}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1807,6 +1807,18 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 
 		// If no declared type, infer from value and register it
 		if declaredType == "" {
+			// Check if it's a multi-return function being assigned to a single variable
+			// Must check BEFORE type inference since inferCallType returns first type for multi-return
+			if tc.isMultiReturnCall(decl.Value) {
+				tc.addError(
+					errors.E3040,
+					"cannot assign multi-return function result to single variable; use multiple variables or discard with _",
+					decl.Name.Token.Line,
+					decl.Name.Token.Column,
+				)
+				return
+			}
+
 			inferredType, ok := tc.inferExpressionType(decl.Value)
 			if ok {
 				if inferredType == "void" {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2513,6 +2513,10 @@ func (tc *TypeChecker) checkExpressionStatement(exprStmt *ast.ExpressionStatemen
 		return
 	}
 
+	// Check for bare identifiers that have no effect as statements
+	// A bare function name or type name as a statement does nothing
+	tc.checkValueExpression(exprStmt.Expression)
+
 	// Validate the entire expression tree
 	tc.checkExpression(exprStmt.Expression)
 }


### PR DESCRIPTION
## Summary

This PR merges the bugfixes branch containing fixes for several issues.

### Fixes included:

- **#989** - Error on bare function/type names as statements
- **#988** - Detect invalid string interpolation syntax at parse time  
- **#987** - Prevent RETURN_VALUE type leak for multi-return functions
- **#983** - Allow command line arguments for programs
- **#951** - Add `isMultiReturnCall` to typechecker

## Test plan
- [x] All unit tests pass
- [x] All 334 integration tests pass

---

Closes #985
Closes #984
Closes #986
Closes #967
Closes #944