### PR TITLE
refactor: rename `std.printf()` to `std.print()` and `std.eprintf()` to `std.eprint()`

### DIFF
--- a/integration-tests/pass/stdlib/std.ez
+++ b/integration-tests/pass/stdlib/std.ez
@@ -2,7 +2,7 @@
  * std.ez - Test @std standard library expanded functions
  *
  * Global builtins (no import needed): exit, EXIT_SUCCESS, EXIT_FAILURE, panic, assert
- * @std module functions (require import): println, printf, sleep_*, eprintln, eprintf
+ * @std module functions (require import): println, print, sleep_*, eprintln, eprint
  */
 
 import @std
@@ -74,13 +74,13 @@ do main() {
     println("  [PASS] eprintln() with multiple args executed")
     passed += 1
 
-    // ==================== eprintf (@std) ====================
-    println("  -- eprintf --")
+    // ==================== eprint (@std) ====================
+    println("  -- eprint --")
 
-    // Test: eprintf outputs to stderr without newline
-    eprintf("stderr without newline")
+    // Test: eprint outputs to stderr without newline
+    eprint("stderr without newline")
     eprintln()  // add newline after
-    println("  [PASS] eprintf() executed without error")
+    println("  [PASS] eprint() executed without error")
     passed += 1
 
     // ==================== assert (global builtin) ====================

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -258,9 +258,9 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Prints values to standard output WITHOUT a newline (like C's printf)
+	// Prints values to standard output WITHOUT a newline
 	// User must explicitly add \n for newlines
-	"std.printf": {
+	"std.print": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
 				if i > 0 {
@@ -1135,10 +1135,10 @@ var StdBuiltins = map[string]*object.Builtin{
 	// See eprintln() documentation for when to use stderr vs stdout.
 	//
 	// Example:
-	//   eprintf("Loading...")
+	//   eprint("Loading...")
 	//   // do work
 	//   eprintln(" done!")  // Output: "Loading... done!"
-	"std.eprintf": {
+	"std.eprint": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
 				if i > 0 {

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -3282,12 +3282,12 @@ func TestEprintln(t *testing.T) {
 	}
 }
 
-// Test eprintf() returns nil
-func TestEprintf(t *testing.T) {
-	eprintfFn := StdBuiltins["std.eprintf"].Fn
-	result := eprintfFn(&object.String{Value: "test output"})
+// Test eprint() returns nil
+func TestEprint(t *testing.T) {
+	eprintFn := StdBuiltins["std.eprint"].Fn
+	result := eprintFn(&object.String{Value: "test output"})
 	if result != object.NIL {
-		t.Errorf("eprintf() should return nil, got %T", result)
+		t.Errorf("eprint() should return nil, got %T", result)
 	}
 }
 
@@ -3301,6 +3301,15 @@ func TestEprintlnMultipleArgs(t *testing.T) {
 	)
 	if result != object.NIL {
 		t.Errorf("eprintln() should return nil, got %T", result)
+	}
+}
+
+// Test print() returns nil
+func TestPrint(t *testing.T) {
+	printFn := StdBuiltins["std.print"].Fn
+	result := printFn(&object.String{Value: "test output"})
+	if result != object.NIL {
+		t.Errorf("print() should return nil, got %T", result)
 	}
 }
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4467,8 +4467,8 @@ func (tc *TypeChecker) isBuiltinConstant(name string) bool {
 func (tc *TypeChecker) isStdlibFunction(moduleName, funcName string) bool {
 	stdFuncs := map[string]map[string]bool{
 		"std": {
-			"println": true, "printf": true, "print": true,
-			"eprintln": true, "eprintf": true, "eprint": true,
+			"println": true, "print": true,
+			"eprintln": true, "eprint": true,
 			"sleep_milliseconds": true, "sleep_seconds": true, "sleep_nanoseconds": true,
 			"read_int": true, "read_float": true, "read_string": true,
 		},
@@ -5331,7 +5331,7 @@ func (tc *TypeChecker) inferModuleCallType(member *ast.MemberExpression, args []
 // inferStdCallType infers return types for @std functions
 func (tc *TypeChecker) inferStdCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "println", "print", "printf":
+	case "println", "print":
 		return "void", true
 	case "input":
 		return "string", true
@@ -6205,8 +6205,8 @@ func (tc *TypeChecker) checkDirectStdlibCall(funcName string, call *ast.CallExpr
 	// Check std module
 	if tc.hasUsingStdlibModule("std") {
 		stdFuncs := map[string]bool{
-			"println": true, "print": true, "printf": true,
-			"eprintln": true, "eprint": true, "eprintf": true,
+			"println": true, "print": true,
+			"eprintln": true, "eprint": true,
 			"sleep_milliseconds": true, "sleep_seconds": true, "sleep_nanoseconds": true,
 			"read_int": true, "read_float": true, "read_string": true,
 		}
@@ -6570,7 +6570,7 @@ func (tc *TypeChecker) isMapsFunction(name string) bool {
 // isStdFunction checks if a function name exists in the std module
 func (tc *TypeChecker) isStdFunction(name string) bool {
 	stdFuncs := map[string]bool{
-		"println": true, "print": true, "printf": true,
+		"println": true, "print": true,
 	}
 	return stdFuncs[name]
 }
@@ -6995,16 +6995,9 @@ func (tc *TypeChecker) checkStdModuleCall(funcName string, call *ast.CallExpress
 	case "println", "print":
 		// Accept any arguments (variadic, any type)
 		return
-	case "printf":
-		// First argument must be a string (format string)
-		if len(call.Arguments) < 1 {
-			tc.addError(errors.E5008, fmt.Sprintf("std.%s requires at least 1 argument (format string)", funcName), line, column)
-			return
-		}
-		argType, ok := tc.inferExpressionType(call.Arguments[0])
-		if ok && argType != "string" {
-			tc.addError(errors.E3001, fmt.Sprintf("std.%s format argument must be string, got %s", funcName, argType), line, column)
-		}
+	case "eprintln", "eprint":
+		// Accept any arguments (variadic, any type)
+		return
 	}
 }
 

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2730,44 +2730,45 @@ do main() {
 }
 
 // ============================================================================
-// Printf Validation Tests
+// Print Validation Tests
 // ============================================================================
 
-func TestPrintfWithFormatString(t *testing.T) {
+func TestPrintWithFormatString(t *testing.T) {
 	input := `
 do main() {
-	printf("Value: %d", 42)
+	print("Value: %d", 42)
 }
 `
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
 
-func TestPrintfNoArgsError(t *testing.T) {
+func TestPrintNoArgsError(t *testing.T) {
 	input := `
 import @std
 using std
 
 do main() {
-	std.printf()
+	std.print()
 }
 `
 	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E5008)
+	assertNoErrors(t, tc)
 }
 
-func TestPrintfNonStringFormatError(t *testing.T) {
-	input := `
-import @std
-using std
+// this is comment out because print does not support format strings
+// func TestPrintNonStringFormatError(t *testing.T) {
+// 	input := `
+// import @std
+// using std
 
-do main() {
-	std.printf(123, "value")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
+// do main() {
+// 	std.print(123, "value")
+// }
+// `
+// 	tc := typecheck(t, input)
+// 	assertHasError(t, tc, errors.E3001)
+// }
 
 // ============================================================================
 // Comparable Enum Type Tests


### PR DESCRIPTION
## Description

This PR renames `std.printf()` to `std.print()` and `std.eprintf()` to `std.eprint()` for clarity and consistency, addressing issue #994.

## Changes

- `std.printf()` → `std.print()` (stdout without newline)
- `std.eprintf()` → `std.eprint()` (stderr without newline)
- Updated function definitions in `pkg/stdlib/builtins.go`
- Updated typechecker validation in `pkg/typechecker/typechecker.go`
- Updated all tests and integration tests

## Breaking Change

⚠️ **This is a breaking change.** Existing code using `printf()` or `eprintf()` will need to be updated to `print()` and `eprint()`.

## Testing

- ✅ All unit tests pass
- ✅ All integration tests pass
- ✅ Typechecker validation updated correctly

issue #994
closses #994 