### PR TITLE
feat(#996): Rename stdlib functions for consistency

### DIFF
--- a/examples/using_stdlib.ez
+++ b/examples/using_stdlib.ez
@@ -116,10 +116,10 @@ do main() {
 
     temp alice_key string = "alice"
     temp diana_key string = "diana"
-    temp has_alice bool = maps.has(scores, alice_key)
-    temp has_diana bool = maps.has(scores, diana_key)
-    println("maps.has(scores, 'alice') = ${has_alice}")
-    println("maps.has(scores, 'diana') = ${has_diana}")
+    temp has_alice bool = maps.contains(scores, alice_key)
+    temp has_diana bool = maps.contains(scores, diana_key)
+    println("maps.contains(scores, 'alice') = ${has_alice}")
+    println("maps.contains(scores, 'diana') = ${has_diana}")
     println("")
 
     // ==================

--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -99,30 +99,30 @@ do main() {
         failed += 1
     }
 
-    // Test 8: maps.has - key exists
-    temp has_a bool = maps.has(m, "a")
+    // Test 8: maps.contains - key exists
+    temp has_a bool = maps.contains(m, "a")
     if has_a == true {
-        println("  [PASS] maps.has(m, \"a\") = true")
+        println("  [PASS] maps.contains(m, \"a\") = true")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, \"a\"): expected true")
+        println("  [FAIL] maps.contains(m, \"a\"): expected true")
         failed += 1
     }
 
-    // Test 9: maps.has - key doesn't exist
-    temp has_z bool = maps.has(m, "z")
+    // Test 9: maps.contains - key doesn't exist
+    temp has_z bool = maps.contains(m, "z")
     if has_z == false {
-        println("  [PASS] maps.has(m, \"z\") = false")
+        println("  [PASS] maps.contains(m, \"z\") = false")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, \"z\"): expected false")
+        println("  [FAIL] maps.contains(m, \"z\"): expected false")
         failed += 1
     }
 
     // Test 10: maps.delete
     temp del_map map[string:int] = {"x": 10, "y": 20}
     maps.delete(del_map, "x")
-    if len(del_map) == 1 && !maps.has(del_map, "x") {
+    if len(del_map) == 1 && !maps.contains(del_map, "x") {
         println("  [PASS] maps.delete() removed key")
         passed += 1
     } otherwise {

--- a/integration-tests/pass/stdlib/maps.ez
+++ b/integration-tests/pass/stdlib/maps.ez
@@ -38,24 +38,24 @@ do main() {
         failed += 1
     }
 
-    // ==================== maps.has ====================
-    println("  -- maps.has --")
+    // ==================== maps.contains ====================
+    println("  -- maps.contains --")
 
-    // Test 3: has - key exists
-    if maps.has(m, "a") == true {
-        println("  [PASS] maps.has(m, 'a') = true")
+    // Test 3: contains - key exists
+    if maps.contains(m, "a") == true {
+        println("  [PASS] maps.contains(m, 'a') = true")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, 'a'): expected true")
+        println("  [FAIL] maps.contains(m, 'a'): expected true")
         failed += 1
     }
 
-    // Test 4: has - key doesn't exist
-    if maps.has(m, "z") == false {
-        println("  [PASS] maps.has(m, 'z') = false")
+    // Test 4: contains - key doesn't exist
+    if maps.contains(m, "z") == false {
+        println("  [PASS] maps.contains(m, 'z') = false")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, 'z'): expected false")
+        println("  [FAIL] maps.contains(m, 'z'): expected false")
         failed += 1
     }
 
@@ -65,11 +65,11 @@ do main() {
     // Test 5: delete removes key
     temp del_map map[string:int] = {"x": 10, "y": 20, "z": 30}
     maps.delete(del_map, "y")
-    if len(del_map) == 2 && !maps.has(del_map, "y") {
+    if len(del_map) == 2 && !maps.contains(del_map, "y") {
         println("  [PASS] maps.delete() removed key 'y'")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete: len=${len(del_map)}, has_y=${maps.has(del_map, "y")}")
+        println("  [FAIL] maps.delete: len=${len(del_map)}, contains_y=${maps.contains(del_map, "y")}")
         failed += 1
     }
 
@@ -137,8 +137,8 @@ do main() {
     }
 
     // Test 11: maps.has with int key
-    if maps.has(int_map, 1) == true && maps.has(int_map, 99) == false {
-        println("  [PASS] maps.has() works with int keys")
+    if maps.contains(int_map, 1) == true && maps.contains(int_map, 99) == false {
+        println("  [PASS] maps.contains() works with int keys")
         passed += 1
     } otherwise {
         println("  [FAIL] maps.has with int keys")

--- a/integration-tests/pass/stdlib/maps.ez
+++ b/integration-tests/pass/stdlib/maps.ez
@@ -136,12 +136,12 @@ do main() {
         failed += 1
     }
 
-    // Test 11: maps.has with int key
+    // Test 11: maps.contains with int key
     if maps.contains(int_map, 1) == true && maps.contains(int_map, 99) == false {
         println("  [PASS] maps.contains() works with int keys")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has with int keys")
+        println("  [FAIL] maps.contains with int keys")
         failed += 1
     }
 

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -564,14 +564,14 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.last_index_of": {
+	"arrays.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return newError("arrays.last_index_of() takes exactly 2 arguments")
+				return newError("arrays.last_index() takes exactly 2 arguments")
 			}
 			arr, ok := args[0].(*object.Array)
 			if !ok {
-				return &object.Error{Code: "E7002", Message: "arrays.last_index_of() requires an array"}
+				return &object.Error{Code: "E7002", Message: "arrays.last_index() requires an array"}
 			}
 			for i := len(arr.Elements) - 1; i >= 0; i-- {
 				if objectsEqual(arr.Elements[i], args[1]) {

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -27,18 +27,18 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.has": {
+	"maps.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return newError("maps.has() takes exactly 2 arguments (map, key)")
+				return newError("maps.contains() takes exactly 2 arguments (map, key)")
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has() requires a map as first argument"}
+				return &object.Error{Code: "E7007", Message: "maps.contains() requires a map as first argument"}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.has() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12001", Message: "maps.contains() key must be a hashable type (string, int, bool, char)"}
 			}
 			_, exists := m.Get(key)
 			if exists {
@@ -226,14 +226,14 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.has_value": {
+	"maps.contains_value": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return newError("maps.has_value() takes exactly 2 arguments (map, value)")
+				return newError("maps.contains_value() takes exactly 2 arguments (map, value)")
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has_value() requires a map as first argument"}
+				return &object.Error{Code: "E7007", Message: "maps.contains_value() requires a map as first argument"}
 			}
 			searchValue := args[1]
 			for _, pair := range m.Pairs {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5366,7 +5366,7 @@ func (tc *TypeChecker) inferMathCallType(funcName string, args []ast.Expression)
 // inferArraysCallType infers return types for @arrays functions
 func (tc *TypeChecker) inferArraysCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "len", "index_of", "last_index_of":
+	case "len", "index_of", "last_index":
 		return "int", true
 	case "contains", "is_empty":
 		return "bool", true
@@ -5461,7 +5461,7 @@ func (tc *TypeChecker) inferTimeCallType(funcName string, args []ast.Expression)
 // inferMapsCallType infers return types for @maps functions
 func (tc *TypeChecker) inferMapsCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "is_empty", "has", "has_key", "has_value", "equals":
+	case "is_empty", "contains", "has_key", "contains_value", "equals":
 		return "bool", true
 	case "delete", "remove":
 		return "bool", true
@@ -6521,7 +6521,7 @@ func (tc *TypeChecker) isArraysFunction(name string) bool {
 		"sort_desc": true, "shuffle": true, "unique": true, "duplicates": true,
 		"flatten": true, "sum": true, "product": true, "min": true, "max": true,
 		"avg": true, "all_equal": true, "append": true, "unshift": true, "contains": true,
-		"index_of": true, "last_index_of": true, "count": true, "remove": true,
+		"index_of": true, "last_index": true, "count": true, "remove": true,
 		"remove_all": true, "fill": true, "get": true, "remove_at": true, "take": true,
 		"drop": true, "set": true, "insert": true, "slice": true, "join": true,
 		"zip": true, "concat": true, "range": true, "repeat": true,
@@ -6560,8 +6560,8 @@ func (tc *TypeChecker) isTimeFunction(name string) bool {
 func (tc *TypeChecker) isMapsFunction(name string) bool {
 	mapsFuncs := map[string]bool{
 		"len": true, "is_empty": true, "keys": true, "values": true, "clear": true,
-		"to_array": true, "invert": true, "has": true, "has_key": true, "delete": true,
-		"remove": true, "has_value": true, "get": true, "set": true, "get_or_set": true,
+		"to_array": true, "invert": true, "contains": true, "has_key": true, "delete": true,
+		"remove": true, "contains_value": true, "get": true, "set": true, "get_or_set": true,
 		"merge": true, "copy": true,
 	}
 	return mapsFuncs[name]
@@ -7126,7 +7126,7 @@ func (tc *TypeChecker) checkArraysModuleCall(funcName string, call *ast.CallExpr
 		"unshift":       {2, -1, []string{"array", "any"}, "array"},
 		"contains":      {2, 2, []string{"array", "any"}, "bool"},
 		"index_of":      {2, 2, []string{"array", "any"}, "int"},
-		"last_index_of": {2, 2, []string{"array", "any"}, "int"},
+		"last_index": {2, 2, []string{"array", "any"}, "int"},
 		"count":         {2, 2, []string{"array", "any"}, "int"},
 		"remove":        {2, 2, []string{"array", "any"}, "array"},
 		"remove_all":    {2, 2, []string{"array", "any"}, "array"},
@@ -7176,7 +7176,7 @@ func (tc *TypeChecker) checkArrayElementTypeCompatibility(funcName string, call 
 	}
 
 	switch funcName {
-	case "append", "unshift", "contains", "index_of", "last_index_of", "count", "remove", "remove_all", "fill":
+	case "append", "unshift", "contains", "index_of", "last_index", "count", "remove", "remove_all", "fill":
 		// First arg is array, remaining args are elements
 		arrayType, ok := tc.inferExpressionType(call.Arguments[0])
 		if !ok || !tc.isArrayType(arrayType) {
@@ -7260,13 +7260,13 @@ func (tc *TypeChecker) checkMapsModuleCall(funcName string, call *ast.CallExpres
 		"invert":   {1, 1, []string{"map"}, "map"},
 
 		// Map + key
-		"has":     {2, 2, []string{"map", "any"}, "bool"},
+		"contains": {2, 2, []string{"map", "any"}, "bool"},
 		"has_key": {2, 2, []string{"map", "any"}, "bool"},
 		"delete":  {2, 2, []string{"map", "any"}, "bool"},
 		"remove":  {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + value
-		"has_value": {2, 2, []string{"map", "any"}, "bool"},
+		"contains_value": {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + key + optional default
 		"get": {2, 3, []string{"map", "any", "any"}, "any"},
@@ -7314,7 +7314,7 @@ func (tc *TypeChecker) checkMapKeyValueTypeCompatibility(funcName string, call *
 	valueType := tc.extractMapValueType(mapType)
 
 	switch funcName {
-	case "has", "has_key", "delete", "remove":
+	case "contains", "has_key", "delete", "remove":
 		// Second arg is key
 		if len(call.Arguments) < 2 {
 			return
@@ -7331,7 +7331,7 @@ func (tc *TypeChecker) checkMapKeyValueTypeCompatibility(funcName string, call *
 				argLine, argCol)
 		}
 
-	case "has_value":
+	case "contains_value":
 		// Second arg is value
 		if len(call.Arguments) < 2 {
 			return

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1649,7 +1649,7 @@ do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
 	temp map_keys [string] = maps.keys(m)
 	temp map_values [int] = maps.values(m)
-	temp key_exists bool = maps.has(m, "a")
+	temp key_exists bool = maps.contains(m, "a")
 }
 `
 	tc := typecheck(t, input)
@@ -5021,7 +5021,7 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp hasKey bool = maps.has(m, "a")
+	temp hasKey bool = maps.contains(m, "a")
 }
 `
 	tc := typecheck(t, input)
@@ -5590,7 +5590,7 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2, "c": 3}
-	temp hasA bool = maps.has(m, "a")
+	temp hasA bool = maps.contains(m, "a")
 	temp mapLen int = maps.len(m)
 }
 `
@@ -6381,7 +6381,7 @@ using arrays
 
 do main() {
 	temp arr [int] = {1, 2, 3, 2}
-	temp idx int = arrays.last_index_of(arr, 3.14)
+	temp idx int = arrays.last_index(arr, 3.14)
 }
 `
 	tc := typecheck(t, input)
@@ -6554,7 +6554,7 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp found bool = maps.has(m, "a")
+	temp found bool = maps.contains(m, "a")
 }
 `
 	tc := typecheck(t, input)


### PR DESCRIPTION
# PR: Rename stdlib functions for consistency

## Summary
Establish consistent naming patterns across stdlib modules by renaming three functions to match existing conventions.

## Changes
- `arrays.last_index_of` → `arrays.last_index`
- `maps.has` → `maps.contains`
- `maps.has_value` → `maps.contains_value`

## Files Changed
- `pkg/stdlib/arrays.go`
- `pkg/stdlib/maps.go`
- `pkg/typechecker/typechecker.go`
- `examples/using_stdlib.ez`
- `integration-tests/pass/stdlib/maps.ez`
- `integration-tests/pass/core/maps.ez`

## Testing
All unit tests pass. Functions verified working correctly.

## Breaking Change
⚠️ Existing code using old function names requires updates.

## Related Issue
Closes #996