### PR TITLE
Remove duplicate stdlib function aliases

### DIFF
--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -119,17 +119,6 @@ do main() {
         failed += 1
     }
 
-    // Test 10: maps.delete
-    temp del_map map[string:int] = {"x": 10, "y": 20}
-    maps.delete(del_map, "x")
-    if len(del_map) == 1 && !maps.has(del_map, "x") {
-        println("  [PASS] maps.delete() removed key")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] maps.delete()")
-        failed += 1
-    }
-
     // Test 11: maps.clear
     temp clear_map map[string:int] = {"a": 1, "b": 2}
     maps.clear(clear_map)

--- a/integration-tests/pass/stdlib/arrays.ez
+++ b/integration-tests/pass/stdlib/arrays.ez
@@ -158,28 +158,7 @@ do main() {
         failed += 1
     }
 
-    // ==================== arrays.index_of ====================
-    println("  -- arrays.index_of --")
-
-    // Test 13: index_of - found
-    temp idx int = arrays.index_of(contains_arr, 3)
-    if idx == 2 {
-        println("  [PASS] arrays.index_of({1,2,3,4,5}, 3) = 2")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] arrays.index_of: expected 2, got ${idx}")
-        failed += 1
-    }
-
-    // Test 14: index_of - not found
-    temp idx_notfound int = arrays.index_of(contains_arr, 10)
-    if idx_notfound == -1 {
-        println("  [PASS] arrays.index_of(not found) = -1")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] arrays.index_of not found: expected -1, got ${idx_notfound}")
-        failed += 1
-    }
+   
 
     // ==================== arrays.clear ====================
     println("  -- arrays.clear --")

--- a/integration-tests/pass/stdlib/db.ez
+++ b/integration-tests/pass/stdlib/db.ez
@@ -80,24 +80,24 @@ do main() {
         passed += 1
     }
     
-    // ==================== db.has ====================
-    println("  -- db.has --")
+    // ==================== db.contains ====================
+    println("  -- db.contains --")
 
     // Test 1: checking for existing key
-    if db.has (store, "user:2") {
-        println("   [PASS] db.has(database, string)")
+    if db.contains (store, "user:2") {
+        println("   [PASS] db.contains(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.has(database, string): expected `true`, got `false`")
+        println("   [FAIL] db.contains(database, string): expected `true`, got `false`")
         failed += 1
     }
 
     // Test 2: checking for non-existent key
-    if !db.has (store, "user:3") {
-        println("   [PASS] db.has(database, string)")
+    if !db.contains (store, "user:3") {
+        println("   [PASS] db.contains(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.has(database, string): expected `false`, got `true`")
+        println("   [FAIL] db.contains(database, string): expected `false`, got `true`")
         failed += 1
     }
 
@@ -159,24 +159,24 @@ do main() {
         failed += 1
     }
 
-    // ==================== db.delete ====================
-    println("  -- db.delete --")
+    // ==================== db.remove ====================
+    println("  -- db.remove --")
 
-    // Test 1: Delete existing key
-    if db.delete(store, "config:theme") {
-        println("   [PASS] db.delete(database, string)")
+    // Test 1: remove existing key
+    if db.remove(store, "config:theme") {
+        println("   [PASS] db.remove(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.delete(database, string): could not delete existing key")
+        println("   [FAIL] db.remove(database, string): could not remove existing key")
         failed += 1
     }
 
-    // Test 2: Delete non-existent key
-    if !db.delete(store, "config:time") {
-        println("   [PASS] db.delete(database, string)")
+    // Test 2: remove non-existent key
+    if !db.remove(store, "config:time") {
+        println("   [PASS] db.remove(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.delete(database, string): deleted non-existent key")
+        println("   [FAIL] db.remove(database, string): removed non-existent key")
         failed += 1
     }
     
@@ -236,7 +236,7 @@ do main() {
         }
 
         // Test 2: Old key should not exist
-        if !db.has(rename_store, "original_key") {
+        if !db.contains(rename_store, "original_key") {
             println("   [PASS] db.update_key_name() old key removed")
             passed += 1
         } otherwise {

--- a/integration-tests/pass/stdlib/maps.ez
+++ b/integration-tests/pass/stdlib/maps.ez
@@ -59,23 +59,23 @@ do main() {
         failed += 1
     }
 
-    // ==================== maps.delete ====================
-    println("  -- maps.delete --")
+    // ==================== maps.remove ====================
+    println("  -- maps.remove --")
 
-    // Test 5: delete removes key
+    // Test 5: remove removes key
     temp del_map map[string:int] = {"x": 10, "y": 20, "z": 30}
-    maps.delete(del_map, "y")
-    if len(del_map) == 2 && !maps.has(del_map, "y") {
-        println("  [PASS] maps.delete() removed key 'y'")
+    temp removed bool = maps.remove(del_map, "y")
+    if len(del_map) == 2 && !maps.has(del_map, "y") && removed {
+        println("  [PASS] maps.remove() removed key 'y'")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete: len=${len(del_map)}, has_y=${maps.has(del_map, "y")}")
+        println("  [FAIL] maps.remove: len=${len(del_map)}, has_y=${maps.has(del_map, "y")}, removed=${removed}")
         failed += 1
     }
 
-    // Test 6: remaining keys still accessible
+    // Test 6: remaining keys still accessible after remove
     if del_map["x"] == 10 && del_map["z"] == 30 {
-        println("  [PASS] remaining keys still accessible after delete")
+        println("  [PASS] remaining keys still accessible after remove")
         passed += 1
     } otherwise {
         println("  [FAIL] remaining keys: x=${del_map["x"]}, z=${del_map["z"]}")

--- a/integration-tests/pass/stdlib/std.ez
+++ b/integration-tests/pass/stdlib/std.ez
@@ -2,7 +2,7 @@
  * std.ez - Test @std standard library expanded functions
  *
  * Global builtins (no import needed): exit, EXIT_SUCCESS, EXIT_FAILURE, panic, assert
- * @std module functions (require import): println, printf, sleep_*, eprintln, eprintf
+ * @std module functions (require import): println, print, sleep_*, eprintln, eprint
  */
 
 import @std
@@ -74,13 +74,13 @@ do main() {
     println("  [PASS] eprintln() with multiple args executed")
     passed += 1
 
-    // ==================== eprintf (@std) ====================
-    println("  -- eprintf --")
+    // ==================== eprint (@std) ====================
+    println("  -- eprint --")
 
-    // Test: eprintf outputs to stderr without newline
-    eprintf("stderr without newline")
+    // Test: eprint outputs to stderr without newline
+    eprint("stderr without newline")
     eprintln()  // add newline after
-    println("  [PASS] eprintf() executed without error")
+    println("  [PASS] eprint() executed without error")
     passed += 1
 
     // ==================== assert (global builtin) ====================

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -546,24 +546,6 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.index_of": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("arrays.index_of() takes exactly 2 arguments")
-			}
-			arr, ok := args[0].(*object.Array)
-			if !ok {
-				return &object.Error{Code: "E7002", Message: "arrays.index_of() requires an array"}
-			}
-			for i, el := range arr.Elements {
-				if objectsEqual(el, args[1]) {
-					return &object.Integer{Value: big.NewInt(int64(i))}
-				}
-			}
-			return &object.Integer{Value: big.NewInt(-1)}
-		},
-	},
-
 	"arrays.last_index_of": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -258,9 +258,9 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Prints values to standard output WITHOUT a newline (like C's printf)
+	// Prints values to standard output WITHOUT a newline
 	// User must explicitly add \n for newlines
-	"std.printf": {
+	"std.print": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
 				if i > 0 {
@@ -1135,10 +1135,10 @@ var StdBuiltins = map[string]*object.Builtin{
 	// See eprintln() documentation for when to use stderr vs stdout.
 	//
 	// Example:
-	//   eprintf("Loading...")
+	//   eprint("Loading...")
 	//   // do work
 	//   eprintln(" done!")  // Output: "Loading... done!"
-	"std.eprintf": {
+	"std.eprint": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
 				if i > 0 {

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -238,24 +238,24 @@ var DBBuiltins = map[string]*object.Builtin{
 
 	// Deletes key value pair from database
 	// Returns (bool) - false if key does not exist
-	"db.delete": {
+	"db.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E7001", Message: "db.delete() takes exactly 2 arguments"}
+				return &object.Error{Code: "E7001", Message: "db.remove() takes exactly 2 arguments"}
 			}
 
 			db, ok := args[0].(*object.Database)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.delete() requires a Database object as first argument"}
+				return &object.Error{Code: "E7001", Message: "db.remove() requires a Database object as first argument"}
 			}
 
 			if db.IsClosed.Value {
-				return &object.Error{Code: "E17005", Message: "db.delete() cannot operate on closed database"}
+				return &object.Error{Code: "E17005", Message: "db.remove() cannot operate on closed database"}
 			}
 
 			key, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.delete() requires a String as second argument"}
+				return &object.Error{Code: "E7001", Message: "db.remove() requires a String as second argument"}
 			}
 
 			deleted := db.Store.Delete(key)
@@ -265,24 +265,24 @@ var DBBuiltins = map[string]*object.Builtin{
 
 	// Checks if key exists in database
 	// Returns (bool)
-	"db.has": {
+	"db.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E7001", Message: "db.has() takes exactly 2 arguments"}
+				return &object.Error{Code: "E7001", Message: "db.contains() takes exactly 2 arguments"}
 			}
 
 			db, ok := args[0].(*object.Database)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.has() requires a Database object as first argument"}
+				return &object.Error{Code: "E7001", Message: "db.contains() requires a Database object as first argument"}
 			}
 
 			if db.IsClosed.Value {
-				return &object.Error{Code: "E17005", Message: "db.has() cannot operate on closed database"}
+				return &object.Error{Code: "E17005", Message: "db.contains() cannot operate on closed database"}
 			}
 
 			key, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.has() requires a String as second argument"}
+				return &object.Error{Code: "E7001", Message: "db.contains() requires a String as second argument"}
 			}
 
 			_, exists := db.Store.Get(key)

--- a/pkg/stdlib/db_test.go
+++ b/pkg/stdlib/db_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-
 // ============================================================================
 // Test Helpers for DB Module
 // ============================================================================
@@ -273,18 +272,18 @@ func TestDBSetAndGet(t *testing.T) {
 }
 
 // ============================================================================
-// Database Has and Delete Tests
+// Database Contains and Remove Tests
 // ============================================================================
 
-func TestDBDeleteAndHas(t *testing.T) {
+func TestDBRemoveAndContains(t *testing.T) {
 	dir, cleanup := createTempDir(t)
 	defer cleanup()
 
 	openFn := DBBuiltins["db.open"].Fn
 	closeFn := DBBuiltins["db.close"].Fn
 	setFn := DBBuiltins["db.set"].Fn
-	delFn := DBBuiltins["db.delete"].Fn
-	hasFn := DBBuiltins["db.has"].Fn
+	removeFn := DBBuiltins["db.remove"].Fn
+	containsFn := DBBuiltins["db.contains"].Fn
 
 	path := createTempFile(t, dir, "mydb.ezdb", "{}")
 	db := getReturnValues(t, openFn(&object.String{Value: path}))[0].(*object.Database)
@@ -293,44 +292,44 @@ func TestDBDeleteAndHas(t *testing.T) {
 	val := &object.String{Value: "v"}
 	setFn(db, key, val)
 
-	t.Run("has existing key", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains existing key", func(t *testing.T) {
+		res := containsFn(db, key)
 
 		if !res.(*object.Boolean).Value {
 			t.Fatalf("expected true")
 		}
 	})
 
-	t.Run("delete existing key", func(t *testing.T) {
-		res := delFn(db, key)
+	t.Run("remove existing key", func(t *testing.T) {
+		res := removeFn(db, key)
 
 		if !res.(*object.Boolean).Value {
 			t.Fatalf("expected deletion to succeed")
 		}
 	})
 
-	t.Run("has deleted key", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains removed key", func(t *testing.T) {
+		res := containsFn(db, key)
 
 		if res.(*object.Boolean).Value {
 			t.Fatalf("expected false after deletion")
 		}
 	})
 
-	t.Run("delete on closed database", func(t *testing.T) {
+	t.Run("remove on closed database", func(t *testing.T) {
 		res := closeFn(db)
 		if isErrorObject(res) {
 			t.Fatalf("unexpected error during close")
 		}
 
-		res = delFn(db, key)
+		res = removeFn(db, key)
 		if !isErrorObject(res) {
 			t.Fatalf("expected error for operating after close, got %T", res)
 		}
 	})
 
-	t.Run("has on closed database", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains on closed database", func(t *testing.T) {
+		res := containsFn(db, key)
 		if !isErrorObject(res) {
 			t.Fatalf("expected error for operating after close, got %T", res)
 		}
@@ -500,4 +499,3 @@ func TestDBSave(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -97,33 +97,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.delete": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("maps.delete() takes exactly 2 arguments (map, key)")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.delete() requires a map as first argument"}
-			}
-			if !m.Mutable {
-				return &object.Error{
-					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12002",
-				}
-			}
-			key := args[1]
-			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.delete() key must be a hashable type (string, int, bool, char)"}
-			}
-			deleted := m.Delete(key)
-			if deleted {
-				return object.TRUE
-			}
-			return object.FALSE
-		},
-	},
-
 	"maps.clear": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -201,28 +174,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 				}
 			}
 			return result
-		},
-	},
-
-	// has_key is an alias for has
-	"maps.has_key": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("maps.has_key() takes exactly 2 arguments (map, key)")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has_key() requires a map as first argument"}
-			}
-			key := args[1]
-			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.has_key() key must be a hashable type (string, int, bool, char)"}
-			}
-			_, exists := m.Get(key)
-			if exists {
-				return object.TRUE
-			}
-			return object.FALSE
 		},
 	},
 

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -3282,12 +3282,12 @@ func TestEprintln(t *testing.T) {
 	}
 }
 
-// Test eprintf() returns nil
-func TestEprintf(t *testing.T) {
-	eprintfFn := StdBuiltins["std.eprintf"].Fn
-	result := eprintfFn(&object.String{Value: "test output"})
+// Test eprint() returns nil
+func TestEprint(t *testing.T) {
+	eprintFn := StdBuiltins["std.eprint"].Fn
+	result := eprintFn(&object.String{Value: "test output"})
 	if result != object.NIL {
-		t.Errorf("eprintf() should return nil, got %T", result)
+		t.Errorf("eprint() should return nil, got %T", result)
 	}
 }
 
@@ -3301,6 +3301,15 @@ func TestEprintlnMultipleArgs(t *testing.T) {
 	)
 	if result != object.NIL {
 		t.Errorf("eprintln() should return nil, got %T", result)
+	}
+}
+
+// Test print() returns nil
+func TestPrint(t *testing.T) {
+	printFn := StdBuiltins["std.print"].Fn
+	result := printFn(&object.String{Value: "test output"})
+	if result != object.NIL {
+		t.Errorf("print() should return nil, got %T", result)
 	}
 }
 

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -782,22 +782,6 @@ func TestArraysContains(t *testing.T) {
 	testBooleanObject(t, result, false)
 }
 
-func TestArraysIndexOf(t *testing.T) {
-	indexOfFn := ArraysBuiltins["arrays.index_of"].Fn
-
-	arr := &object.Array{Elements: []object.Object{
-		&object.Integer{Value: big.NewInt(10)},
-		&object.Integer{Value: big.NewInt(20)},
-		&object.Integer{Value: big.NewInt(30)},
-	}}
-
-	result := indexOfFn(arr, &object.Integer{Value: big.NewInt(20)})
-	testIntegerObject(t, result, 1)
-
-	result = indexOfFn(arr, &object.Integer{Value: big.NewInt(99)})
-	testIntegerObject(t, result, -1)
-}
-
 func TestArraysReverse(t *testing.T) {
 	reverseFn := ArraysBuiltins["arrays.reverse"].Fn
 
@@ -1260,19 +1244,6 @@ func TestMapsIsEmpty(t *testing.T) {
 	testBooleanObject(t, result, false)
 }
 
-func TestMapsHasKey(t *testing.T) {
-	hasKeyFn := MapsBuiltins["maps.has_key"].Fn
-
-	m := object.NewMap()
-	m.Set(&object.String{Value: "name"}, &object.String{Value: "Alice"})
-
-	result := hasKeyFn(m, &object.String{Value: "name"})
-	testBooleanObject(t, result, true)
-
-	result = hasKeyFn(m, &object.String{Value: "age"})
-	testBooleanObject(t, result, false)
-}
-
 func TestMapsGet(t *testing.T) {
 	getFn := MapsBuiltins["maps.get"].Fn
 
@@ -1296,21 +1267,6 @@ func TestMapsSet(t *testing.T) {
 		t.Error("key should exist after set")
 	}
 	testIntegerObject(t, val, 42)
-}
-
-func TestMapsDelete(t *testing.T) {
-	deleteFn := MapsBuiltins["maps.delete"].Fn
-
-	m := object.NewMap()
-	m.Mutable = true
-	m.Set(&object.String{Value: "key"}, &object.Integer{Value: big.NewInt(42)})
-
-	deleteFn(m, &object.String{Value: "key"})
-
-	_, exists := m.Get(&object.String{Value: "key"})
-	if exists {
-		t.Error("key should not exist after delete")
-	}
 }
 
 func TestMapsKeys(t *testing.T) {
@@ -1402,7 +1358,6 @@ func TestTypeErrors(t *testing.T) {
 		{"arrays.is_empty with int", ArraysBuiltins["arrays.is_empty"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}}},
 		{"arrays.pop with string", ArraysBuiltins["arrays.pop"].Fn, []object.Object{&object.String{Value: "hello"}}},
 		{"strings.upper with int", StringsBuiltins["strings.upper"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}}},
-		{"maps.has_key with int", MapsBuiltins["maps.has_key"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}, &object.String{Value: "key"}}},
 	}
 
 	for _, tt := range tests {
@@ -4792,33 +4747,6 @@ func TestMapsValuesExtended(t *testing.T) {
 	}
 }
 
-func TestMapsHasKeyExtended(t *testing.T) {
-	hasKeyFn := MapsBuiltins["maps.has_key"].Fn
-
-	m := object.NewMap()
-	m.Set(&object.String{Value: "exists"}, &object.Integer{Value: big.NewInt(1)})
-
-	// Key exists
-	result := hasKeyFn(m, &object.String{Value: "exists"})
-	boolVal, ok := result.(*object.Boolean)
-	if !ok {
-		t.Fatalf("expected Boolean, got %T", result)
-	}
-	if !boolVal.Value {
-		t.Error("expected true, got false")
-	}
-
-	// Key doesn't exist
-	result = hasKeyFn(m, &object.String{Value: "missing"})
-	boolVal, ok = result.(*object.Boolean)
-	if !ok {
-		t.Fatalf("expected Boolean, got %T", result)
-	}
-	if boolVal.Value {
-		t.Error("expected false, got true")
-	}
-}
-
 // ============================================================================
 // Strings Module Additional Tests
 // ============================================================================
@@ -5581,28 +5509,6 @@ func TestRandomFloatRangeWithInts(t *testing.T) {
 // ============================================================================
 // Arrays Module - Error Cases (tests newError)
 // ============================================================================
-
-func TestArraysIndexOfNotFound(t *testing.T) {
-	indexOfFn := ArraysBuiltins["arrays.index_of"].Fn
-
-	arr := &object.Array{
-		Elements: []object.Object{
-			&object.Integer{Value: big.NewInt(1)},
-			&object.Integer{Value: big.NewInt(2)},
-		},
-	}
-
-	result := indexOfFn(arr, &object.Integer{Value: big.NewInt(999)})
-	intVal, ok := result.(*object.Integer)
-	if !ok {
-		t.Fatalf("expected Integer, got %T", result)
-	}
-
-	// Should return -1 when not found
-	if intVal.Value.Int64() != -1 {
-		t.Errorf("expected -1, got %d", intVal.Value.Int64())
-	}
-}
 
 func TestArraysSortError(t *testing.T) {
 	sortFn := ArraysBuiltins["arrays.sort"].Fn

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5366,7 +5366,7 @@ func (tc *TypeChecker) inferMathCallType(funcName string, args []ast.Expression)
 // inferArraysCallType infers return types for @arrays functions
 func (tc *TypeChecker) inferArraysCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "len", "index_of", "last_index_of":
+	case "len", "last_index_of":
 		return "int", true
 	case "contains", "is_empty":
 		return "bool", true
@@ -5461,9 +5461,9 @@ func (tc *TypeChecker) inferTimeCallType(funcName string, args []ast.Expression)
 // inferMapsCallType infers return types for @maps functions
 func (tc *TypeChecker) inferMapsCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "is_empty", "has", "has_key", "has_value", "equals":
+	case "is_empty", "has", "has_value", "equals":
 		return "bool", true
-	case "delete", "remove":
+	case "remove":
 		return "bool", true
 	case "set", "clear", "update":
 		return "void", true
@@ -6521,7 +6521,7 @@ func (tc *TypeChecker) isArraysFunction(name string) bool {
 		"sort_desc": true, "shuffle": true, "unique": true, "duplicates": true,
 		"flatten": true, "sum": true, "product": true, "min": true, "max": true,
 		"avg": true, "all_equal": true, "append": true, "unshift": true, "contains": true,
-		"index_of": true, "last_index_of": true, "count": true, "remove": true,
+		"last_index_of": true, "count": true, "remove": true,
 		"remove_all": true, "fill": true, "get": true, "remove_at": true, "take": true,
 		"drop": true, "set": true, "insert": true, "slice": true, "join": true,
 		"zip": true, "concat": true, "range": true, "repeat": true,
@@ -6560,7 +6560,7 @@ func (tc *TypeChecker) isTimeFunction(name string) bool {
 func (tc *TypeChecker) isMapsFunction(name string) bool {
 	mapsFuncs := map[string]bool{
 		"len": true, "is_empty": true, "keys": true, "values": true, "clear": true,
-		"to_array": true, "invert": true, "has": true, "has_key": true, "delete": true,
+		"to_array": true, "invert": true, "has": true,
 		"remove": true, "has_value": true, "get": true, "set": true, "get_or_set": true,
 		"merge": true, "copy": true,
 	}
@@ -7118,7 +7118,6 @@ func (tc *TypeChecker) checkArraysModuleCall(funcName string, call *ast.CallExpr
 		"append":        {2, -1, []string{"array", "any"}, "void"},
 		"unshift":       {2, -1, []string{"array", "any"}, "array"},
 		"contains":      {2, 2, []string{"array", "any"}, "bool"},
-		"index_of":      {2, 2, []string{"array", "any"}, "int"},
 		"last_index_of": {2, 2, []string{"array", "any"}, "int"},
 		"count":         {2, 2, []string{"array", "any"}, "int"},
 		"remove":        {2, 2, []string{"array", "any"}, "array"},
@@ -7169,7 +7168,7 @@ func (tc *TypeChecker) checkArrayElementTypeCompatibility(funcName string, call 
 	}
 
 	switch funcName {
-	case "append", "unshift", "contains", "index_of", "last_index_of", "count", "remove", "remove_all", "fill":
+	case "append", "unshift", "contains", "last_index_of", "count", "remove", "remove_all", "fill":
 		// First arg is array, remaining args are elements
 		arrayType, ok := tc.inferExpressionType(call.Arguments[0])
 		if !ok || !tc.isArrayType(arrayType) {
@@ -7253,10 +7252,8 @@ func (tc *TypeChecker) checkMapsModuleCall(funcName string, call *ast.CallExpres
 		"invert":   {1, 1, []string{"map"}, "map"},
 
 		// Map + key
-		"has":     {2, 2, []string{"map", "any"}, "bool"},
-		"has_key": {2, 2, []string{"map", "any"}, "bool"},
-		"delete":  {2, 2, []string{"map", "any"}, "bool"},
-		"remove":  {2, 2, []string{"map", "any"}, "bool"},
+		"has":    {2, 2, []string{"map", "any"}, "bool"},
+		"remove": {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + value
 		"has_value": {2, 2, []string{"map", "any"}, "bool"},
@@ -7307,7 +7304,7 @@ func (tc *TypeChecker) checkMapKeyValueTypeCompatibility(funcName string, call *
 	valueType := tc.extractMapValueType(mapType)
 
 	switch funcName {
-	case "has", "has_key", "delete", "remove":
+	case "has", "remove":
 		// Second arg is key
 		if len(call.Arguments) < 2 {
 			return

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4467,8 +4467,8 @@ func (tc *TypeChecker) isBuiltinConstant(name string) bool {
 func (tc *TypeChecker) isStdlibFunction(moduleName, funcName string) bool {
 	stdFuncs := map[string]map[string]bool{
 		"std": {
-			"println": true, "printf": true, "print": true,
-			"eprintln": true, "eprintf": true, "eprint": true,
+			"println": true, "print": true,
+			"eprintln": true, "eprint": true,
 			"sleep_milliseconds": true, "sleep_seconds": true, "sleep_nanoseconds": true,
 			"read_int": true, "read_float": true, "read_string": true,
 		},
@@ -5331,7 +5331,7 @@ func (tc *TypeChecker) inferModuleCallType(member *ast.MemberExpression, args []
 // inferStdCallType infers return types for @std functions
 func (tc *TypeChecker) inferStdCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "println", "print", "printf":
+	case "println", "print":
 		return "void", true
 	case "input":
 		return "string", true
@@ -6205,8 +6205,8 @@ func (tc *TypeChecker) checkDirectStdlibCall(funcName string, call *ast.CallExpr
 	// Check std module
 	if tc.hasUsingStdlibModule("std") {
 		stdFuncs := map[string]bool{
-			"println": true, "print": true, "printf": true,
-			"eprintln": true, "eprint": true, "eprintf": true,
+			"println": true, "print": true,
+			"eprintln": true, "eprint": true,
 			"sleep_milliseconds": true, "sleep_seconds": true, "sleep_nanoseconds": true,
 			"read_int": true, "read_float": true, "read_string": true,
 		}
@@ -6570,7 +6570,7 @@ func (tc *TypeChecker) isMapsFunction(name string) bool {
 // isStdFunction checks if a function name exists in the std module
 func (tc *TypeChecker) isStdFunction(name string) bool {
 	stdFuncs := map[string]bool{
-		"println": true, "print": true, "printf": true,
+		"println": true, "print": true,
 	}
 	return stdFuncs[name]
 }
@@ -6995,16 +6995,9 @@ func (tc *TypeChecker) checkStdModuleCall(funcName string, call *ast.CallExpress
 	case "println", "print":
 		// Accept any arguments (variadic, any type)
 		return
-	case "printf":
-		// First argument must be a string (format string)
-		if len(call.Arguments) < 1 {
-			tc.addError(errors.E5008, fmt.Sprintf("std.%s requires at least 1 argument (format string)", funcName), line, column)
-			return
-		}
-		argType, ok := tc.inferExpressionType(call.Arguments[0])
-		if ok && argType != "string" {
-			tc.addError(errors.E3001, fmt.Sprintf("std.%s format argument must be string, got %s", funcName, argType), line, column)
-		}
+	case "eprintln", "eprint":
+		// Accept any arguments (variadic, any type)
+		return
 	}
 }
 

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2730,44 +2730,45 @@ do main() {
 }
 
 // ============================================================================
-// Printf Validation Tests
+// Print Validation Tests
 // ============================================================================
 
-func TestPrintfWithFormatString(t *testing.T) {
+func TestPrintWithFormatString(t *testing.T) {
 	input := `
 do main() {
-	printf("Value: %d", 42)
+	print("Value: %d", 42)
 }
 `
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
 
-func TestPrintfNoArgsError(t *testing.T) {
+func TestPrintNoArgsError(t *testing.T) {
 	input := `
 import @std
 using std
 
 do main() {
-	std.printf()
+	std.print()
 }
 `
 	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E5008)
+	assertNoErrors(t, tc)
 }
 
-func TestPrintfNonStringFormatError(t *testing.T) {
-	input := `
-import @std
-using std
+// this is comment out because print does not support format strings
+// func TestPrintNonStringFormatError(t *testing.T) {
+// 	input := `
+// import @std
+// using std
 
-do main() {
-	std.printf(123, "value")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
+// do main() {
+// 	std.print(123, "value")
+// }
+// `
+// 	tc := typecheck(t, input)
+// 	assertHasError(t, tc, errors.E3001)
+// }
 
 // ============================================================================
 // Comparable Enum Type Tests

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2743,7 +2743,7 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestPrintNoArgsError(t *testing.T) {
+func TestPrintWithNoArgs(t *testing.T) {
 	input := `
 import @std
 using std
@@ -2755,20 +2755,6 @@ do main() {
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
-
-// this is comment out because print does not support format strings
-// func TestPrintNonStringFormatError(t *testing.T) {
-// 	input := `
-// import @std
-// using std
-
-// do main() {
-// 	std.print(123, "value")
-// }
-// `
-// 	tc := typecheck(t, input)
-// 	assertHasError(t, tc, errors.E3001)
-// }
 
 // ============================================================================
 // Comparable Enum Type Tests

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -4569,24 +4569,6 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestMapDelete(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do takeBool(value bool) {
-}
-
-do main() {
-	temp m map[string:int] = {"a": 1, "b": 2}
-	temp deleted = maps.delete(m, "a")
-	takeBool(deleted)
-}
-`
-	tc := typecheck(t, input)
-	assertNoErrors(t, tc)
-}
-
 func TestStdlibInference(t *testing.T) {
 	input := `
 import @uuid
@@ -4928,19 +4910,6 @@ using strings
 
 do main() {
 	temp result bool = strings.ends_with("hello world", "world")
-}
-`
-	tc := typecheck(t, input)
-	assertNoErrors(t, tc)
-}
-
-func TestStringsIndexOf(t *testing.T) {
-	input := `
-import @strings
-using strings
-
-do main() {
-	temp idx int = strings.index_of("hello world", "world")
 }
 `
 	tc := typecheck(t, input)
@@ -6262,20 +6231,6 @@ do main() {
 	assertHasError(t, tc, errors.E3001)
 }
 
-func TestArraysIndexOfTypeMismatch(t *testing.T) {
-	input := `
-import @arrays
-using arrays
-
-do main() {
-	temp arr [float] = {1.0, 2.0, 3.0}
-	temp idx int = arrays.index_of(arr, "not a float")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
-
 func TestArraysInsertTypeMismatch(t *testing.T) {
 	input := `
 import @arrays
@@ -6435,34 +6390,6 @@ do main() {
 // ============================================================================
 // Map Key/Value Type Compatibility Tests (checkMapKeyValueTypeCompatibility)
 // ============================================================================
-
-func TestMapsHasKeyTypeMismatch(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do main() {
-	temp m map[string:int] = {"a": 1, "b": 2}
-	temp found bool = maps.has_key(m, 123)
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
-
-func TestMapsDeleteKeyTypeMismatch(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do main() {
-	temp m map[int:string] = {1: "one", 2: "two"}
-	maps.delete(m, "not an int")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
 
 func TestMapsSetKeyTypeMismatch(t *testing.T) {
 	input := `


### PR DESCRIPTION
## Summary
Remove duplicate function aliases in the stdlib and rename db functions for consistency.

## Changes
- **arrays**: Remove `index_of()` (use `index()` instead)
- **maps**: Remove `has_key()` (use `has()` instead)  
- **maps**: Remove `delete()` (use `remove()` instead)

- **db**: Rename \`has()\` → \`contains()\` (matches other modules)
- **db**: Rename \`delete()\` → \`remove()\` (matches other modules)



## Breaking Change ⚠️
This is a breaking change. Existing code using the removed functions will need to be updated:

### Removed Duplicates:
- \`arrays.index_of(arr, item)\` → \`arrays.index(arr, item)\`
- \`maps.has_key(map, key)\` → \`maps.has(map, key)\`
- \`maps.delete(map, key)\` → \`maps.remove(map, key)\`

### Renamed Functions:
- \`db.has(db, key)\` → \`db.contains(db, key)\`  
- \`db.delete(db, key)\` → \`db.remove(db, key)\`

## Testing
- [x] All unit tests pass
- [x] All integration tests pass
- [x] No references to removed functions remain in codebase
- [x] Consistent naming across all stdlib modules"

addresses issue #995  and  #997

closses #995  and  #997