### PR TITLE
refactor: remove duplicate stdlib aliases and rename db functions

### DIFF
--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -119,14 +119,14 @@ do main() {
         failed += 1
     }
 
-    // Test 10: maps.delete
+    // Test 10: maps.remove
     temp del_map map[string:int] = {"x": 10, "y": 20}
-    maps.delete(del_map, "x")
+    maps.remove(del_map, "x")
     if len(del_map) == 1 && !maps.contains(del_map, "x") {
-        println("  [PASS] maps.delete() removed key")
+        println("  [PASS] maps.remove() removed key")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete()")
+        println("  [FAIL] maps.remove()")
         failed += 1
     }
 

--- a/integration-tests/pass/stdlib/arrays.ez
+++ b/integration-tests/pass/stdlib/arrays.ez
@@ -158,29 +158,6 @@ do main() {
         failed += 1
     }
 
-    // ==================== arrays.index_of ====================
-    println("  -- arrays.index_of --")
-
-    // Test 13: index_of - found
-    temp idx int = arrays.index_of(contains_arr, 3)
-    if idx == 2 {
-        println("  [PASS] arrays.index_of({1,2,3,4,5}, 3) = 2")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] arrays.index_of: expected 2, got ${idx}")
-        failed += 1
-    }
-
-    // Test 14: index_of - not found
-    temp idx_notfound int = arrays.index_of(contains_arr, 10)
-    if idx_notfound == -1 {
-        println("  [PASS] arrays.index_of(not found) = -1")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] arrays.index_of not found: expected -1, got ${idx_notfound}")
-        failed += 1
-    }
-
     // ==================== arrays.clear ====================
     println("  -- arrays.clear --")
 

--- a/integration-tests/pass/stdlib/db.ez
+++ b/integration-tests/pass/stdlib/db.ez
@@ -80,24 +80,24 @@ do main() {
         passed += 1
     }
     
-    // ==================== db.has ====================
-    println("  -- db.has --")
+    // ==================== db.contains ====================
+    println("  -- db.contains --")
 
     // Test 1: checking for existing key
-    if db.has (store, "user:2") {
-        println("   [PASS] db.has(database, string)")
+    if db.contains (store, "user:2") {
+        println("   [PASS] db.contains(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.has(database, string): expected `true`, got `false`")
+        println("   [FAIL] db.contains(database, string): expected `true`, got `false`")
         failed += 1
     }
 
     // Test 2: checking for non-existent key
-    if !db.has (store, "user:3") {
-        println("   [PASS] db.has(database, string)")
+    if !db.contains (store, "user:3") {
+        println("   [PASS] db.contains(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.has(database, string): expected `false`, got `true`")
+        println("   [FAIL] db.contains(database, string): expected `false`, got `true`")
         failed += 1
     }
 
@@ -159,24 +159,24 @@ do main() {
         failed += 1
     }
 
-    // ==================== db.delete ====================
-    println("  -- db.delete --")
+    // ==================== db.remove ====================
+    println("  -- db.remove --")
 
-    // Test 1: Delete existing key
-    if db.delete(store, "config:theme") {
-        println("   [PASS] db.delete(database, string)")
+    // Test 1: remove existing key
+    if db.remove(store, "config:theme") {
+        println("   [PASS] db.remove(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.delete(database, string): could not delete existing key")
+        println("   [FAIL] db.remove(database, string): could not remove existing key")
         failed += 1
     }
 
-    // Test 2: Delete non-existent key
-    if !db.delete(store, "config:time") {
-        println("   [PASS] db.delete(database, string)")
+    // Test 2: remove non-existent key
+    if !db.remove(store, "config:time") {
+        println("   [PASS] db.remove(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.delete(database, string): deleted non-existent key")
+        println("   [FAIL] db.remove(database, string): removed non-existent key")
         failed += 1
     }
     
@@ -236,7 +236,7 @@ do main() {
         }
 
         // Test 2: Old key should not exist
-        if !db.has(rename_store, "original_key") {
+        if !db.contains(rename_store, "original_key") {
             println("   [PASS] db.update_key_name() old key removed")
             passed += 1
         } otherwise {

--- a/integration-tests/pass/stdlib/maps.ez
+++ b/integration-tests/pass/stdlib/maps.ez
@@ -59,23 +59,23 @@ do main() {
         failed += 1
     }
 
-    // ==================== maps.delete ====================
-    println("  -- maps.delete --")
+    // ==================== maps.remove ====================
+    println("  -- maps.remove --")
 
-    // Test 5: delete removes key
+    // Test 5: remove removes key
     temp del_map map[string:int] = {"x": 10, "y": 20, "z": 30}
-    maps.delete(del_map, "y")
-    if len(del_map) == 2 && !maps.contains(del_map, "y") {
-        println("  [PASS] maps.delete() removed key 'y'")
+    temp removed bool = maps.remove(del_map, "y")
+    if len(del_map) == 2 && !maps.contains(del_map, "y") && removed {
+        println("  [PASS] maps.remove() removed key 'y'")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete: len=${len(del_map)}, contains_y=${maps.contains(del_map, "y")}")
+        println("  [FAIL] maps.remove: len=${len(del_map)}, contains_y=${maps.contains(del_map, "y")}, removed=${removed}")
         failed += 1
     }
 
-    // Test 6: remaining keys still accessible
+    // Test 6: remaining keys still accessible after remove
     if del_map["x"] == 10 && del_map["z"] == 30 {
-        println("  [PASS] remaining keys still accessible after delete")
+        println("  [PASS] remaining keys still accessible after remove")
         passed += 1
     } otherwise {
         println("  [FAIL] remaining keys: x=${del_map["x"]}, z=${del_map["z"]}")

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -546,24 +546,6 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.index_of": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("arrays.index_of() takes exactly 2 arguments")
-			}
-			arr, ok := args[0].(*object.Array)
-			if !ok {
-				return &object.Error{Code: "E7002", Message: "arrays.index_of() requires an array"}
-			}
-			for i, el := range arr.Elements {
-				if objectsEqual(el, args[1]) {
-					return &object.Integer{Value: big.NewInt(int64(i))}
-				}
-			}
-			return &object.Integer{Value: big.NewInt(-1)}
-		},
-	},
-
 	"arrays.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -236,26 +236,26 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Deletes key value pair from database
+	// Removes key value pair from database
 	// Returns (bool) - false if key does not exist
-	"db.delete": {
+	"db.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E7001", Message: "db.delete() takes exactly 2 arguments"}
+				return &object.Error{Code: "E7001", Message: "db.remove() takes exactly 2 arguments"}
 			}
 
 			db, ok := args[0].(*object.Database)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.delete() requires a Database object as first argument"}
+				return &object.Error{Code: "E7001", Message: "db.remove() requires a Database object as first argument"}
 			}
 
 			if db.IsClosed.Value {
-				return &object.Error{Code: "E17005", Message: "db.delete() cannot operate on closed database"}
+				return &object.Error{Code: "E17005", Message: "db.remove() cannot operate on closed database"}
 			}
 
 			key, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.delete() requires a String as second argument"}
+				return &object.Error{Code: "E7001", Message: "db.remove() requires a String as second argument"}
 			}
 
 			deleted := db.Store.Delete(key)
@@ -265,24 +265,24 @@ var DBBuiltins = map[string]*object.Builtin{
 
 	// Checks if key exists in database
 	// Returns (bool)
-	"db.has": {
+	"db.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E7001", Message: "db.has() takes exactly 2 arguments"}
+				return &object.Error{Code: "E7001", Message: "db.contains() takes exactly 2 arguments"}
 			}
 
 			db, ok := args[0].(*object.Database)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.has() requires a Database object as first argument"}
+				return &object.Error{Code: "E7001", Message: "db.contains() requires a Database object as first argument"}
 			}
 
 			if db.IsClosed.Value {
-				return &object.Error{Code: "E17005", Message: "db.has() cannot operate on closed database"}
+				return &object.Error{Code: "E17005", Message: "db.contains() cannot operate on closed database"}
 			}
 
 			key, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.has() requires a String as second argument"}
+				return &object.Error{Code: "E7001", Message: "db.contains() requires a String as second argument"}
 			}
 
 			_, exists := db.Store.Get(key)

--- a/pkg/stdlib/db_test.go
+++ b/pkg/stdlib/db_test.go
@@ -273,18 +273,18 @@ func TestDBSetAndGet(t *testing.T) {
 }
 
 // ============================================================================
-// Database Has and Delete Tests
+// Database Contains and Remove Tests
 // ============================================================================
 
-func TestDBDeleteAndHas(t *testing.T) {
+func TestDBRemoveAndContains(t *testing.T) {
 	dir, cleanup := createTempDir(t)
 	defer cleanup()
 
 	openFn := DBBuiltins["db.open"].Fn
 	closeFn := DBBuiltins["db.close"].Fn
 	setFn := DBBuiltins["db.set"].Fn
-	delFn := DBBuiltins["db.delete"].Fn
-	hasFn := DBBuiltins["db.has"].Fn
+	removeFn := DBBuiltins["db.remove"].Fn
+	containsFn := DBBuiltins["db.contains"].Fn
 
 	path := createTempFile(t, dir, "mydb.ezdb", "{}")
 	db := getReturnValues(t, openFn(&object.String{Value: path}))[0].(*object.Database)
@@ -293,44 +293,44 @@ func TestDBDeleteAndHas(t *testing.T) {
 	val := &object.String{Value: "v"}
 	setFn(db, key, val)
 
-	t.Run("has existing key", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains existing key", func(t *testing.T) {
+		res := containsFn(db, key)
 
 		if !res.(*object.Boolean).Value {
 			t.Fatalf("expected true")
 		}
 	})
 
-	t.Run("delete existing key", func(t *testing.T) {
-		res := delFn(db, key)
+	t.Run("remove existing key", func(t *testing.T) {
+		res := removeFn(db, key)
 
 		if !res.(*object.Boolean).Value {
 			t.Fatalf("expected deletion to succeed")
 		}
 	})
 
-	t.Run("has deleted key", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains removed key", func(t *testing.T) {
+		res := containsFn(db, key)
 
 		if res.(*object.Boolean).Value {
 			t.Fatalf("expected false after deletion")
 		}
 	})
 
-	t.Run("delete on closed database", func(t *testing.T) {
+	t.Run("remove on closed database", func(t *testing.T) {
 		res := closeFn(db)
 		if isErrorObject(res) {
 			t.Fatalf("unexpected error during close")
 		}
 
-		res = delFn(db, key)
+		res = removeFn(db, key)
 		if !isErrorObject(res) {
 			t.Fatalf("expected error for operating after close, got %T", res)
 		}
 	})
 
-	t.Run("has on closed database", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains on closed database", func(t *testing.T) {
+		res := containsFn(db, key)
 		if !isErrorObject(res) {
 			t.Fatalf("expected error for operating after close, got %T", res)
 		}

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -97,33 +97,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.delete": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("maps.delete() takes exactly 2 arguments (map, key)")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.delete() requires a map as first argument"}
-			}
-			if !m.Mutable {
-				return &object.Error{
-					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12002",
-				}
-			}
-			key := args[1]
-			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.delete() key must be a hashable type (string, int, bool, char)"}
-			}
-			deleted := m.Delete(key)
-			if deleted {
-				return object.TRUE
-			}
-			return object.FALSE
-		},
-	},
-
 	"maps.clear": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -201,28 +174,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 				}
 			}
 			return result
-		},
-	},
-
-	// has_key is an alias for has
-	"maps.has_key": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("maps.has_key() takes exactly 2 arguments (map, key)")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has_key() requires a map as first argument"}
-			}
-			key := args[1]
-			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.has_key() key must be a hashable type (string, int, bool, char)"}
-			}
-			_, exists := m.Get(key)
-			if exists {
-				return object.TRUE
-			}
-			return object.FALSE
 		},
 	},
 

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -782,22 +782,6 @@ func TestArraysContains(t *testing.T) {
 	testBooleanObject(t, result, false)
 }
 
-func TestArraysIndexOf(t *testing.T) {
-	indexOfFn := ArraysBuiltins["arrays.index_of"].Fn
-
-	arr := &object.Array{Elements: []object.Object{
-		&object.Integer{Value: big.NewInt(10)},
-		&object.Integer{Value: big.NewInt(20)},
-		&object.Integer{Value: big.NewInt(30)},
-	}}
-
-	result := indexOfFn(arr, &object.Integer{Value: big.NewInt(20)})
-	testIntegerObject(t, result, 1)
-
-	result = indexOfFn(arr, &object.Integer{Value: big.NewInt(99)})
-	testIntegerObject(t, result, -1)
-}
-
 func TestArraysReverse(t *testing.T) {
 	reverseFn := ArraysBuiltins["arrays.reverse"].Fn
 
@@ -1260,19 +1244,6 @@ func TestMapsIsEmpty(t *testing.T) {
 	testBooleanObject(t, result, false)
 }
 
-func TestMapsHasKey(t *testing.T) {
-	hasKeyFn := MapsBuiltins["maps.has_key"].Fn
-
-	m := object.NewMap()
-	m.Set(&object.String{Value: "name"}, &object.String{Value: "Alice"})
-
-	result := hasKeyFn(m, &object.String{Value: "name"})
-	testBooleanObject(t, result, true)
-
-	result = hasKeyFn(m, &object.String{Value: "age"})
-	testBooleanObject(t, result, false)
-}
-
 func TestMapsGet(t *testing.T) {
 	getFn := MapsBuiltins["maps.get"].Fn
 
@@ -1296,21 +1267,6 @@ func TestMapsSet(t *testing.T) {
 		t.Error("key should exist after set")
 	}
 	testIntegerObject(t, val, 42)
-}
-
-func TestMapsDelete(t *testing.T) {
-	deleteFn := MapsBuiltins["maps.delete"].Fn
-
-	m := object.NewMap()
-	m.Mutable = true
-	m.Set(&object.String{Value: "key"}, &object.Integer{Value: big.NewInt(42)})
-
-	deleteFn(m, &object.String{Value: "key"})
-
-	_, exists := m.Get(&object.String{Value: "key"})
-	if exists {
-		t.Error("key should not exist after delete")
-	}
 }
 
 func TestMapsKeys(t *testing.T) {
@@ -1402,7 +1358,6 @@ func TestTypeErrors(t *testing.T) {
 		{"arrays.is_empty with int", ArraysBuiltins["arrays.is_empty"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}}},
 		{"arrays.pop with string", ArraysBuiltins["arrays.pop"].Fn, []object.Object{&object.String{Value: "hello"}}},
 		{"strings.upper with int", StringsBuiltins["strings.upper"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}}},
-		{"maps.has_key with int", MapsBuiltins["maps.has_key"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}, &object.String{Value: "key"}}},
 	}
 
 	for _, tt := range tests {
@@ -4792,33 +4747,6 @@ func TestMapsValuesExtended(t *testing.T) {
 	}
 }
 
-func TestMapsHasKeyExtended(t *testing.T) {
-	hasKeyFn := MapsBuiltins["maps.has_key"].Fn
-
-	m := object.NewMap()
-	m.Set(&object.String{Value: "exists"}, &object.Integer{Value: big.NewInt(1)})
-
-	// Key exists
-	result := hasKeyFn(m, &object.String{Value: "exists"})
-	boolVal, ok := result.(*object.Boolean)
-	if !ok {
-		t.Fatalf("expected Boolean, got %T", result)
-	}
-	if !boolVal.Value {
-		t.Error("expected true, got false")
-	}
-
-	// Key doesn't exist
-	result = hasKeyFn(m, &object.String{Value: "missing"})
-	boolVal, ok = result.(*object.Boolean)
-	if !ok {
-		t.Fatalf("expected Boolean, got %T", result)
-	}
-	if boolVal.Value {
-		t.Error("expected false, got true")
-	}
-}
-
 // ============================================================================
 // Strings Module Additional Tests
 // ============================================================================
@@ -5581,28 +5509,6 @@ func TestRandomFloatRangeWithInts(t *testing.T) {
 // ============================================================================
 // Arrays Module - Error Cases (tests newError)
 // ============================================================================
-
-func TestArraysIndexOfNotFound(t *testing.T) {
-	indexOfFn := ArraysBuiltins["arrays.index_of"].Fn
-
-	arr := &object.Array{
-		Elements: []object.Object{
-			&object.Integer{Value: big.NewInt(1)},
-			&object.Integer{Value: big.NewInt(2)},
-		},
-	}
-
-	result := indexOfFn(arr, &object.Integer{Value: big.NewInt(999)})
-	intVal, ok := result.(*object.Integer)
-	if !ok {
-		t.Fatalf("expected Integer, got %T", result)
-	}
-
-	// Should return -1 when not found
-	if intVal.Value.Int64() != -1 {
-		t.Errorf("expected -1, got %d", intVal.Value.Int64())
-	}
-}
 
 func TestArraysSortError(t *testing.T) {
 	sortFn := ArraysBuiltins["arrays.sort"].Fn

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -4583,7 +4583,7 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestMapDelete(t *testing.T) {
+func TestMapRemove(t *testing.T) {
 	input := `
 import @maps
 using maps
@@ -4593,8 +4593,8 @@ do takeBool(value bool) {
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp deleted = maps.delete(m, "a")
-	takeBool(deleted)
+	temp removed = maps.remove(m, "a")
+	takeBool(removed)
 }
 `
 	tc := typecheck(t, input)
@@ -6276,20 +6276,6 @@ do main() {
 	assertHasError(t, tc, errors.E3001)
 }
 
-func TestArraysIndexOfTypeMismatch(t *testing.T) {
-	input := `
-import @arrays
-using arrays
-
-do main() {
-	temp arr [float] = {1.0, 2.0, 3.0}
-	temp idx int = arrays.index_of(arr, "not a float")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
-
 func TestArraysInsertTypeMismatch(t *testing.T) {
 	input := `
 import @arrays
@@ -6449,34 +6435,6 @@ do main() {
 // ============================================================================
 // Map Key/Value Type Compatibility Tests (checkMapKeyValueTypeCompatibility)
 // ============================================================================
-
-func TestMapsHasKeyTypeMismatch(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do main() {
-	temp m map[string:int] = {"a": 1, "b": 2}
-	temp found bool = maps.has_key(m, 123)
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
-
-func TestMapsDeleteKeyTypeMismatch(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do main() {
-	temp m map[int:string] = {1: "one", 2: "two"}
-	maps.delete(m, "not an int")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
 
 func TestMapsSetKeyTypeMismatch(t *testing.T) {
 	input := `


### PR DESCRIPTION
## Summary
Remove duplicate function aliases and rename db functions for consistency across stdlib modules.

## Changes

### Removed Duplicate Aliases (#995)
- `arrays.index_of` → use `arrays.index` instead
- `maps.has_key` → use `maps.contains` instead  
- `maps.delete` → use `maps.remove` instead

### Renamed DB Functions (#997)
- `db.has()` → `db.contains()`
- `db.delete()` → `db.remove()`

## Rationale
- Establishes consistent naming patterns across stdlib modules
- `contains` is used everywhere else for checking existence (strings, bytes, arrays, maps)
- `remove` is used everywhere else for deletion (arrays, maps, io)

## Files Changed
- `pkg/stdlib/arrays.go` - removed `arrays.index_of`
- `pkg/stdlib/maps.go` - removed `maps.has_key` and `maps.delete`
- `pkg/stdlib/db.go` - renamed `db.has` → `db.contains`, `db.delete` → `db.remove`
- `pkg/typechecker/typechecker.go` - updated all references
- Integration tests - updated to use new function names
- Unit tests - removed tests for deleted functions, updated tests for renamed functions

## Testing
- ✅ All unit tests pass
- ✅ All integration tests pass
- ✅ All typechecker tests pass

## Breaking Change
⚠️ **This is a breaking change.** Existing code using the removed/renamed functions will need to be updated.

Closes #995
Closes #997