### PR TITLE
fix(typechecker): use correct error code for continue outside loop

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1628,7 +1628,7 @@ func (tc *TypeChecker) checkStatement(stmt ast.Statement, expectedReturnTypes []
 		// Check that continue is inside a loop (#603)
 		if tc.loopDepth == 0 {
 			tc.addError(
-				errors.E5009,
+				errors.E5010,
 				"continue statement outside loop",
 				s.Token.Line,
 				s.Token.Column,


### PR DESCRIPTION
## Summary
- Fixes #963
- Changed error code from E5009 to E5010 for `continue` statements outside loops
- Error detail now correctly says "continue not inside loop" instead of "break not inside loop"

## Test plan
- [x] Verified error message shows correct code and description
- [x] Ran typechecker tests for continue/break
- [x] Ran E5010 integration test