### PR TITLE
fix(stdlib): handle empty database files in db.open()

### DIFF
--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -64,6 +64,18 @@ var DBBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E17002", Message: "db.open(): could not read database file"}
 			}
 
+			// Handle empty files the same as non-existent files - initialize with empty map
+			if len(content) == 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.Database{
+						Path:     *path,
+						Store:    *object.NewMap(),
+						IsClosed: object.Boolean{Value: false},
+					},
+					object.NIL,
+				}}
+			}
+
 			result, err := decodeFromJSON(string(content))
 			if err != nil {
 				return &object.Error{Code: "E17004", Message: "db.open(): database file is corrupted"}


### PR DESCRIPTION
## Summary
- Fixes #941
- Empty .ezdb files now initialize with an empty map instead of reporting "corrupted"
- Consistent behavior with non-existent files

## Test plan
- [x] Tested db.open() on empty file - now works correctly
- [x] All db stdlib tests pass