### PR TITLE
fix(stdlib): improve error message when db file contains JSON array

### DIFF
--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -71,6 +71,9 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			dbContent, ok := result.(*object.Map)
 			if !ok {
+				if _, isArray := result.(*object.Array); isArray {
+					return &object.Error{Code: "E17004", Message: "db.open(): database file must contain a JSON object, not an array"}
+				}
 				return &object.Error{Code: "E17004", Message: "db.open(): database file is corrupted"}
 			}
 


### PR DESCRIPTION
## Summary
- Fixes #942
- When `db.open()` encounters a file with valid JSON array instead of object, now shows specific error instead of generic "corrupted" message

**Before:** `db.open(): database file is corrupted`
**After:** `db.open(): database file must contain a JSON object, not an array`

## Test plan
- [x] Tested with JSON array file - shows correct error
- [x] All db stdlib tests pass