### PR TITLE
Bug fixes batch: 1-15-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://schoolyb.github.io/language.ez">Website</a> •
-  <a href="https://schoolyb.github.io/language.ez/docs">Documentation</a>
+  <a href="https://schoolyb.github.io/EZ-Language-Webapp">Website</a> •
+  <a href="https://schoolyb.github.io/EZ-Language-Webapp/docs">Documentation</a>
 </p>
 
 <p align="center">
@@ -52,7 +52,7 @@ go build -o ez.exe ./cmd/ez
 
 **Requirements:** Go 1.23.1 or higher
 
-For pre-built binaries and installation instructions, visit the [documentation](https://schoolyb.github.io/language.ez/docs).
+For pre-built binaries and installation instructions, visit the [documentation](https://schoolyb.github.io/EZ-Language-Webapp/docs).
 
 ---
 

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -83,6 +83,9 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			dbContent, ok := result.(*object.Map)
 			if !ok {
+				if _, isArray := result.(*object.Array); isArray {
+					return &object.Error{Code: "E17004", Message: "db.open(): database file must contain a JSON object, not an array"}
+				}
 				return &object.Error{Code: "E17004", Message: "db.open(): database file is corrupted"}
 			}
 

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -64,6 +64,18 @@ var DBBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E17002", Message: "db.open(): could not read database file"}
 			}
 
+			// Handle empty files the same as non-existent files - initialize with empty map
+			if len(content) == 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.Database{
+						Path:     *path,
+						Store:    *object.NewMap(),
+						IsClosed: object.Boolean{Value: false},
+					},
+					object.NIL,
+				}}
+			}
+
 			result, err := decodeFromJSON(string(content))
 			if err != nil {
 				return &object.Error{Code: "E17004", Message: "db.open(): database file is corrupted"}

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1628,7 +1628,7 @@ func (tc *TypeChecker) checkStatement(stmt ast.Statement, expectedReturnTypes []
 		// Check that continue is inside a loop (#603)
 		if tc.loopDepth == 0 {
 			tc.addError(
-				errors.E5009,
+				errors.E5010,
 				"continue statement outside loop",
 				s.Token.Line,
 				s.Token.Column,


### PR DESCRIPTION
## Summary

Batch of bug fixes from January 15, 2026.

### Fixes included:

| Issue | Description |
|-------|-------------|
| #963 | Fixed continue error using wrong code (E5009 → E5010) |
| #941 | Fixed `db.open()` failing on empty files |
| #1009 | Added error codes and location info to 15+ runtime errors |
| #942 | Better error message when db file contains JSON array instead of object |
| #962 | Integer type narrowing now validates ranges at runtime |

### Details:

**#963 - Continue error message fix**
- Typechecker was using E5009 (break) instead of E5010 (continue)

**#941 - Empty database file handling**  
- Empty `.ezdb` files now initialize with empty map instead of "corrupted" error

**#1009 - Runtime error formatting**
- Added proper error codes and source locations to errors like: module not imported, field not found, function not found, range type errors, etc.

**#942 - JSON array error message**
- When db file contains valid JSON array instead of object, now shows specific error instead of generic "corrupted"

**#962 - Integer type narrowing**
- Validates ranges when assigning larger int types to smaller ones (e.g., i64 → i8)
- Applies to both variable declarations and function parameters
- Error messages include valid range: `value 9999999 out of range for type 'i8' (valid range: -128 to 127)`

## Test plan
- [x] All individual fixes tested
- [x] All interpreter tests pass
- [x] All typechecker tests pass
- [x] All stdlib tests pass