### PR TITLE
chore: Clean up of error and warning codes done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.0](https://github.com/SchoolyB/EZ/compare/v0.40.5...v1.0.0) (2026-01-14)
+
+
+### ⚠ BREAKING CHANGES
+
+* Existing code using removed/renamed functions must be updated.
+
+### Features
+
+* **#996:** Rename stdlib functions for consistency ([#1001](https://github.com/SchoolyB/EZ/issues/1001)) ([0ad96f8](https://github.com/SchoolyB/EZ/commit/0ad96f881a24123d6fba7f414a48bdb0b819a22d))
+* stdlib function renaming for consistency ([09b658b](https://github.com/SchoolyB/EZ/commit/09b658b681593511294c6fe41d762d117c2aea4f))
+
+
+### Code Refactoring
+
+* remove duplicate stdlib aliases and rename db functions ([#1003](https://github.com/SchoolyB/EZ/issues/1003)) ([4e0dc08](https://github.com/SchoolyB/EZ/commit/4e0dc081711bd70b237bd71fde809972b0db7eca)), closes [#995](https://github.com/SchoolyB/EZ/issues/995) [#997](https://github.com/SchoolyB/EZ/issues/997)
+
 ## [0.40.5](https://github.com/SchoolyB/EZ/compare/v0.40.4...v0.40.5) (2026-01-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.0.1](https://github.com/SchoolyB/EZ/compare/v1.0.0...v1.0.1) (2026-01-15)
+
+
+### Bug Fixes
+
+* **interpreter:** add error codes and location info to runtime errors ([#1009](https://github.com/SchoolyB/EZ/issues/1009)) ([#1013](https://github.com/SchoolyB/EZ/issues/1013)) ([d1bb289](https://github.com/SchoolyB/EZ/commit/d1bb2897768307a194bbe71b5df8574b976ba272))
+* **interpreter:** add range checking for integer type narrowing ([#962](https://github.com/SchoolyB/EZ/issues/962)) ([#1016](https://github.com/SchoolyB/EZ/issues/1016)) ([02f953b](https://github.com/SchoolyB/EZ/commit/02f953bb6e4efb2b42c47af5708ac5826abd5723))
+* **stdlib:** handle empty database files in db.open() ([#941](https://github.com/SchoolyB/EZ/issues/941)) ([#1012](https://github.com/SchoolyB/EZ/issues/1012)) ([eadc48d](https://github.com/SchoolyB/EZ/commit/eadc48d3edb7817aeddf8b405b01697d6015b3ff))
+* **stdlib:** improve error message when db file contains JSON array ([#942](https://github.com/SchoolyB/EZ/issues/942)) ([#1014](https://github.com/SchoolyB/EZ/issues/1014)) ([bea2f65](https://github.com/SchoolyB/EZ/commit/bea2f659dd141a09014e4a3d7fefd31796380050))
+* **typechecker:** use correct error code E5010 for continue outside loop ([#963](https://github.com/SchoolyB/EZ/issues/963)) ([#1011](https://github.com/SchoolyB/EZ/issues/1011)) ([9f55570](https://github.com/SchoolyB/EZ/commit/9f55570b34c66af16e7eb46cc630801361fe6e87))
+
 ## [1.0.0](https://github.com/SchoolyB/EZ/compare/v0.40.5...v1.0.0) (2026-01-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.40.5](https://github.com/SchoolyB/EZ/compare/v0.40.4...v0.40.5) (2026-01-11)
+
+
+### Bug Fixes
+
+* Add `isMultiReturnCall` to typechecker ([#951](https://github.com/SchoolyB/EZ/issues/951)) ([981d068](https://github.com/SchoolyB/EZ/commit/981d068676520c1bd1a545c8f0b524ff614856eb))
+* **cli:** Allow command line arguments for programs ([#983](https://github.com/SchoolyB/EZ/issues/983)) ([9f4439d](https://github.com/SchoolyB/EZ/commit/9f4439d29be136c720d62d2c3bb0f971e60a414e))
+* Detect invalid string interpolation syntax at parse time ([#988](https://github.com/SchoolyB/EZ/issues/988)) ([7fcbcc1](https://github.com/SchoolyB/EZ/commit/7fcbcc152400e7b8e201eef2c92153a1d56c488d)), closes [#984](https://github.com/SchoolyB/EZ/issues/984)
+* Error on bare function/type names as statements ([#989](https://github.com/SchoolyB/EZ/issues/989)) ([a84ab6b](https://github.com/SchoolyB/EZ/commit/a84ab6b2c742b5411ce84da4b54ff0785549c24a)), closes [#985](https://github.com/SchoolyB/EZ/issues/985)
+* Prevent RETURN_VALUE type leak for multi-return functions ([#987](https://github.com/SchoolyB/EZ/issues/987)) ([750906f](https://github.com/SchoolyB/EZ/commit/750906fcbb445ecdf119c0a8f9204453674a2dcf)), closes [#986](https://github.com/SchoolyB/EZ/issues/986)
+
 ## [0.40.4](https://github.com/SchoolyB/EZ/compare/v0.40.3...v0.40.4) (2026-01-10)
 
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -376,4 +376,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 257 error/warning codes
+**Total:** 258 error/warning codes

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -92,6 +92,7 @@ Syntax and parsing errors
 | E2054 | when-strict-non-enum-case | #strict when requires explicit enum member values in cases |
 | E2055 | strict-invalid-target | #strict can only be applied to when statements |
 | E2056 | executable-at-file-scope | executable statement not allowed at file scope |
+| E2057 | invalid-interpolation-syntax | invalid string interpolation syntax |
 
 ## Type Errors (E3xxx)
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -138,6 +138,7 @@ Type system errors
 | E3037 | invalid-private-usage | private modifier cannot be used here |
 | E3038 | void-type-not-allowed | 'void' is not a valid type |
 | E3039 | ensure-expects-call | ensure expects a function call |
+| E3040 | multi-return-to-single-var | cannot assign multiple return values to single variable |
 
 ## Reference Errors (E4xxx)
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -122,7 +122,7 @@ Type system errors
 | E3020 | negative-to-unsigned | cannot assign negative value to unsigned type |
 | E3021 | type-change-not-allowed | cannot change type of variable after declaration |
 | E3022 | undefined-struct-field | struct field not found |
-| E3023 | undefined-enum-value | enum value not found |
+| E3023 | enum-value-not-found | enum value not found |
 | E3024 | missing-return-statement | function must return a value |
 | E3025 | byte-value-out-of-range | byte value must be between 0 and 255 |
 | E3026 | byte-array-element-out-of-range | byte array element must be between 0 and 255 |
@@ -216,7 +216,7 @@ Standard library validation errors
 
 | Code | Type | Message |
 |------|------|---------|
-| E7001 | wrong-argument-count | wrong number of arguments |
+| E7001 | stdlib-argument-mismatch | wrong number of arguments |
 | E7002 | requires-array | argument must be an array |
 | E7003 | requires-string | argument must be a string |
 | E7004 | requires-integer | argument must be an integer |
@@ -249,6 +249,7 @@ Standard library validation errors
 | E7031 | command-failed | command execution failed |
 | E7032 | sleep-negative | sleep duration cannot be negative |
 | E7033 | conversion-overflow | value exceeds target type range |
+| E7035 | env-var-not-set | environment variable is not set |
 | E7040 | empty-path | path cannot be empty |
 | E7041 | path-null-byte | path contains null byte |
 | E7042 | read-directory-as-file | cannot read directory as file |
@@ -282,6 +283,7 @@ Array-specific errors
 | E9004 | chunk-size-invalid | chunk size must be greater than zero |
 | E9005 | range-invalid-bounds | range start must be less than or equal to end |
 | E9006 | array-modified-during-iteration | cannot modify array during for_each iteration |
+| E9007 | empty-array-selection | cannot select from empty array |
 
 ## String Errors (E10xxx)
 
@@ -290,7 +292,6 @@ String-specific errors
 | Code | Type | Message |
 |------|------|---------|
 | E10001 | repeat-count-negative | repeat count cannot be negative |
-| E10002 | empty-array-selection | cannot select from empty array |
 | E10003 | string-index-out-of-bounds | string index out of bounds |
 | E10004 | string-empty-index | cannot index empty string |
 
@@ -325,6 +326,49 @@ JSON module errors
 | E13002 | json-unsupported-type | type cannot be converted to JSON |
 | E13003 | json-invalid-map-key | JSON object keys must be strings |
 | E13004 | json-decode-requires-type | json.decode() requires a type argument |
+
+## HTTP Errors (E14xxx)
+
+HTTP request errors
+
+| Code | Type | Message |
+|------|------|---------|
+| E14001 | http-invalid-url | invalid URL |
+| E14002 | http-failed-request | request failed (network error) |
+| E14003 | http-timeout | timeout exceeded |
+| E14004 | http-invalid-method | invalid HTTP method |
+| E14005 | http-failed-url-decode | URL decode failed |
+| E14006 | http-failed-json-encoding | JSON encoding failed |
+
+## Crypto Errors (E15xxx)
+
+Cryptography-specific errors
+
+| Code | Type | Message |
+|------|------|---------|
+| E15001 | crypto-random-failed | cryptographic random generation failed |
+
+## Encoding Errors (E16xxx)
+
+Encoding/decoding errors
+
+| Code | Type | Message |
+|------|------|---------|
+| E16001 | invalid-base64 | invalid base64 encoded input |
+| E16002 | invalid-hex | invalid hexadecimal encoded input |
+| E16003 | invalid-url-encoding | invalid URL encoded input |
+
+## DB Errors (E17xxx)
+
+Database operation errors
+
+| Code | Type | Message |
+|------|------|---------|
+| E17001 | db-open-failed | failed to open database |
+| E17002 | db-read-failed | failed to read database file |
+| E17003 | db-write-failed | failed to write database file |
+| E17004 | db-corrupted | database file is corrupted |
+| E17005 | db-closed | operation on closed database |
 
 ## Code Style Warnings (W1xxx)
 
@@ -376,4 +420,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 258 error/warning codes
+**Total:** 263 error/warning codes

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -375,4 +375,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 256 error/warning codes
+**Total:** 257 error/warning codes

--- a/README.md
+++ b/README.md
@@ -160,3 +160,5 @@ Thank you to everyone who has contributed to EZ!
 <a href="https://github.com/elect0"><img src="https://github.com/elect0.png" width="50" height="50" alt="elect0"/></a>
 <a href="https://github.com/jgafnea"><img src="https://github.com/jgafnea.png" width="50" height="50" alt="jgafnea"/></a>
 <a href="https://github.com/madhav-murali"><img src="https://github.com/madhav-murali.png" width="50" height="50" alt="madhav-murali"/></a>
+<a href="https://github.com/preettrank53"><img src="https://github.com/preettrank53.png" width="50" height="50" alt="preettrank53"/></a>
+<a href="https://github.com/TechLateef"><img src="https://github.com/TechLateef.png" width="50" height="50" alt="TechLateef"/></a>

--- a/README.md
+++ b/README.md
@@ -159,3 +159,4 @@ Thank you to everyone who has contributed to EZ!
 <a href="https://github.com/HCH1212"><img src="https://github.com/HCH1212.png" width="50" height="50" alt="HCH1212"/></a>
 <a href="https://github.com/elect0"><img src="https://github.com/elect0.png" width="50" height="50" alt="elect0"/></a>
 <a href="https://github.com/jgafnea"><img src="https://github.com/jgafnea.png" width="50" height="50" alt="jgafnea"/></a>
+<a href="https://github.com/madhav-murali"><img src="https://github.com/madhav-murali.png" width="50" height="50" alt="madhav-murali"/></a>

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://schoolyb.github.io/language.ez">Website</a> •
-  <a href="https://schoolyb.github.io/language.ez/docs">Documentation</a>
+  <a href="https://schoolyb.github.io/EZ-Language-Webapp">Website</a> •
+  <a href="https://schoolyb.github.io/EZ-Language-Webapp/docs">Documentation</a>
 </p>
 
 <p align="center">
@@ -52,7 +52,7 @@ go build -o ez.exe ./cmd/ez
 
 **Requirements:** Go 1.23.1 or higher
 
-For pre-built binaries and installation instructions, visit the [documentation](https://schoolyb.github.io/language.ez/docs).
+For pre-built binaries and installation instructions, visit the [documentation](https://schoolyb.github.io/EZ-Language-Webapp/docs).
 
 ---
 

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
+	"slices"
 	"strings"
 
+	"github.com/marshallburns/ez/pkg/stdlib"
 	"github.com/spf13/cobra"
 )
 
@@ -83,14 +86,26 @@ var rootCmd = &cobra.Command{
 	Use:     "ez [file.ez]",
 	Short:   "EZ Language Interpreter",
 	Long:    "A simple, interpreted, statically-typed programming language designed for clarity and ease of use.",
-	Args:    cobra.MaximumNArgs(1),
+	Args:    cobra.ArbitraryArgs,
 	Version: getVersionString(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 1 && strings.HasSuffix(args[0], ".ez") {
-			runFile(args[0])
-			return nil
+		if len(args) == 0 {
+			return cmd.Help()
 		}
-		return cmd.Help()
+		if !strings.HasSuffix(args[0], ".ez") {
+			return cmd.Help()
+		}
+
+		programArgs := []string{os.Args[0], args[0]}
+		if cmd.ArgsLenAtDash() > 0 {
+			programArgs = slices.Concat(programArgs, args[cmd.ArgsLenAtDash():])
+		} else if len(args) > 1 {
+			programArgs = slices.Concat(programArgs, args[1:])
+		}
+		stdlib.CommandLineArgs = programArgs
+
+		runFile(args[0])
+		return nil
 	},
 }
 

--- a/examples/using_stdlib.ez
+++ b/examples/using_stdlib.ez
@@ -116,10 +116,10 @@ do main() {
 
     temp alice_key string = "alice"
     temp diana_key string = "diana"
-    temp has_alice bool = maps.has(scores, alice_key)
-    temp has_diana bool = maps.has(scores, diana_key)
-    println("maps.has(scores, 'alice') = ${has_alice}")
-    println("maps.has(scores, 'diana') = ${has_diana}")
+    temp has_alice bool = maps.contains(scores, alice_key)
+    temp has_diana bool = maps.contains(scores, diana_key)
+    println("maps.contains(scores, 'alice') = ${has_alice}")
+    println("maps.contains(scores, 'diana') = ${has_diana}")
     println("")
 
     // ==================

--- a/integration-tests/fail/errors/E2057_invalid_interpolation_syntax.ez
+++ b/integration-tests/fail/errors/E2057_invalid_interpolation_syntax.ez
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E2057 - invalid-interpolation-syntax
+ * Expected: "invalid interpolation syntax" or "$identifier"
+ */
+
+do main() {
+    temp file string = "test.ez"
+    temp s string = "$File: something"
+}

--- a/integration-tests/fail/errors/E3031_bare_function_name.ez
+++ b/integration-tests/fail/errors/E3031_bare_function_name.ez
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3031 - function-as-value
+ * Expected: "function" and "cannot be used as a value"
+ */
+
+do some_function() {
+    // Some function
+}
+
+do main() {
+    some_function
+}

--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -99,30 +99,30 @@ do main() {
         failed += 1
     }
 
-    // Test 8: maps.has - key exists
-    temp has_a bool = maps.has(m, "a")
+    // Test 8: maps.contains - key exists
+    temp has_a bool = maps.contains(m, "a")
     if has_a == true {
-        println("  [PASS] maps.has(m, \"a\") = true")
+        println("  [PASS] maps.contains(m, \"a\") = true")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, \"a\"): expected true")
+        println("  [FAIL] maps.contains(m, \"a\"): expected true")
         failed += 1
     }
 
-    // Test 9: maps.has - key doesn't exist
-    temp has_z bool = maps.has(m, "z")
+    // Test 9: maps.contains - key doesn't exist
+    temp has_z bool = maps.contains(m, "z")
     if has_z == false {
-        println("  [PASS] maps.has(m, \"z\") = false")
+        println("  [PASS] maps.contains(m, \"z\") = false")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, \"z\"): expected false")
+        println("  [FAIL] maps.contains(m, \"z\"): expected false")
         failed += 1
     }
 
     // Test 10: maps.delete
     temp del_map map[string:int] = {"x": 10, "y": 20}
     maps.delete(del_map, "x")
-    if len(del_map) == 1 && !maps.has(del_map, "x") {
+    if len(del_map) == 1 && !maps.contains(del_map, "x") {
         println("  [PASS] maps.delete() removed key")
         passed += 1
     } otherwise {

--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -119,14 +119,14 @@ do main() {
         failed += 1
     }
 
-    // Test 10: maps.delete
+    // Test 10: maps.remove
     temp del_map map[string:int] = {"x": 10, "y": 20}
-    maps.delete(del_map, "x")
+    maps.remove(del_map, "x")
     if len(del_map) == 1 && !maps.contains(del_map, "x") {
-        println("  [PASS] maps.delete() removed key")
+        println("  [PASS] maps.remove() removed key")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete()")
+        println("  [FAIL] maps.remove()")
         failed += 1
     }
 

--- a/integration-tests/pass/stdlib/arrays.ez
+++ b/integration-tests/pass/stdlib/arrays.ez
@@ -158,29 +158,6 @@ do main() {
         failed += 1
     }
 
-    // ==================== arrays.index_of ====================
-    println("  -- arrays.index_of --")
-
-    // Test 13: index_of - found
-    temp idx int = arrays.index_of(contains_arr, 3)
-    if idx == 2 {
-        println("  [PASS] arrays.index_of({1,2,3,4,5}, 3) = 2")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] arrays.index_of: expected 2, got ${idx}")
-        failed += 1
-    }
-
-    // Test 14: index_of - not found
-    temp idx_notfound int = arrays.index_of(contains_arr, 10)
-    if idx_notfound == -1 {
-        println("  [PASS] arrays.index_of(not found) = -1")
-        passed += 1
-    } otherwise {
-        println("  [FAIL] arrays.index_of not found: expected -1, got ${idx_notfound}")
-        failed += 1
-    }
-
     // ==================== arrays.clear ====================
     println("  -- arrays.clear --")
 

--- a/integration-tests/pass/stdlib/db.ez
+++ b/integration-tests/pass/stdlib/db.ez
@@ -80,24 +80,24 @@ do main() {
         passed += 1
     }
     
-    // ==================== db.has ====================
-    println("  -- db.has --")
+    // ==================== db.contains ====================
+    println("  -- db.contains --")
 
     // Test 1: checking for existing key
-    if db.has (store, "user:2") {
-        println("   [PASS] db.has(database, string)")
+    if db.contains (store, "user:2") {
+        println("   [PASS] db.contains(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.has(database, string): expected `true`, got `false`")
+        println("   [FAIL] db.contains(database, string): expected `true`, got `false`")
         failed += 1
     }
 
     // Test 2: checking for non-existent key
-    if !db.has (store, "user:3") {
-        println("   [PASS] db.has(database, string)")
+    if !db.contains (store, "user:3") {
+        println("   [PASS] db.contains(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.has(database, string): expected `false`, got `true`")
+        println("   [FAIL] db.contains(database, string): expected `false`, got `true`")
         failed += 1
     }
 
@@ -159,24 +159,24 @@ do main() {
         failed += 1
     }
 
-    // ==================== db.delete ====================
-    println("  -- db.delete --")
+    // ==================== db.remove ====================
+    println("  -- db.remove --")
 
-    // Test 1: Delete existing key
-    if db.delete(store, "config:theme") {
-        println("   [PASS] db.delete(database, string)")
+    // Test 1: remove existing key
+    if db.remove(store, "config:theme") {
+        println("   [PASS] db.remove(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.delete(database, string): could not delete existing key")
+        println("   [FAIL] db.remove(database, string): could not remove existing key")
         failed += 1
     }
 
-    // Test 2: Delete non-existent key
-    if !db.delete(store, "config:time") {
-        println("   [PASS] db.delete(database, string)")
+    // Test 2: remove non-existent key
+    if !db.remove(store, "config:time") {
+        println("   [PASS] db.remove(database, string)")
         passed += 1
     } otherwise {
-        println("   [FAIL] db.delete(database, string): deleted non-existent key")
+        println("   [FAIL] db.remove(database, string): removed non-existent key")
         failed += 1
     }
     
@@ -236,7 +236,7 @@ do main() {
         }
 
         // Test 2: Old key should not exist
-        if !db.has(rename_store, "original_key") {
+        if !db.contains(rename_store, "original_key") {
             println("   [PASS] db.update_key_name() old key removed")
             passed += 1
         } otherwise {

--- a/integration-tests/pass/stdlib/maps.ez
+++ b/integration-tests/pass/stdlib/maps.ez
@@ -59,23 +59,23 @@ do main() {
         failed += 1
     }
 
-    // ==================== maps.delete ====================
-    println("  -- maps.delete --")
+    // ==================== maps.remove ====================
+    println("  -- maps.remove --")
 
-    // Test 5: delete removes key
+    // Test 5: remove removes key
     temp del_map map[string:int] = {"x": 10, "y": 20, "z": 30}
-    maps.delete(del_map, "y")
-    if len(del_map) == 2 && !maps.contains(del_map, "y") {
-        println("  [PASS] maps.delete() removed key 'y'")
+    temp removed bool = maps.remove(del_map, "y")
+    if len(del_map) == 2 && !maps.contains(del_map, "y") && removed {
+        println("  [PASS] maps.remove() removed key 'y'")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete: len=${len(del_map)}, contains_y=${maps.contains(del_map, "y")}")
+        println("  [FAIL] maps.remove: len=${len(del_map)}, contains_y=${maps.contains(del_map, "y")}, removed=${removed}")
         failed += 1
     }
 
-    // Test 6: remaining keys still accessible
+    // Test 6: remaining keys still accessible after remove
     if del_map["x"] == 10 && del_map["z"] == 30 {
-        println("  [PASS] remaining keys still accessible after delete")
+        println("  [PASS] remaining keys still accessible after remove")
         passed += 1
     } otherwise {
         println("  [FAIL] remaining keys: x=${del_map["x"]}, z=${del_map["z"]}")

--- a/integration-tests/pass/stdlib/maps.ez
+++ b/integration-tests/pass/stdlib/maps.ez
@@ -38,24 +38,24 @@ do main() {
         failed += 1
     }
 
-    // ==================== maps.has ====================
-    println("  -- maps.has --")
+    // ==================== maps.contains ====================
+    println("  -- maps.contains --")
 
-    // Test 3: has - key exists
-    if maps.has(m, "a") == true {
-        println("  [PASS] maps.has(m, 'a') = true")
+    // Test 3: contains - key exists
+    if maps.contains(m, "a") == true {
+        println("  [PASS] maps.contains(m, 'a') = true")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, 'a'): expected true")
+        println("  [FAIL] maps.contains(m, 'a'): expected true")
         failed += 1
     }
 
-    // Test 4: has - key doesn't exist
-    if maps.has(m, "z") == false {
-        println("  [PASS] maps.has(m, 'z') = false")
+    // Test 4: contains - key doesn't exist
+    if maps.contains(m, "z") == false {
+        println("  [PASS] maps.contains(m, 'z') = false")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has(m, 'z'): expected false")
+        println("  [FAIL] maps.contains(m, 'z'): expected false")
         failed += 1
     }
 
@@ -65,11 +65,11 @@ do main() {
     // Test 5: delete removes key
     temp del_map map[string:int] = {"x": 10, "y": 20, "z": 30}
     maps.delete(del_map, "y")
-    if len(del_map) == 2 && !maps.has(del_map, "y") {
+    if len(del_map) == 2 && !maps.contains(del_map, "y") {
         println("  [PASS] maps.delete() removed key 'y'")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.delete: len=${len(del_map)}, has_y=${maps.has(del_map, "y")}")
+        println("  [FAIL] maps.delete: len=${len(del_map)}, contains_y=${maps.contains(del_map, "y")}")
         failed += 1
     }
 
@@ -136,12 +136,12 @@ do main() {
         failed += 1
     }
 
-    // Test 11: maps.has with int key
-    if maps.has(int_map, 1) == true && maps.has(int_map, 99) == false {
-        println("  [PASS] maps.has() works with int keys")
+    // Test 11: maps.contains with int key
+    if maps.contains(int_map, 1) == true && maps.contains(int_map, 99) == false {
+        println("  [PASS] maps.contains() works with int keys")
         passed += 1
     } otherwise {
-        println("  [FAIL] maps.has with int keys")
+        println("  [FAIL] maps.contains with int keys")
         failed += 1
     }
 

--- a/integration-tests/pass/stdlib/std.ez
+++ b/integration-tests/pass/stdlib/std.ez
@@ -2,7 +2,7 @@
  * std.ez - Test @std standard library expanded functions
  *
  * Global builtins (no import needed): exit, EXIT_SUCCESS, EXIT_FAILURE, panic, assert
- * @std module functions (require import): println, printf, sleep_*, eprintln, eprintf
+ * @std module functions (require import): println, print, sleep_*, eprintln, eprint
  */
 
 import @std
@@ -74,13 +74,13 @@ do main() {
     println("  [PASS] eprintln() with multiple args executed")
     passed += 1
 
-    // ==================== eprintf (@std) ====================
-    println("  -- eprintf --")
+    // ==================== eprint (@std) ====================
+    println("  -- eprint --")
 
-    // Test: eprintf outputs to stderr without newline
-    eprintf("stderr without newline")
+    // Test: eprint outputs to stderr without newline
+    eprint("stderr without newline")
     eprintln()  // add newline after
-    println("  [PASS] eprintf() executed without error")
+    println("  [PASS] eprint() executed without error")
     passed += 1
 
     // ==================== assert (global builtin) ====================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -138,6 +138,7 @@ var (
 	E3037 = ErrorCode{"E3037", "invalid-private-usage", "private modifier cannot be used here"}
 	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is not a valid type"}
 	E3039 = ErrorCode{"E3039", "ensure-expects-call", "ensure expects a function call"}
+	E3040 = ErrorCode{"E3040", "multi-return-to-single-var", "cannot assign multiple return values to single variable"}
 )
 
 // =============================================================================

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -93,6 +93,7 @@ var (
 	E2054 = ErrorCode{"E2054", "when-strict-non-enum-case", "#strict when requires explicit enum member values in cases"}
 	E2055 = ErrorCode{"E2055", "strict-invalid-target", "#strict can only be applied to when statements"}
 	E2056 = ErrorCode{"E2056", "executable-at-file-scope", "executable statement not allowed at file scope"}
+	E2057 = ErrorCode{"E2057", "invalid-interpolation-syntax", "invalid string interpolation syntax"}
 )
 
 // =============================================================================
@@ -349,11 +350,11 @@ var (
 // These are errors unique to HTTP operations
 // =============================================================================
 var (
-	E14001 = ErrorCode{"E14001", "http-invalid-url",					"invalid URL"}
-	E14002 = ErrorCode{"E14002", "http-failed-request",       "request failed (network error)"}
-	E14003 = ErrorCode{"E14003", "http-timeout",							"timeout exceeded"}
-	E14004 = ErrorCode{"E14004", "http-invalid-method",				"invalid HTTP method"}
-	E14005 = ErrorCode{"E14005", "http-failed-url-decode",		"URL decode failed"}
+	E14001 = ErrorCode{"E14001", "http-invalid-url", "invalid URL"}
+	E14002 = ErrorCode{"E14002", "http-failed-request", "request failed (network error)"}
+	E14003 = ErrorCode{"E14003", "http-timeout", "timeout exceeded"}
+	E14004 = ErrorCode{"E14004", "http-invalid-method", "invalid HTTP method"}
+	E14005 = ErrorCode{"E14005", "http-failed-url-decode", "URL decode failed"}
 	E14006 = ErrorCode{"E14006", "http-failed-json-encoding", "JSON encoding failed"}
 )
 

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -122,7 +122,8 @@ var (
 	E3020 = ErrorCode{"E3020", "negative-to-unsigned", "cannot assign negative value to unsigned type"}
 	E3021 = ErrorCode{"E3021", "type-change-not-allowed", "cannot change type of variable after declaration"}
 	E3022 = ErrorCode{"E3022", "undefined-struct-field", "struct field not found"}
-	E3023 = ErrorCode{"E3023", "undefined-enum-value", "enum value not found"}
+	E3023 = ErrorCode{"E3023", "enum-value-not-found", "enum value not found"}
+
 	E3024 = ErrorCode{"E3024", "missing-return-statement", "function must return a value"}
 	E3025 = ErrorCode{"E3025", "byte-value-out-of-range", "byte value must be between 0 and 255"}
 	E3026 = ErrorCode{"E3026", "byte-array-element-out-of-range", "byte array element must be between 0 and 255"}
@@ -214,7 +215,8 @@ var (
 // =============================================================================
 var (
 	// Argument count errors
-	E7001 = ErrorCode{"E7001", "wrong-argument-count", "wrong number of arguments"}
+	E7001 = ErrorCode{"E7001", "stdlib-argument-mismatch", "wrong number of arguments"}
+
 
 	// Type requirement errors - used when function requires specific type
 	E7002 = ErrorCode{"E7002", "requires-array", "argument must be an array"}
@@ -250,6 +252,8 @@ var (
 
 	// OS module errors
 	E7024 = ErrorCode{"E7024", "env-var-operation-failed", "environment variable operation failed"}
+	E7035 = ErrorCode{"E7035", "env-var-not-set", "environment variable is not set"}
+
 	E7025 = ErrorCode{"E7025", "get-cwd-failed", "failed to get current directory"}
 	E7026 = ErrorCode{"E7026", "chdir-failed", "failed to change directory"}
 	E7027 = ErrorCode{"E7027", "get-hostname-failed", "failed to get hostname"}
@@ -300,7 +304,9 @@ var (
 	E9004 = ErrorCode{"E9004", "chunk-size-invalid", "chunk size must be greater than zero"}
 	E9005 = ErrorCode{"E9005", "range-invalid-bounds", "range start must be less than or equal to end"}
 	E9006 = ErrorCode{"E9006", "array-modified-during-iteration", "cannot modify array during for_each iteration"}
+	E9007 = ErrorCode{"E9007", "empty-array-selection", "cannot select from empty array"}
 )
+
 
 // =============================================================================
 // STRING ERRORS (E10xxx) - String-specific domain errors
@@ -308,7 +314,7 @@ var (
 // =============================================================================
 var (
 	E10001 = ErrorCode{"E10001", "repeat-count-negative", "repeat count cannot be negative"}
-	E10002 = ErrorCode{"E10002", "empty-array-selection", "cannot select from empty array"}
+
 	E10003 = ErrorCode{"E10003", "string-index-out-of-bounds", "string index out of bounds"}
 	E10004 = ErrorCode{"E10004", "string-empty-index", "cannot index empty string"}
 )
@@ -371,6 +377,23 @@ var (
 	E17004 = ErrorCode{"E17004", "db-corrupted", "database file is corrupted"}
 	E17005 = ErrorCode{"E17005", "db-closed", "operation on closed database"}
 )
+
+// =============================================================================
+// CRYPTO ERRORS (E15xxx) - Cryptography-specific errors
+// =============================================================================
+var (
+	E15001 = ErrorCode{"E15001", "crypto-random-failed", "cryptographic random generation failed"}
+)
+
+// =============================================================================
+// ENCODING ERRORS (E16xxx) - Encoding/decoding errors
+// =============================================================================
+var (
+	E16001 = ErrorCode{"E16001", "invalid-base64", "invalid base64 encoded input"}
+	E16002 = ErrorCode{"E16002", "invalid-hex", "invalid hexadecimal encoded input"}
+	E16003 = ErrorCode{"E16003", "invalid-url-encoding", "invalid URL encoded input"}
+)
+
 
 // =============================================================================
 // WARNINGS (W1xxx - W6xxx)

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -564,14 +564,14 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.last_index_of": {
+	"arrays.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return newError("arrays.last_index_of() takes exactly 2 arguments")
+				return newError("arrays.last_index() takes exactly 2 arguments")
 			}
 			arr, ok := args[0].(*object.Array)
 			if !ok {
-				return &object.Error{Code: "E7002", Message: "arrays.last_index_of() requires an array"}
+				return &object.Error{Code: "E7002", Message: "arrays.last_index() requires an array"}
 			}
 			for i := len(arr.Elements) - 1; i >= 0; i-- {
 				if objectsEqual(arr.Elements[i], args[1]) {

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -546,24 +546,6 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"arrays.index_of": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("arrays.index_of() takes exactly 2 arguments")
-			}
-			arr, ok := args[0].(*object.Array)
-			if !ok {
-				return &object.Error{Code: "E7002", Message: "arrays.index_of() requires an array"}
-			}
-			for i, el := range arr.Elements {
-				if objectsEqual(el, args[1]) {
-					return &object.Integer{Value: big.NewInt(int64(i))}
-				}
-			}
-			return &object.Integer{Value: big.NewInt(-1)}
-		},
-	},
-
 	"arrays.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -258,9 +258,9 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Prints values to standard output WITHOUT a newline (like C's printf)
+	// Prints values to standard output WITHOUT a newline
 	// User must explicitly add \n for newlines
-	"std.printf": {
+	"std.print": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
 				if i > 0 {
@@ -1135,10 +1135,10 @@ var StdBuiltins = map[string]*object.Builtin{
 	// See eprintln() documentation for when to use stderr vs stdout.
 	//
 	// Example:
-	//   eprintf("Loading...")
+	//   eprint("Loading...")
 	//   // do work
 	//   eprintln(" done!")  // Output: "Loading... done!"
-	"std.eprintf": {
+	"std.eprint": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
 				if i > 0 {

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -76,6 +76,20 @@ func getEZTypeName(obj object.Object) string {
 		return "nil"
 	case *object.Function:
 		return "function"
+	case *object.ReturnValue:
+		// Handle multi-return values - show tuple type
+		if len(v.Values) == 0 {
+			return "void"
+		}
+		if len(v.Values) == 1 {
+			return getEZTypeName(v.Values[0])
+		}
+		// Multiple values - show as tuple
+		types := make([]string, len(v.Values))
+		for i, val := range v.Values {
+			types[i] = getEZTypeName(val)
+		}
+		return "(" + strings.Join(types, ", ") + ")"
 	default:
 		return string(obj.Type())
 	}

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -83,6 +83,9 @@ var DBBuiltins = map[string]*object.Builtin{
 
 			dbContent, ok := result.(*object.Map)
 			if !ok {
+				if _, isArray := result.(*object.Array); isArray {
+					return &object.Error{Code: "E17004", Message: "db.open(): database file must contain a JSON object, not an array"}
+				}
 				return &object.Error{Code: "E17004", Message: "db.open(): database file is corrupted"}
 			}
 

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -236,26 +236,26 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Deletes key value pair from database
+	// Removes key value pair from database
 	// Returns (bool) - false if key does not exist
-	"db.delete": {
+	"db.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E7001", Message: "db.delete() takes exactly 2 arguments"}
+				return &object.Error{Code: "E7001", Message: "db.remove() takes exactly 2 arguments"}
 			}
 
 			db, ok := args[0].(*object.Database)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.delete() requires a Database object as first argument"}
+				return &object.Error{Code: "E7001", Message: "db.remove() requires a Database object as first argument"}
 			}
 
 			if db.IsClosed.Value {
-				return &object.Error{Code: "E17005", Message: "db.delete() cannot operate on closed database"}
+				return &object.Error{Code: "E17005", Message: "db.remove() cannot operate on closed database"}
 			}
 
 			key, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.delete() requires a String as second argument"}
+				return &object.Error{Code: "E7001", Message: "db.remove() requires a String as second argument"}
 			}
 
 			deleted := db.Store.Delete(key)
@@ -265,24 +265,24 @@ var DBBuiltins = map[string]*object.Builtin{
 
 	// Checks if key exists in database
 	// Returns (bool)
-	"db.has": {
+	"db.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return &object.Error{Code: "E7001", Message: "db.has() takes exactly 2 arguments"}
+				return &object.Error{Code: "E7001", Message: "db.contains() takes exactly 2 arguments"}
 			}
 
 			db, ok := args[0].(*object.Database)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.has() requires a Database object as first argument"}
+				return &object.Error{Code: "E7001", Message: "db.contains() requires a Database object as first argument"}
 			}
 
 			if db.IsClosed.Value {
-				return &object.Error{Code: "E17005", Message: "db.has() cannot operate on closed database"}
+				return &object.Error{Code: "E17005", Message: "db.contains() cannot operate on closed database"}
 			}
 
 			key, ok := args[1].(*object.String)
 			if !ok {
-				return &object.Error{Code: "E7001", Message: "db.has() requires a String as second argument"}
+				return &object.Error{Code: "E7001", Message: "db.contains() requires a String as second argument"}
 			}
 
 			_, exists := db.Store.Get(key)

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -64,6 +64,18 @@ var DBBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E17002", Message: "db.open(): could not read database file"}
 			}
 
+			// Handle empty files the same as non-existent files - initialize with empty map
+			if len(content) == 0 {
+				return &object.ReturnValue{Values: []object.Object{
+					&object.Database{
+						Path:     *path,
+						Store:    *object.NewMap(),
+						IsClosed: object.Boolean{Value: false},
+					},
+					object.NIL,
+				}}
+			}
+
 			result, err := decodeFromJSON(string(content))
 			if err != nil {
 				return &object.Error{Code: "E17004", Message: "db.open(): database file is corrupted"}

--- a/pkg/stdlib/db_test.go
+++ b/pkg/stdlib/db_test.go
@@ -273,18 +273,18 @@ func TestDBSetAndGet(t *testing.T) {
 }
 
 // ============================================================================
-// Database Has and Delete Tests
+// Database Contains and Remove Tests
 // ============================================================================
 
-func TestDBDeleteAndHas(t *testing.T) {
+func TestDBRemoveAndContains(t *testing.T) {
 	dir, cleanup := createTempDir(t)
 	defer cleanup()
 
 	openFn := DBBuiltins["db.open"].Fn
 	closeFn := DBBuiltins["db.close"].Fn
 	setFn := DBBuiltins["db.set"].Fn
-	delFn := DBBuiltins["db.delete"].Fn
-	hasFn := DBBuiltins["db.has"].Fn
+	removeFn := DBBuiltins["db.remove"].Fn
+	containsFn := DBBuiltins["db.contains"].Fn
 
 	path := createTempFile(t, dir, "mydb.ezdb", "{}")
 	db := getReturnValues(t, openFn(&object.String{Value: path}))[0].(*object.Database)
@@ -293,44 +293,44 @@ func TestDBDeleteAndHas(t *testing.T) {
 	val := &object.String{Value: "v"}
 	setFn(db, key, val)
 
-	t.Run("has existing key", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains existing key", func(t *testing.T) {
+		res := containsFn(db, key)
 
 		if !res.(*object.Boolean).Value {
 			t.Fatalf("expected true")
 		}
 	})
 
-	t.Run("delete existing key", func(t *testing.T) {
-		res := delFn(db, key)
+	t.Run("remove existing key", func(t *testing.T) {
+		res := removeFn(db, key)
 
 		if !res.(*object.Boolean).Value {
 			t.Fatalf("expected deletion to succeed")
 		}
 	})
 
-	t.Run("has deleted key", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains removed key", func(t *testing.T) {
+		res := containsFn(db, key)
 
 		if res.(*object.Boolean).Value {
 			t.Fatalf("expected false after deletion")
 		}
 	})
 
-	t.Run("delete on closed database", func(t *testing.T) {
+	t.Run("remove on closed database", func(t *testing.T) {
 		res := closeFn(db)
 		if isErrorObject(res) {
 			t.Fatalf("unexpected error during close")
 		}
 
-		res = delFn(db, key)
+		res = removeFn(db, key)
 		if !isErrorObject(res) {
 			t.Fatalf("expected error for operating after close, got %T", res)
 		}
 	})
 
-	t.Run("has on closed database", func(t *testing.T) {
-		res := hasFn(db, key)
+	t.Run("contains on closed database", func(t *testing.T) {
+		res := containsFn(db, key)
 		if !isErrorObject(res) {
 			t.Fatalf("expected error for operating after close, got %T", res)
 		}

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -27,18 +27,18 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.has": {
+	"maps.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return newError("maps.has() takes exactly 2 arguments (map, key)")
+				return newError("maps.contains() takes exactly 2 arguments (map, key)")
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has() requires a map as first argument"}
+				return &object.Error{Code: "E7007", Message: "maps.contains() requires a map as first argument"}
 			}
 			key := args[1]
 			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.has() key must be a hashable type (string, int, bool, char)"}
+				return &object.Error{Code: "E12001", Message: "maps.contains() key must be a hashable type (string, int, bool, char)"}
 			}
 			_, exists := m.Get(key)
 			if exists {
@@ -226,14 +226,14 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.has_value": {
+	"maps.contains_value": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
-				return newError("maps.has_value() takes exactly 2 arguments (map, value)")
+				return newError("maps.contains_value() takes exactly 2 arguments (map, value)")
 			}
 			m, ok := args[0].(*object.Map)
 			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has_value() requires a map as first argument"}
+				return &object.Error{Code: "E7007", Message: "maps.contains_value() requires a map as first argument"}
 			}
 			searchValue := args[1]
 			for _, pair := range m.Pairs {

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -97,33 +97,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"maps.delete": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("maps.delete() takes exactly 2 arguments (map, key)")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.delete() requires a map as first argument"}
-			}
-			if !m.Mutable {
-				return &object.Error{
-					Message: "cannot modify immutable map (declared as const)",
-					Code:    "E12002",
-				}
-			}
-			key := args[1]
-			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.delete() key must be a hashable type (string, int, bool, char)"}
-			}
-			deleted := m.Delete(key)
-			if deleted {
-				return object.TRUE
-			}
-			return object.FALSE
-		},
-	},
-
 	"maps.clear": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -201,28 +174,6 @@ var MapsBuiltins = map[string]*object.Builtin{
 				}
 			}
 			return result
-		},
-	},
-
-	// has_key is an alias for has
-	"maps.has_key": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("maps.has_key() takes exactly 2 arguments (map, key)")
-			}
-			m, ok := args[0].(*object.Map)
-			if !ok {
-				return &object.Error{Code: "E7007", Message: "maps.has_key() requires a map as first argument"}
-			}
-			key := args[1]
-			if _, hashOk := object.HashKey(key); !hashOk {
-				return &object.Error{Code: "E12001", Message: "maps.has_key() key must be a hashable type (string, int, bool, char)"}
-			}
-			_, exists := m.Get(key)
-			if exists {
-				return object.TRUE
-			}
-			return object.FALSE
 		},
 	},
 

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -136,13 +136,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	"os.args": {
 		Fn: func(args ...object.Object) object.Object {
 			// Use CommandLineArgs if set, otherwise fall back to os.Args
-			sourceArgs := CommandLineArgs
-			if len(sourceArgs) == 0 {
-				sourceArgs = os.Args
-			}
-
-			elements := make([]object.Object, len(sourceArgs))
-			for i, arg := range sourceArgs {
+			elements := make([]object.Object, len(CommandLineArgs))
+			for i, arg := range CommandLineArgs {
 				elements[i] = &object.String{Value: arg}
 			}
 			return &object.Array{Elements: elements, Mutable: false, ElementType: "string"}

--- a/pkg/stdlib/random.go
+++ b/pkg/stdlib/random.go
@@ -141,7 +141,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E7002", Message: "random.choice() requires an array argument"}
 			}
 			if len(arr.Elements) == 0 {
-				return &object.Error{Code: "E10002", Message: "random.choice() cannot select from empty array"}
+				return &object.Error{Code: "E9007", Message: "random.choice() cannot select from empty array"}
 			}
 			return arr.Elements[rand.Intn(len(arr.Elements))]
 		},
@@ -192,7 +192,7 @@ var RandomBuiltins = map[string]*object.Builtin{
 				return &object.Error{Code: "E10001", Message: "random.sample() count cannot be negative"}
 			}
 			if n > len(arr.Elements) {
-				return &object.Error{Code: "E10002", Message: "random.sample() count exceeds array length"}
+				return &object.Error{Code: "E9007", Message: "random.sample() count exceeds array length"}
 			}
 
 			// Create index slice and shuffle it

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -3282,12 +3282,12 @@ func TestEprintln(t *testing.T) {
 	}
 }
 
-// Test eprintf() returns nil
-func TestEprintf(t *testing.T) {
-	eprintfFn := StdBuiltins["std.eprintf"].Fn
-	result := eprintfFn(&object.String{Value: "test output"})
+// Test eprint() returns nil
+func TestEprint(t *testing.T) {
+	eprintFn := StdBuiltins["std.eprint"].Fn
+	result := eprintFn(&object.String{Value: "test output"})
 	if result != object.NIL {
-		t.Errorf("eprintf() should return nil, got %T", result)
+		t.Errorf("eprint() should return nil, got %T", result)
 	}
 }
 
@@ -3301,6 +3301,15 @@ func TestEprintlnMultipleArgs(t *testing.T) {
 	)
 	if result != object.NIL {
 		t.Errorf("eprintln() should return nil, got %T", result)
+	}
+}
+
+// Test print() returns nil
+func TestPrint(t *testing.T) {
+	printFn := StdBuiltins["std.print"].Fn
+	result := printFn(&object.String{Value: "test output"})
+	if result != object.NIL {
+		t.Errorf("print() should return nil, got %T", result)
 	}
 }
 

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -782,22 +782,6 @@ func TestArraysContains(t *testing.T) {
 	testBooleanObject(t, result, false)
 }
 
-func TestArraysIndexOf(t *testing.T) {
-	indexOfFn := ArraysBuiltins["arrays.index_of"].Fn
-
-	arr := &object.Array{Elements: []object.Object{
-		&object.Integer{Value: big.NewInt(10)},
-		&object.Integer{Value: big.NewInt(20)},
-		&object.Integer{Value: big.NewInt(30)},
-	}}
-
-	result := indexOfFn(arr, &object.Integer{Value: big.NewInt(20)})
-	testIntegerObject(t, result, 1)
-
-	result = indexOfFn(arr, &object.Integer{Value: big.NewInt(99)})
-	testIntegerObject(t, result, -1)
-}
-
 func TestArraysReverse(t *testing.T) {
 	reverseFn := ArraysBuiltins["arrays.reverse"].Fn
 
@@ -1260,19 +1244,6 @@ func TestMapsIsEmpty(t *testing.T) {
 	testBooleanObject(t, result, false)
 }
 
-func TestMapsHasKey(t *testing.T) {
-	hasKeyFn := MapsBuiltins["maps.has_key"].Fn
-
-	m := object.NewMap()
-	m.Set(&object.String{Value: "name"}, &object.String{Value: "Alice"})
-
-	result := hasKeyFn(m, &object.String{Value: "name"})
-	testBooleanObject(t, result, true)
-
-	result = hasKeyFn(m, &object.String{Value: "age"})
-	testBooleanObject(t, result, false)
-}
-
 func TestMapsGet(t *testing.T) {
 	getFn := MapsBuiltins["maps.get"].Fn
 
@@ -1296,21 +1267,6 @@ func TestMapsSet(t *testing.T) {
 		t.Error("key should exist after set")
 	}
 	testIntegerObject(t, val, 42)
-}
-
-func TestMapsDelete(t *testing.T) {
-	deleteFn := MapsBuiltins["maps.delete"].Fn
-
-	m := object.NewMap()
-	m.Mutable = true
-	m.Set(&object.String{Value: "key"}, &object.Integer{Value: big.NewInt(42)})
-
-	deleteFn(m, &object.String{Value: "key"})
-
-	_, exists := m.Get(&object.String{Value: "key"})
-	if exists {
-		t.Error("key should not exist after delete")
-	}
 }
 
 func TestMapsKeys(t *testing.T) {
@@ -1402,7 +1358,6 @@ func TestTypeErrors(t *testing.T) {
 		{"arrays.is_empty with int", ArraysBuiltins["arrays.is_empty"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}}},
 		{"arrays.pop with string", ArraysBuiltins["arrays.pop"].Fn, []object.Object{&object.String{Value: "hello"}}},
 		{"strings.upper with int", StringsBuiltins["strings.upper"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}}},
-		{"maps.has_key with int", MapsBuiltins["maps.has_key"].Fn, []object.Object{&object.Integer{Value: big.NewInt(1)}, &object.String{Value: "key"}}},
 	}
 
 	for _, tt := range tests {
@@ -4792,33 +4747,6 @@ func TestMapsValuesExtended(t *testing.T) {
 	}
 }
 
-func TestMapsHasKeyExtended(t *testing.T) {
-	hasKeyFn := MapsBuiltins["maps.has_key"].Fn
-
-	m := object.NewMap()
-	m.Set(&object.String{Value: "exists"}, &object.Integer{Value: big.NewInt(1)})
-
-	// Key exists
-	result := hasKeyFn(m, &object.String{Value: "exists"})
-	boolVal, ok := result.(*object.Boolean)
-	if !ok {
-		t.Fatalf("expected Boolean, got %T", result)
-	}
-	if !boolVal.Value {
-		t.Error("expected true, got false")
-	}
-
-	// Key doesn't exist
-	result = hasKeyFn(m, &object.String{Value: "missing"})
-	boolVal, ok = result.(*object.Boolean)
-	if !ok {
-		t.Fatalf("expected Boolean, got %T", result)
-	}
-	if boolVal.Value {
-		t.Error("expected false, got true")
-	}
-}
-
 // ============================================================================
 // Strings Module Additional Tests
 // ============================================================================
@@ -5581,28 +5509,6 @@ func TestRandomFloatRangeWithInts(t *testing.T) {
 // ============================================================================
 // Arrays Module - Error Cases (tests newError)
 // ============================================================================
-
-func TestArraysIndexOfNotFound(t *testing.T) {
-	indexOfFn := ArraysBuiltins["arrays.index_of"].Fn
-
-	arr := &object.Array{
-		Elements: []object.Object{
-			&object.Integer{Value: big.NewInt(1)},
-			&object.Integer{Value: big.NewInt(2)},
-		},
-	}
-
-	result := indexOfFn(arr, &object.Integer{Value: big.NewInt(999)})
-	intVal, ok := result.(*object.Integer)
-	if !ok {
-		t.Fatalf("expected Integer, got %T", result)
-	}
-
-	// Should return -1 when not found
-	if intVal.Value.Int64() != -1 {
-		t.Errorf("expected -1, got %d", intVal.Value.Int64())
-	}
-}
 
 func TestArraysSortError(t *testing.T) {
 	sortFn := ArraysBuiltins["arrays.sort"].Fn

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5366,7 +5366,7 @@ func (tc *TypeChecker) inferMathCallType(funcName string, args []ast.Expression)
 // inferArraysCallType infers return types for @arrays functions
 func (tc *TypeChecker) inferArraysCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "len", "index_of", "last_index_of":
+	case "len", "index_of", "last_index":
 		return "int", true
 	case "contains", "is_empty":
 		return "bool", true
@@ -5461,7 +5461,7 @@ func (tc *TypeChecker) inferTimeCallType(funcName string, args []ast.Expression)
 // inferMapsCallType infers return types for @maps functions
 func (tc *TypeChecker) inferMapsCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "is_empty", "has", "has_key", "has_value", "equals":
+	case "is_empty", "contains", "has_key", "contains_value", "equals":
 		return "bool", true
 	case "delete", "remove":
 		return "bool", true
@@ -6521,7 +6521,7 @@ func (tc *TypeChecker) isArraysFunction(name string) bool {
 		"sort_desc": true, "shuffle": true, "unique": true, "duplicates": true,
 		"flatten": true, "sum": true, "product": true, "min": true, "max": true,
 		"avg": true, "all_equal": true, "append": true, "unshift": true, "contains": true,
-		"index_of": true, "last_index_of": true, "count": true, "remove": true,
+		"index_of": true, "last_index": true, "count": true, "remove": true,
 		"remove_all": true, "fill": true, "get": true, "remove_at": true, "take": true,
 		"drop": true, "set": true, "insert": true, "slice": true, "join": true,
 		"zip": true, "concat": true, "range": true, "repeat": true,
@@ -6560,8 +6560,8 @@ func (tc *TypeChecker) isTimeFunction(name string) bool {
 func (tc *TypeChecker) isMapsFunction(name string) bool {
 	mapsFuncs := map[string]bool{
 		"len": true, "is_empty": true, "keys": true, "values": true, "clear": true,
-		"to_array": true, "invert": true, "has": true, "has_key": true, "delete": true,
-		"remove": true, "has_value": true, "get": true, "set": true, "get_or_set": true,
+		"to_array": true, "invert": true, "contains": true, "has_key": true, "delete": true,
+		"remove": true, "contains_value": true, "get": true, "set": true, "get_or_set": true,
 		"merge": true, "copy": true,
 	}
 	return mapsFuncs[name]
@@ -7119,7 +7119,7 @@ func (tc *TypeChecker) checkArraysModuleCall(funcName string, call *ast.CallExpr
 		"unshift":       {2, -1, []string{"array", "any"}, "array"},
 		"contains":      {2, 2, []string{"array", "any"}, "bool"},
 		"index_of":      {2, 2, []string{"array", "any"}, "int"},
-		"last_index_of": {2, 2, []string{"array", "any"}, "int"},
+		"last_index": {2, 2, []string{"array", "any"}, "int"},
 		"count":         {2, 2, []string{"array", "any"}, "int"},
 		"remove":        {2, 2, []string{"array", "any"}, "array"},
 		"remove_all":    {2, 2, []string{"array", "any"}, "array"},
@@ -7169,7 +7169,7 @@ func (tc *TypeChecker) checkArrayElementTypeCompatibility(funcName string, call 
 	}
 
 	switch funcName {
-	case "append", "unshift", "contains", "index_of", "last_index_of", "count", "remove", "remove_all", "fill":
+	case "append", "unshift", "contains", "index_of", "last_index", "count", "remove", "remove_all", "fill":
 		// First arg is array, remaining args are elements
 		arrayType, ok := tc.inferExpressionType(call.Arguments[0])
 		if !ok || !tc.isArrayType(arrayType) {
@@ -7253,13 +7253,13 @@ func (tc *TypeChecker) checkMapsModuleCall(funcName string, call *ast.CallExpres
 		"invert":   {1, 1, []string{"map"}, "map"},
 
 		// Map + key
-		"has":     {2, 2, []string{"map", "any"}, "bool"},
+		"contains": {2, 2, []string{"map", "any"}, "bool"},
 		"has_key": {2, 2, []string{"map", "any"}, "bool"},
 		"delete":  {2, 2, []string{"map", "any"}, "bool"},
 		"remove":  {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + value
-		"has_value": {2, 2, []string{"map", "any"}, "bool"},
+		"contains_value": {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + key + optional default
 		"get": {2, 3, []string{"map", "any", "any"}, "any"},
@@ -7307,7 +7307,7 @@ func (tc *TypeChecker) checkMapKeyValueTypeCompatibility(funcName string, call *
 	valueType := tc.extractMapValueType(mapType)
 
 	switch funcName {
-	case "has", "has_key", "delete", "remove":
+	case "contains", "has_key", "delete", "remove":
 		// Second arg is key
 		if len(call.Arguments) < 2 {
 			return
@@ -7324,7 +7324,7 @@ func (tc *TypeChecker) checkMapKeyValueTypeCompatibility(funcName string, call *
 				argLine, argCol)
 		}
 
-	case "has_value":
+	case "contains_value":
 		// Second arg is value
 		if len(call.Arguments) < 2 {
 			return

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1807,6 +1807,18 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 
 		// If no declared type, infer from value and register it
 		if declaredType == "" {
+			// Check if it's a multi-return function being assigned to a single variable
+			// Must check BEFORE type inference since inferCallType returns first type for multi-return
+			if tc.isMultiReturnCall(decl.Value) {
+				tc.addError(
+					errors.E3040,
+					"cannot assign multi-return function result to single variable; use multiple variables or discard with _",
+					decl.Name.Token.Line,
+					decl.Name.Token.Column,
+				)
+				return
+			}
+
 			inferredType, ok := tc.inferExpressionType(decl.Value)
 			if ok {
 				if inferredType == "void" {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1628,7 +1628,7 @@ func (tc *TypeChecker) checkStatement(stmt ast.Statement, expectedReturnTypes []
 		// Check that continue is inside a loop (#603)
 		if tc.loopDepth == 0 {
 			tc.addError(
-				errors.E5009,
+				errors.E5010,
 				"continue statement outside loop",
 				s.Token.Line,
 				s.Token.Column,

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4467,8 +4467,8 @@ func (tc *TypeChecker) isBuiltinConstant(name string) bool {
 func (tc *TypeChecker) isStdlibFunction(moduleName, funcName string) bool {
 	stdFuncs := map[string]map[string]bool{
 		"std": {
-			"println": true, "printf": true, "print": true,
-			"eprintln": true, "eprintf": true, "eprint": true,
+			"println": true, "print": true,
+			"eprintln": true, "eprint": true,
 			"sleep_milliseconds": true, "sleep_seconds": true, "sleep_nanoseconds": true,
 			"read_int": true, "read_float": true, "read_string": true,
 		},
@@ -5331,7 +5331,7 @@ func (tc *TypeChecker) inferModuleCallType(member *ast.MemberExpression, args []
 // inferStdCallType infers return types for @std functions
 func (tc *TypeChecker) inferStdCallType(funcName string, args []ast.Expression) (string, bool) {
 	switch funcName {
-	case "println", "print", "printf":
+	case "println", "print":
 		return "void", true
 	case "input":
 		return "string", true
@@ -6205,8 +6205,8 @@ func (tc *TypeChecker) checkDirectStdlibCall(funcName string, call *ast.CallExpr
 	// Check std module
 	if tc.hasUsingStdlibModule("std") {
 		stdFuncs := map[string]bool{
-			"println": true, "print": true, "printf": true,
-			"eprintln": true, "eprint": true, "eprintf": true,
+			"println": true, "print": true,
+			"eprintln": true, "eprint": true,
 			"sleep_milliseconds": true, "sleep_seconds": true, "sleep_nanoseconds": true,
 			"read_int": true, "read_float": true, "read_string": true,
 		}
@@ -6570,7 +6570,7 @@ func (tc *TypeChecker) isMapsFunction(name string) bool {
 // isStdFunction checks if a function name exists in the std module
 func (tc *TypeChecker) isStdFunction(name string) bool {
 	stdFuncs := map[string]bool{
-		"println": true, "print": true, "printf": true,
+		"println": true, "print": true,
 	}
 	return stdFuncs[name]
 }
@@ -6995,16 +6995,9 @@ func (tc *TypeChecker) checkStdModuleCall(funcName string, call *ast.CallExpress
 	case "println", "print":
 		// Accept any arguments (variadic, any type)
 		return
-	case "printf":
-		// First argument must be a string (format string)
-		if len(call.Arguments) < 1 {
-			tc.addError(errors.E5008, fmt.Sprintf("std.%s requires at least 1 argument (format string)", funcName), line, column)
-			return
-		}
-		argType, ok := tc.inferExpressionType(call.Arguments[0])
-		if ok && argType != "string" {
-			tc.addError(errors.E3001, fmt.Sprintf("std.%s format argument must be string, got %s", funcName, argType), line, column)
-		}
+	case "eprintln", "eprint":
+		// Accept any arguments (variadic, any type)
+		return
 	}
 }
 

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2513,6 +2513,10 @@ func (tc *TypeChecker) checkExpressionStatement(exprStmt *ast.ExpressionStatemen
 		return
 	}
 
+	// Check for bare identifiers that have no effect as statements
+	// A bare function name or type name as a statement does nothing
+	tc.checkValueExpression(exprStmt.Expression)
+
 	// Validate the entire expression tree
 	tc.checkExpression(exprStmt.Expression)
 }

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -4583,7 +4583,7 @@ do main() {
 	assertNoErrors(t, tc)
 }
 
-func TestMapDelete(t *testing.T) {
+func TestMapRemove(t *testing.T) {
 	input := `
 import @maps
 using maps
@@ -4593,8 +4593,8 @@ do takeBool(value bool) {
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp deleted = maps.delete(m, "a")
-	takeBool(deleted)
+	temp removed = maps.remove(m, "a")
+	takeBool(removed)
 }
 `
 	tc := typecheck(t, input)
@@ -6276,20 +6276,6 @@ do main() {
 	assertHasError(t, tc, errors.E3001)
 }
 
-func TestArraysIndexOfTypeMismatch(t *testing.T) {
-	input := `
-import @arrays
-using arrays
-
-do main() {
-	temp arr [float] = {1.0, 2.0, 3.0}
-	temp idx int = arrays.index_of(arr, "not a float")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
-
 func TestArraysInsertTypeMismatch(t *testing.T) {
 	input := `
 import @arrays
@@ -6449,34 +6435,6 @@ do main() {
 // ============================================================================
 // Map Key/Value Type Compatibility Tests (checkMapKeyValueTypeCompatibility)
 // ============================================================================
-
-func TestMapsHasKeyTypeMismatch(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do main() {
-	temp m map[string:int] = {"a": 1, "b": 2}
-	temp found bool = maps.has_key(m, 123)
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
-
-func TestMapsDeleteKeyTypeMismatch(t *testing.T) {
-	input := `
-import @maps
-using maps
-
-do main() {
-	temp m map[int:string] = {1: "one", 2: "two"}
-	maps.delete(m, "not an int")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
 
 func TestMapsSetKeyTypeMismatch(t *testing.T) {
 	input := `

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -1649,7 +1649,7 @@ do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
 	temp map_keys [string] = maps.keys(m)
 	temp map_values [int] = maps.values(m)
-	temp key_exists bool = maps.has(m, "a")
+	temp key_exists bool = maps.contains(m, "a")
 }
 `
 	tc := typecheck(t, input)
@@ -5022,7 +5022,7 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp hasKey bool = maps.has(m, "a")
+	temp hasKey bool = maps.contains(m, "a")
 }
 `
 	tc := typecheck(t, input)
@@ -5591,7 +5591,7 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2, "c": 3}
-	temp hasA bool = maps.has(m, "a")
+	temp hasA bool = maps.contains(m, "a")
 	temp mapLen int = maps.len(m)
 }
 `
@@ -6382,7 +6382,7 @@ using arrays
 
 do main() {
 	temp arr [int] = {1, 2, 3, 2}
-	temp idx int = arrays.last_index_of(arr, 3.14)
+	temp idx int = arrays.last_index(arr, 3.14)
 }
 `
 	tc := typecheck(t, input)
@@ -6555,7 +6555,7 @@ using maps
 
 do main() {
 	temp m map[string:int] = {"a": 1, "b": 2}
-	temp found bool = maps.has(m, "a")
+	temp found bool = maps.contains(m, "a")
 }
 `
 	tc := typecheck(t, input)

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -2730,44 +2730,45 @@ do main() {
 }
 
 // ============================================================================
-// Printf Validation Tests
+// Print Validation Tests
 // ============================================================================
 
-func TestPrintfWithFormatString(t *testing.T) {
+func TestPrintWithFormatString(t *testing.T) {
 	input := `
 do main() {
-	printf("Value: %d", 42)
+	print("Value: %d", 42)
 }
 `
 	tc := typecheck(t, input)
 	assertNoErrors(t, tc)
 }
 
-func TestPrintfNoArgsError(t *testing.T) {
+func TestPrintNoArgsError(t *testing.T) {
 	input := `
 import @std
 using std
 
 do main() {
-	std.printf()
+	std.print()
 }
 `
 	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E5008)
+	assertNoErrors(t, tc)
 }
 
-func TestPrintfNonStringFormatError(t *testing.T) {
-	input := `
-import @std
-using std
+// this is comment out because print does not support format strings
+// func TestPrintNonStringFormatError(t *testing.T) {
+// 	input := `
+// import @std
+// using std
 
-do main() {
-	std.printf(123, "value")
-}
-`
-	tc := typecheck(t, input)
-	assertHasError(t, tc, errors.E3001)
-}
+// do main() {
+// 	std.print(123, "value")
+// }
+// `
+// 	tc := typecheck(t, input)
+// 	assertHasError(t, tc, errors.E3001)
+// }
 
 // ============================================================================
 // Comparable Enum Type Tests

--- a/scripts/generate_errors_doc.go
+++ b/scripts/generate_errors_doc.go
@@ -87,6 +87,10 @@ func generateMarkdown(codes []ErrorCode) string {
 		{"E11", "Time Errors (E11xxx)", "Time-specific errors"},
 		{"E12", "Map Errors (E12xxx)", "Map-specific errors"},
 		{"E13", "JSON Errors (E13xxx)", "JSON module errors"},
+		{"E14", "HTTP Errors (E14xxx)", "HTTP request errors"},
+		{"E15", "Crypto Errors (E15xxx)", "Cryptography-specific errors"},
+		{"E16", "Encoding Errors (E16xxx)", "Encoding/decoding errors"},
+		{"E17", "DB Errors (E17xxx)", "Database operation errors"},
 		{"W1", "Code Style Warnings (W1xxx)", "Unused declarations"},
 		{"W2", "Potential Bug Warnings (W2xxx)", "Possible bugs"},
 		{"W3", "Code Quality Warnings (W3xxx)", "Code quality issues"},
@@ -130,11 +134,11 @@ func filterByPrefix(codes []ErrorCode, prefix string) []ErrorCode {
 }
 
 func matchesPrefix(code, prefix string) bool {
-	// Double-digit prefixes (E10, E11, E12, E13) produce 6-character codes (E10xxx)
+	// Double-digit prefixes (E10-E17) produce 6-character codes (E1xxxx)
 	// Single-digit prefixes (E1-E9, W1-W4) produce 5-character codes (Exxx, Wxxx)
 
-	if prefix == "E10" || prefix == "E11" || prefix == "E12" || prefix == "E13" {
-		// E10xxx codes must be 6 characters AND start with the prefix
+	if len(prefix) == 3 && prefix[0] == 'E' && prefix[1] >= '1' && prefix[2] >= '0' {
+		// E10xxx - E17xxx codes must be 6 characters AND start with the prefix
 		return len(code) == 6 && strings.HasPrefix(code, prefix)
 	}
 


### PR DESCRIPTION
Fixes : #999 
## Error Code Refactoring and Documentation Update

This PR focuses on sanitizing error codes within `pkg/errors/codes.go` and enhancing the documentation generation script to ensure all error categories are accurately represented.

---

### 🛠 Changes

#### 1. New Error Codes

Added several missing codes to improve error specificity:

* **E7035**: `env-var-not-set`
* **E15001**: `crypto-random-failed`
* **E16001, E16002, E16003**: Encoding errors (Base64, Hex, URL)

#### 2. Renames & Conflict Resolution

Resolved naming collisions and clarified ambiguous identifiers:

* **E7001**: Renamed to `stdlib-argument-mismatch` (previously collided with `wrong-argument-count`).
* **E3023**: Renamed to `enum-value-not-found` (previously `undefined-enum-value`).

#### 3. Logical Reorganization

Moved misplaced codes to their appropriate functional categories:

* **E10002** (`empty-array-selection`): Relocated from **String Errors** to **Array Errors** as **E9007**.
* Updated all internal references in `pkg/stdlib/random.go` to reflect these changes.

---

### 📜 Documentation Script Updates

Modified `scripts/generate_errors_doc.go` to support the expanded error set:

| Category | Prefix | Status |
| --- | --- | --- |
| **HTTP** | `E14` | Added |
| **Crypto** | `E15` | Added |
| **Encoding** | `E16` | Added |
| **DB** | `E17` | Added |

> [!NOTE]
> The **prefix matching logic** was also updated to ensure these new categories are correctly parsed and rendered in the final documentation.

---
