### PR TITLE
fix(typechecker): error when fixed-size array has too many elements

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -140,6 +140,7 @@ Type system errors
 | E3038 | void-type-not-allowed | 'void' is not a valid type |
 | E3039 | ensure-expects-call | ensure expects a function call |
 | E3040 | multi-return-to-single-var | cannot assign multiple return values to single variable |
+| E3041 | array-size-overflow | array literal has more elements than declared size |
 
 ## Reference Errors (E4xxx)
 
@@ -421,4 +422,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 264 error/warning codes
+**Total:** 265 error/warning codes

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -141,6 +141,7 @@ var (
 	E3038 = ErrorCode{"E3038", "void-type-not-allowed", "'void' is not a valid type"}
 	E3039 = ErrorCode{"E3039", "ensure-expects-call", "ensure expects a function call"}
 	E3040 = ErrorCode{"E3040", "multi-return-to-single-var", "cannot assign multiple return values to single variable"}
+	E3041 = ErrorCode{"E3041", "array-size-overflow", "array literal has more elements than declared size"}
 )
 
 // =============================================================================

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -1966,7 +1966,7 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 				}
 			}
 
-			// Check for fixed-size array size mismatch (W3003)
+			// Check for fixed-size array size mismatch (W3003, E3041)
 			if tc.isArrayType(declaredType) {
 				declaredSize := tc.extractArraySize(declaredType)
 				if declaredSize > 0 {
@@ -1983,6 +1983,14 @@ func (tc *TypeChecker) checkVariableDeclaration(decl *ast.VariableDeclaration) {
 									decl.Name.Token.Column,
 								)
 							}
+						} else if actualSize > declaredSize {
+							tc.addError(
+								errors.E3041,
+								fmt.Sprintf("array literal has %d element(s) but declared size is %d",
+									actualSize, declaredSize),
+								decl.Name.Token.Line,
+								decl.Name.Token.Column,
+							)
 						}
 					}
 				}

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -940,6 +940,16 @@ do main() {
 	assertHasWarning(t, tc, errors.W3003)
 }
 
+func TestFixedSizeArrayOverflow(t *testing.T) {
+	input := `
+do main() {
+	const arr [int, 3] = {0, 1, 2, 3}
+}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3041)
+}
+
 // ============================================================================
 // Control Flow Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add E3041 error for array literals that exceed their declared size
- Previously `const arr [int, 3] = {0,1,2,3}` silently passed validation

## Test plan

- [x] Added unit test `TestFixedSizeArrayOverflow`
- [x] Ran typechecker test suite - all pass

Closes #1029