### PR TITLE
fix(interpreter): infer element type for array literals

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -594,7 +594,12 @@ func Eval(node ast.Node, env *Environment) Object {
 		if len(elements) == 1 && isError(elements[0]) {
 			return elements[0]
 		}
-		return &Array{Elements: elements, Mutable: true}
+		// Infer element type from first element if available
+		elementType := ""
+		if len(elements) > 0 {
+			elementType = objectTypeToEZ(elements[0])
+		}
+		return &Array{Elements: elements, Mutable: true, ElementType: elementType}
 
 	case *ast.MapValue:
 		return evalMapLiteral(node, env)


### PR DESCRIPTION
## Summary

When evaluating array literals like `{1, 2, 3}`, infer the `ElementType` from the first element. This fixes return type checking where arrays were reported as generic `"array"` instead of typed `"[int]"`.

## Problem

Assigning a function return value to a struct field would fail:
```ez
item.lineCount = get_line_content()  // Error: return type mismatch: expected [int], got array
```

## Root Cause

In `evaluator.go`, when creating an `Array` from an array literal, `ElementType` was not being set, so `objectTypeToEZ()` returned `"array"` instead of `"[int]"`.

## Test plan

- [x] All tests pass
- [x] Manual test with struct field assignment works

Closes #1008