### PR TITLE
fix: context-aware return type inference for array literals (#1008)

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -594,7 +594,12 @@ func Eval(node ast.Node, env *Environment) Object {
 		if len(elements) == 1 && isError(elements[0]) {
 			return elements[0]
 		}
-		return &Array{Elements: elements, Mutable: true}
+		// Infer element type from first element if available
+		elementType := ""
+		if len(elements) > 0 {
+			elementType = objectTypeToEZ(elements[0])
+		}
+		return &Array{Elements: elements, Mutable: true, ElementType: elementType}
 
 	case *ast.MapValue:
 		return evalMapLiteral(node, env)

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -594,12 +594,7 @@ func Eval(node ast.Node, env *Environment) Object {
 		if len(elements) == 1 && isError(elements[0]) {
 			return elements[0]
 		}
-		// Infer element type from first element if available
-		elementType := ""
-		if len(elements) > 0 {
-			elementType = objectTypeToEZ(elements[0])
-		}
-		return &Array{Elements: elements, Mutable: true, ElementType: elementType}
+		return &Array{Elements: elements, Mutable: true}
 
 	case *ast.MapValue:
 		return evalMapLiteral(node, env)
@@ -1580,14 +1575,35 @@ func checkMutableContainerAccess(expr ast.Expression, env *Environment) bool {
 
 func evalReturn(node *ast.ReturnStatement, env *Environment) Object {
 	values := make([]Object, len(node.Values))
+	returnTypes := env.GetReturnTypes()
+
 	for i, v := range node.Values {
-		val := Eval(v, env)
+		// Get expected type for this return value if available
+		expectedType := ""
+		if i < len(returnTypes) {
+			expectedType = returnTypes[i]
+		}
+
+		// Evaluate with expected type context
+		val := evalWithExpectedType(v, expectedType, env)
 		if isError(val) {
 			return val
 		}
 		values[i] = val
 	}
 	return &ReturnValue{Values: values}
+}
+
+// evalWithExpectedType evaluates an expression with an expected type context
+// This allows literals to inherit the expected type from function signatures
+func evalWithExpectedType(expr ast.Expression, expectedType string, env *Environment) Object {
+	// Handle array literals specially when we know the expected type
+	if arrLit, ok := expr.(*ast.ArrayValue); ok && expectedType != "" && len(expectedType) > 2 && expectedType[0] == '[' {
+		return evalArrayLiteralWithType(arrLit, expectedType, env)
+	}
+
+	// For all other cases, use regular evaluation
+	return Eval(expr, env)
 }
 
 func evalEnsure(node *ast.EnsureStatement, env *Environment) Object {
@@ -3318,6 +3334,9 @@ func objectTypeToEZ(obj Object) string {
 func extendFunctionEnv(fn *Function, args []Object) *Environment {
 	env := NewEnclosedEnvironment(fn.Env)
 
+	// Set expected return types for this function's scope
+	env.SetReturnTypes(fn.ReturnTypes)
+
 	for i, param := range fn.Parameters {
 		var value Object
 		if i < len(args) {
@@ -3398,6 +3417,71 @@ func evalInterpolatedString(node *ast.InterpolatedString, env *Environment) Obje
 	}
 
 	return &String{Value: result.String(), Mutable: true}
+}
+
+// evalArrayLiteralWithType evaluates an array literal with a known expected type
+// This allows the array to inherit the correct element type from function return signatures
+func evalArrayLiteralWithType(node *ast.ArrayValue, expectedType string, env *Environment) Object {
+	// Extract element type from array type (e.g., "[u64]" -> "u64", "[int,5]" -> "int")
+	elementType := extractElementType(expectedType)
+
+	// Evaluate all elements
+	elements := make([]Object, 0, len(node.Elements))
+	for _, elemExpr := range node.Elements {
+		elem := Eval(elemExpr, env)
+		if isError(elem) {
+			return elem
+		}
+
+		// Validate element against expected type
+		if elementType != "" {
+			if err := validateElementType(elem, elementType, node.Token.Line, node.Token.Column); err != nil {
+				return err
+			}
+		}
+
+		elements = append(elements, elem)
+	}
+
+	return &Array{Elements: elements, Mutable: true, ElementType: elementType}
+}
+
+// extractElementType extracts the element type from an array type string
+// e.g., "[u64]" -> "u64", "[int,5]" -> "int", "[[u8]]" -> "[u8]"
+func extractElementType(arrayType string) string {
+	if len(arrayType) < 3 || arrayType[0] != '[' {
+		return ""
+	}
+
+	// Remove outer brackets
+	inner := arrayType[1 : len(arrayType)-1]
+
+	// Check for fixed-size array format "[type,size]"
+	if commaIdx := strings.Index(inner, ","); commaIdx != -1 {
+		return strings.TrimSpace(inner[:commaIdx])
+	}
+
+	return inner
+}
+
+// validateElementType checks if an element value is valid for the expected element type
+func validateElementType(elem Object, expectedType string, line, col int) *Error {
+	// Check for negative values to unsigned types
+	if intVal, ok := elem.(*Integer); ok && isUnsignedIntegerType(expectedType) {
+		if intVal.Value.Sign() < 0 {
+			return newErrorWithLocation("E3020", line, col,
+				"cannot use negative value %s in array of type [%s]",
+				intVal.Value.String(), expectedType)
+		}
+		// Check range for the specific unsigned type
+		if checkOverflow(intVal.Value, expectedType) {
+			return newErrorWithLocation("E3036", line, col,
+				"value %s out of range for array element type %s (valid range: %s)",
+				intVal.Value.String(), expectedType, getTypeRangeString(expectedType))
+		}
+	}
+
+	return nil
 }
 
 func evalStructValue(node *ast.StructValue, env *Environment) Object {

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -683,16 +683,17 @@ const (
 
 // Environment holds variable bindings
 type Environment struct {
-	store      map[string]Object
-	mutable    map[string]bool
-	visibility map[string]Visibility // Visibility of each binding
-	structDefs map[string]*StructDef
-	outer      *Environment
-	imports    map[string]string        // Legacy: alias -> stdlib module name
-	modules    map[string]*ModuleObject // User modules: alias -> module object
-	using      []string
-	loopDepth  int
+	store       map[string]Object
+	mutable     map[string]bool
+	visibility  map[string]Visibility // Visibility of each binding
+	structDefs  map[string]*StructDef
+	outer       *Environment
+	imports     map[string]string        // Legacy: alias -> stdlib module name
+	modules     map[string]*ModuleObject // User modules: alias -> module object
+	using       []string
+	loopDepth   int
 	ensureStack []*ast.CallExpression // Stack of ensure statements (LIFO order)
+	returnTypes []string              // Expected return types for current function
 }
 
 func NewEnvironment() *Environment {
@@ -796,6 +797,16 @@ func (e *Environment) GetUsing() []string {
 	}
 
 	return deduped
+}
+
+// SetReturnTypes sets the expected return types for the current function
+func (e *Environment) SetReturnTypes(types []string) {
+	e.returnTypes = types
+}
+
+// GetReturnTypes returns the expected return types for the current function
+func (e *Environment) GetReturnTypes() []string {
+	return e.returnTypes
 }
 
 func (e *Environment) Get(name string) (Object, bool) {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -2477,7 +2477,9 @@ func (tc *TypeChecker) checkReturnStatement(ret *ast.ReturnStatement, expectedTy
 
 	// Check each return value type
 	for i, val := range ret.Values {
-		actualType, ok := tc.inferExpressionType(val)
+		expectedType := expectedTypes[i]
+		// Use context-aware inference for better type checking
+		actualType, ok := tc.inferExpressionTypeWithContext(val, expectedType)
 		if !ok {
 			// Check if this is an undefined variable (simple identifier)
 			if label, isLabel := val.(*ast.Label); isLabel {
@@ -2503,7 +2505,6 @@ func (tc *TypeChecker) checkReturnStatement(ret *ast.ReturnStatement, expectedTy
 			continue // Can't determine type
 		}
 
-		expectedType := expectedTypes[i]
 		if !tc.typesCompatible(expectedType, actualType) {
 			tc.addError(
 				errors.E3012,
@@ -4864,6 +4865,355 @@ func (tc *TypeChecker) inferExpressionType(expr ast.Expression) (string, bool) {
 	}
 }
 
+// inferExpressionTypeWithContext infers the type of an expression with an expected type context
+// This allows literals to inherit the expected type from function signatures
+func (tc *TypeChecker) inferExpressionTypeWithContext(expr ast.Expression, expectedType string) (string, bool) {
+	if expr == nil {
+		return "", false
+	}
+
+	switch e := expr.(type) {
+	case *ast.ArrayValue:
+		// For array literals, use expected type if available
+		if expectedType != "" && tc.isArrayType(expectedType) {
+			elementType := tc.extractElementType(expectedType)
+			if elementType != "" {
+				// Validate elements against expected element type
+				for _, elem := range e.Elements {
+					// Check for negative literals going to unsigned types
+					if tc.isUnsignedIntegerType(elementType) {
+						if prefixExpr, ok := elem.(*ast.PrefixExpression); ok && prefixExpr.Operator == "-" {
+							if intLit, ok := prefixExpr.Right.(*ast.IntegerValue); ok {
+								line, column := tc.getExpressionPosition(elem)
+								tc.addError(
+									errors.E3020,
+									fmt.Sprintf("cannot use negative value -%s in array of type [%s]", intLit.Value.String(), elementType),
+									line,
+									column,
+								)
+								return "", false
+							}
+						}
+						// Also check integer literals for overflow
+						if intLit, ok := elem.(*ast.IntegerValue); ok {
+							if tc.checkIntegerOverflow(intLit.Value, elementType) {
+								line, column := tc.getExpressionPosition(elem)
+								tc.addError(
+									errors.E3036,
+									fmt.Sprintf("value %s out of range for array element type %s", intLit.Value.String(), elementType),
+									line,
+									column,
+								)
+								return "", false
+							}
+						}
+					}
+
+					elemType, ok := tc.inferExpressionType(elem)
+					if !ok {
+						return "", false
+					}
+					// Check element compatibility
+					if !tc.typesCompatible(elementType, elemType) {
+						line, column := tc.getExpressionPosition(elem)
+						tc.addError(
+							errors.E3001,
+							fmt.Sprintf("array element type mismatch: expected %s, got %s", elementType, elemType),
+							line,
+							column,
+						)
+						return "", false
+					}
+				}
+				return expectedType, true
+			}
+		}
+		// Fall back to regular inference
+		return tc.inferArrayType(e)
+
+	case *ast.MapValue:
+		// For map literals, use expected type if available
+		if expectedType != "" && tc.isMapType(expectedType) {
+			expectedKeyType, expectedValueType := tc.extractMapTypes(expectedType)
+			if expectedKeyType != "" && expectedValueType != "" {
+				// Validate all pairs against expected types
+				for _, pair := range e.Pairs {
+					keyType, ok := tc.inferExpressionType(pair.Key)
+					if !ok {
+						return "", false
+					}
+					valueType, ok := tc.inferExpressionType(pair.Value)
+					if !ok {
+						return "", false
+					}
+					// Check compatibility
+					if !tc.typesCompatible(expectedKeyType, keyType) {
+						line, column := tc.getExpressionPosition(pair.Key)
+						tc.addError(
+							errors.E3001,
+							fmt.Sprintf("map key type mismatch: expected %s, got %s", expectedKeyType, keyType),
+							line,
+							column,
+						)
+						return "", false
+					}
+					if !tc.typesCompatible(expectedValueType, valueType) {
+						line, column := tc.getExpressionPosition(pair.Value)
+						tc.addError(
+							errors.E3001,
+							fmt.Sprintf("map value type mismatch: expected %s, got %s", expectedValueType, valueType),
+							line,
+							column,
+						)
+						return "", false
+					}
+				}
+				return expectedType, true
+			}
+		}
+		// Fall back to regular inference
+		return tc.inferMapType(e)
+
+	case *ast.StructValue:
+		// For struct literals, use expected type if available
+		if expectedType != "" {
+			if structType, exists := tc.getStructTypeIncludingModules(expectedType); exists {
+				// Validate struct literal against expected type
+				tc.validateStructLiteral(e, structType)
+				return expectedType, true
+			}
+		}
+		// Fall back to regular inference
+		if e.Name != nil {
+			return e.Name.Value, true
+		}
+		return "", false
+
+	case *ast.StringValue:
+		// String literals are always string type, but validate against expected type
+		if expectedType != "" && expectedType != "string" {
+			if !tc.typesCompatible(expectedType, "string") {
+				line, column := tc.getExpressionPosition(e)
+				tc.addError(
+					errors.E3012,
+					fmt.Sprintf("return type mismatch: expected %s, got string", expectedType),
+					line,
+					column,
+				)
+				return "", false
+			}
+		}
+		return "string", true
+
+	case *ast.IntegerValue:
+		// Integer literals need validation against expected numeric type
+		if expectedType != "" && tc.isNumericType(expectedType) {
+			// Validate integer value against expected numeric type
+			if tc.isUnsignedIntegerType(expectedType) && e.Value.Sign() < 0 {
+				line, column := tc.getExpressionPosition(e)
+				tc.addError(
+					errors.E3020,
+					fmt.Sprintf("cannot use negative value %s in context expecting %s", e.Value.String(), expectedType),
+					line,
+					column,
+				)
+				return "", false
+			}
+			// Check range for specific integer types
+			if tc.checkIntegerOverflow(e.Value, expectedType) {
+				line, column := tc.getExpressionPosition(e)
+				tc.addError(
+					errors.E3036,
+					fmt.Sprintf("value %s out of range for type %s", e.Value.String(), expectedType),
+					line,
+					column,
+				)
+				return "", false
+			}
+			return expectedType, true
+		}
+		// Fall back to regular inference
+		return "int", true
+
+	case *ast.FloatValue:
+		// Float literals need validation against expected numeric type
+		if expectedType != "" && tc.isNumericType(expectedType) {
+			if tc.isIntegerType(expectedType) {
+				line, column := tc.getExpressionPosition(e)
+				tc.addError(
+					errors.E3014,
+					fmt.Sprintf("cannot assign float value to integer type %s", expectedType),
+					line,
+					column,
+				)
+				return "", false
+			}
+			return expectedType, true
+		}
+		// Fall back to regular inference
+		return "float", true
+
+	case *ast.PrefixExpression:
+		// Handle negative literals like -1 (parsed as prefix expression with -)
+		if e.Operator == "-" {
+			if intLit, ok := e.Right.(*ast.IntegerValue); ok {
+				// This is a negative integer literal
+				if expectedType != "" && tc.isNumericType(expectedType) {
+					// Check if expected type is unsigned - negative values not allowed
+					if tc.isUnsignedIntegerType(expectedType) {
+						line, column := tc.getExpressionPosition(e)
+						tc.addError(
+							errors.E3020,
+							fmt.Sprintf("cannot use negative value -%s in context expecting %s", intLit.Value.String(), expectedType),
+							line,
+							column,
+						)
+						return "", false
+					}
+					// For signed types, check range with negated value
+					negValue := new(big.Int).Neg(intLit.Value)
+					if tc.checkIntegerOverflow(negValue, expectedType) {
+						line, column := tc.getExpressionPosition(e)
+						tc.addError(
+							errors.E3036,
+							fmt.Sprintf("value -%s out of range for type %s", intLit.Value.String(), expectedType),
+							line,
+							column,
+						)
+						return "", false
+					}
+					return expectedType, true
+				}
+			}
+		}
+		// Fall back to regular inference for other prefix expressions
+		return tc.inferPrefixType(e)
+
+	default:
+		// For all other expression types, use regular inference
+		return tc.inferExpressionType(expr)
+	}
+}
+
+// extractElementType extracts the element type from an array type string
+// e.g., "[u64]" -> "u64", "[int,5]" -> "int", "[[u8]]" -> "[u8]"
+func (tc *TypeChecker) extractElementType(arrayType string) string {
+	if len(arrayType) < 3 || arrayType[0] != '[' {
+		return ""
+	}
+
+	// Remove outer brackets
+	inner := arrayType[1 : len(arrayType)-1]
+
+	// Check for fixed-size array format "[type,size]"
+	if commaIdx := strings.Index(inner, ","); commaIdx != -1 {
+		return strings.TrimSpace(inner[:commaIdx])
+	}
+
+	return inner
+}
+
+// extractMapTypes extracts key and value types from a map type string
+// e.g., "map[string:int]" -> ("string", "int")
+func (tc *TypeChecker) extractMapTypes(mapType string) (string, string) {
+	if !strings.HasPrefix(mapType, "map[") || !strings.HasSuffix(mapType, "]") {
+		return "", ""
+	}
+
+	inner := mapType[4 : len(mapType)-1] // Remove "map[" and "]"
+	if colonIdx := strings.Index(inner, ":"); colonIdx != -1 {
+		keyType := strings.TrimSpace(inner[:colonIdx])
+		valueType := strings.TrimSpace(inner[colonIdx+1:])
+		return keyType, valueType
+	}
+
+	return "", ""
+}
+
+// validateStructLiteral validates a struct literal against its expected type
+func (tc *TypeChecker) validateStructLiteral(structLit *ast.StructValue, expectedStruct *Type) {
+	// Check that all required fields are present
+	for fieldName, fieldType := range expectedStruct.Fields {
+		if fieldExpr, exists := structLit.Fields[fieldName]; exists {
+			// Validate field type
+			fieldValueType, ok := tc.inferExpressionType(fieldExpr)
+			if !ok {
+				continue
+			}
+			if !tc.typesCompatible(fieldType.Name, fieldValueType) {
+				line, column := tc.getExpressionPosition(fieldExpr)
+				tc.addError(
+					errors.E3001,
+					fmt.Sprintf("struct field '%s' type mismatch: expected %s, got %s", fieldName, fieldType.Name, fieldValueType),
+					line,
+					column,
+				)
+			}
+		} else {
+			line, column := tc.getExpressionPosition(structLit)
+			tc.addError(
+				errors.E4003,
+				fmt.Sprintf("missing required field '%s' in struct literal", fieldName),
+				line,
+				column,
+			)
+		}
+	}
+
+	// Check for extra fields
+	for fieldName := range structLit.Fields {
+		if _, exists := expectedStruct.Fields[fieldName]; !exists {
+			line, column := tc.getExpressionPosition(structLit)
+			tc.addError(
+				errors.E4003,
+				fmt.Sprintf("struct '%s' has no field '%s'", expectedStruct.Name, fieldName),
+				line,
+				column,
+			)
+		}
+	}
+}
+
+// checkIntegerOverflow checks if an integer value overflows the target type
+func (tc *TypeChecker) checkIntegerOverflow(value *big.Int, targetType string) bool {
+	switch targetType {
+	case "i8":
+		return value.Cmp(big.NewInt(-128)) < 0 || value.Cmp(big.NewInt(127)) > 0
+	case "i16":
+		return value.Cmp(big.NewInt(-32768)) < 0 || value.Cmp(big.NewInt(32767)) > 0
+	case "i32":
+		return value.Cmp(big.NewInt(-2147483648)) < 0 || value.Cmp(big.NewInt(2147483647)) > 0
+	case "i64":
+		return value.Cmp(big.NewInt(-9223372036854775808)) < 0 || value.Cmp(big.NewInt(9223372036854775807)) > 0
+	case "i128":
+		minI128 := new(big.Int)
+		minI128.SetString("-170141183460469231731687303715884105728", 10)
+		maxI128 := new(big.Int)
+		maxI128.SetString("170141183460469231731687303715884105727", 10)
+		return value.Cmp(minI128) < 0 || value.Cmp(maxI128) > 0
+	case "uint":
+		maxUint := new(big.Int)
+		maxUint.SetString("18446744073709551615", 10)
+		return value.Cmp(big.NewInt(0)) < 0 || value.Cmp(maxUint) > 0
+	case "u8":
+		return value.Cmp(big.NewInt(0)) < 0 || value.Cmp(big.NewInt(255)) > 0
+	case "u16":
+		return value.Cmp(big.NewInt(0)) < 0 || value.Cmp(big.NewInt(65535)) > 0
+	case "u32":
+		return value.Cmp(big.NewInt(0)) < 0 || value.Cmp(big.NewInt(4294967295)) > 0
+	case "u64":
+		maxU64 := new(big.Int)
+		maxU64.SetString("18446744073709551615", 10)
+		return value.Cmp(big.NewInt(0)) < 0 || value.Cmp(maxU64) > 0
+	case "u128":
+		maxU128 := new(big.Int)
+		maxU128.SetString("340282366920938463463374607431768211455", 10)
+		return value.Cmp(big.NewInt(0)) < 0 || value.Cmp(maxU128) > 0
+	default:
+		return false
+	}
+}
+
 // inferArrayType infers the type of an array literal
 func (tc *TypeChecker) inferArrayType(arr *ast.ArrayValue) (string, bool) {
 	if len(arr.Elements) == 0 {
@@ -7123,14 +7473,14 @@ func (tc *TypeChecker) checkArraysModuleCall(funcName string, call *ast.CallExpr
 		"all_equal":  {1, 1, []string{"array"}, "bool"},
 
 		// Array + value
-		"append":        {2, -1, []string{"array", "any"}, "void"},
-		"unshift":       {2, -1, []string{"array", "any"}, "array"},
-		"contains":      {2, 2, []string{"array", "any"}, "bool"},
+		"append":     {2, -1, []string{"array", "any"}, "void"},
+		"unshift":    {2, -1, []string{"array", "any"}, "array"},
+		"contains":   {2, 2, []string{"array", "any"}, "bool"},
 		"last_index": {2, 2, []string{"array", "any"}, "int"},
-		"count":         {2, 2, []string{"array", "any"}, "int"},
-		"remove":        {2, 2, []string{"array", "any"}, "array"},
-		"remove_all":    {2, 2, []string{"array", "any"}, "array"},
-		"fill":          {2, 2, []string{"array", "any"}, "array"},
+		"count":      {2, 2, []string{"array", "any"}, "int"},
+		"remove":     {2, 2, []string{"array", "any"}, "array"},
+		"remove_all": {2, 2, []string{"array", "any"}, "array"},
+		"fill":       {2, 2, []string{"array", "any"}, "array"},
 
 		// Array + int
 		"get":       {2, 2, []string{"array", "int"}, "any"},
@@ -7261,7 +7611,7 @@ func (tc *TypeChecker) checkMapsModuleCall(funcName string, call *ast.CallExpres
 
 		// Map + key
 		"contains": {2, 2, []string{"map", "any"}, "bool"},
-		"remove":  {2, 2, []string{"map", "any"}, "bool"},
+		"remove":   {2, 2, []string{"map", "any"}, "bool"},
 
 		// Map + value
 		"contains_value": {2, 2, []string{"map", "any"}, "bool"},
@@ -7889,9 +8239,9 @@ func (tc *TypeChecker) checkDBModuleCall(funcName string, call *ast.CallExpressi
 		"remove":   {2, 2, []string{"Database", "string"}, "bool"},
 		"contains": {2, 2, []string{"Database", "string"}, "bool"},
 		"keys":     {1, 1, []string{"Database"}, "[string]"},
-		"prefix": {2, 2, []string{"Database", "string"}, "[string]"},
-		"count":  {1, 1, []string{"Database"}, "int"},
-		"clear":  {1, 1, []string{"Database"}, "nil"},
+		"prefix":   {2, 2, []string{"Database", "string"}, "[string]"},
+		"count":    {1, 1, []string{"Database"}, "int"},
+		"clear":    {1, 1, []string{"Database"}, "nil"},
 	}
 
 	sig, exists := signatures[funcName]


### PR DESCRIPTION
## Summary
- Fixes issue #1008: array literals in return statements now inherit element type from function signature
- Adds runtime validation for negative values to unsigned array types
- Adds checktime (typechecker) validation for return type constraints

## Test plan
- [x] Run `./ez test_issue_1008.ez` - original reproduction case passes
- [x] Run `./ez test_return_type_inference.ez` - comprehensive test suite passes
- [x] Run `go test ./...` - all Go tests pass
- [x] Verify checktime catches negative values to unsigned types
- [x] Verify checktime catches integer overflow in return values