### PR TITLE
chore(stdlib): remove duplicate URL encoding functions from http module

### DIFF
--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -504,53 +504,6 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	"http.encode_url": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return &object.Error{Code: "E7001", Message: "http.encode_url() takes exactly 1 arguments"}
-			}
-
-			s, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Code: "E7003", Message: "http.encode_url() requires a string argument"}
-			}
-
-			encoded := url.QueryEscape(s.Value)
-
-			return &object.String{Value: encoded}
-		},
-	},
-
-	"http.decode_url": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return &object.Error{Code: "E7001", Message: "http.decode_url() takes exactly 1 arguments"}
-			}
-
-			s, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Code: "E7003", Message: "http.decode_url() requires a string argument"}
-			}
-
-			decoded, err := url.QueryUnescape(s.Value)
-			if err != nil {
-				return &object.ReturnValue{
-					Values: []object.Object{
-						&object.Nil{},
-						createHttpError("E14005", "URL decode failed"),
-					},
-				}
-			}
-
-			return &object.ReturnValue{
-				Values: []object.Object{
-					&object.String{Value: decoded},
-					&object.Nil{},
-				},
-			}
-		},
-	},
-
 	"http.build_query": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/http_test.go
+++ b/pkg/stdlib/http_test.go
@@ -209,42 +209,7 @@ func TestHTTPRequests(t *testing.T) {
 // ============================================================================
 
 func TestURLUtility(t *testing.T) {
-	encodeURLFn  := HttpBuiltins["http.encode_url"].Fn
-	decodeURLFn  := HttpBuiltins["http.decode_url"].Fn
 	buildQueryFn := HttpBuiltins["http.build_query"].Fn
-
-	t.Run("encode_url", func(t *testing.T) {
-		input := &object.String{Value: "hello world & golang"}
-
-		res := encodeURLFn(input)
-
-		str, ok := res.(*object.String)
-		if !ok {
-			t.Fatalf("expected String, got %T", res)
-		}
-
-		expected := "hello+world+%26+golang"
-		if str.Value != expected {
-			t.Fatalf("expected %q, got %q", expected, str.Value)
-		}
-	})
-
-	t.Run("decode_url", func(t *testing.T) {
-		input := &object.String{Value: "hello+world+%26+golang"}
-
-		res := decodeURLFn(input)
-		assertNoError(t, res)
-
-		str, ok := getReturnValues(t, res)[0].(*object.String)
-		if !ok {
-			t.Fatalf("expected String, got %T", res)
-		}
-
-		expected := "hello world & golang"
-		if str.Value != expected {
-			t.Fatalf("expected %q, got %q", expected, str.Value)
-		}
-	})
 
 	t.Run("build_query", func(t *testing.T) {
 		input := object.NewMap()

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -5594,8 +5594,6 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		switch funcName {
 		case "get", "post", "put", "delete", "patch", "request":
 			return []string{"HttpResponse", "error"}
-		case "decode_url":
-			return []string{"string", "error"}
 		}
 	}
 	return nil
@@ -7102,7 +7100,7 @@ func (tc *TypeChecker) isHttpFunction(name string) bool {
 
 		"request": true,
 
-		"encode_url": true, "decode_url": true, "build_query": true,
+		"build_query": true,
 
 		"json_body": true,
 	}
@@ -8387,8 +8385,6 @@ func (tc *TypeChecker) checkHttpModuleCall(funcName string, call *ast.CallExpres
 
 		"request": {5, 5, []string{"string", "string", "string", "map[string:string]", "int"}, "tuple"},
 
-		"encode_url":  {1, 1, []string{"string"}, "string"},
-		"decode_url":  {1, 1, []string{"string"}, "tuple"},
 		"build_query": {1, 1, []string{"map[string:string]"}, "string"},
 
 		"json_body": {1, 1, []string{"map"}, "string"},


### PR DESCRIPTION
## Summary
- Removes `http.encode_url` and `http.decode_url` 
- These duplicate `encoding.url_encode` and `encoding.url_decode`
- URL encoding belongs in the encoding module, not http

Fixes #998

## Test plan
- [x] `go test ./...` passes
- [x] Removed corresponding test cases