### PR TITLE
feat(stdlib):Add Unix timestamp functions and date utilities to time module (#1023)

### DIFF
--- a/integration-tests/pass/stdlib/time.ez
+++ b/integration-tests/pass/stdlib/time.ez
@@ -2,7 +2,7 @@
  * time.ez - Test @time standard library with PROPER ASSERTIONS
  */
 
-import @std, @time
+import @std, @time, @strings
 using std
 
 do main() {
@@ -209,6 +209,162 @@ do main() {
         println("  [FAIL] time.week_of_year(): expected 1-53, got ${week}")
         failed += 1
     }
+
+    // ==================== Unix timestamp conversions ====================
+    println("  -- Unix timestamp conversions --")
+
+    // Test 18: from_unix converts Unix seconds to timestamp
+    temp unix_secs int = 1577836800
+    temp ts_from_unix = time.from_unix(unix_secs)
+    if ts_from_unix == unix_secs {
+        println(" [PASS] time.from_unix(${unix_secs}) = ${ts_from_unix}")
+        passed += 1
+    } otherwise {
+        println(" [FAIL] time.from_unix: expected &{unix_secs}, got ${ts_from_unix}")
+    }
+
+    // Test 19: from_unix_ms converts Unix milliseconds to timestamp
+    temp unix_ms int = 1577836800000
+    temp ts_from_ms int = time.from_unix_ms(unix_ms)
+    if ts_from_ms == 1577836800 {
+        println("  [PASS] time.from_unix_ms(${unix_ms}) = ${ts_from_ms}")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.from_unix_ms: expected 1577836800, got ${ts_from_ms}")
+        failed += 1
+    }
+
+    // Test 20: to_unix converts timestamp to Unix seconds
+    temp test_ts int = 1577836800
+    temp unix_result int = time.to_unix(test_ts)
+    if unix_result == test_ts {
+        println("  [PASS] time.to_unix(${test_ts}) = ${unix_result}")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.to_unix: expected ${test_ts}, got ${unix_result}")
+        failed += 1
+    }
+
+    // Test 21: to_unix_ms converts timestamp to Unix milliseconds
+    temp ts_secs int = 1577836800
+    temp ms_result int = time.to_unix_ms(ts_secs)
+    // Should be milliseconds (1577836800000)
+    if ms_result == 1577836800000 {
+        println("  [PASS] time.to_unix_ms(${ts_secs}) = ${ms_result}")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.to_unix_ms: expected 1577836800000, got ${ms_result}")
+        failed += 1
+    }
+
+    // ==================== Date checks ====================
+    println("  -- Date checks --")
+
+    // Test 22: is_weekend detects weekends
+    // Jan 4, 2020 (Saturday) = 1578096000
+    temp saturday int = 1578096000
+    temp is_sat bool = time.is_weekend(saturday)
+    if is_sat {
+        println("  [PASS] time.is_weekend(${saturday}) = true (Saturday)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.is_weekend: expected true for Saturday, got false")
+        failed += 1
+    }
+
+    // Test 23: is_weekday detects weekdays
+    // Jan 6, 2020 (Monday) = 1578268800
+    temp monday int = 1578268800
+    temp is_mon bool = time.is_weekday(monday)
+    if is_mon {
+        println("  [PASS] time.is_weekday(${monday}) = true (Monday)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.is_weekday: expected true for Monday, got false")
+        failed += 1
+    }
+
+    // Test 24: is_today checks if timestamp is today
+    temp today_ts int = time.now()
+    temp is_today_result bool = time.is_today(today_ts)
+    if is_today_result {
+        println("  [PASS] time.is_today(${today_ts}) = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.is_today: expected true for now, got false")
+        failed += 1
+    }
+
+    // Test 25: is_same_day checks if two timestamps are same day
+    temp base_ts int = 1577836800  // Jan 1 2020 00:00:00
+    temp same_day_ts int = 1577836800 + 3600  // Jan 1 2020 01:00:00
+    temp same_day bool = time.is_same_day(base_ts, same_day_ts)
+    if same_day {
+        println("  [PASS] time.is_same_day(${base_ts}, ${same_day_ts}) = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.is_same_day: expected true for same day, got false")
+        failed += 1
+    }
+
+    // Test 26: is_same_day returns false for different days
+    temp next_day_ts int = 1577836800 + 86400  // Jan 2 2020 00:00:00
+    temp diff_day bool = time.is_same_day(base_ts, next_day_ts)
+    if !diff_day {
+        println("  [PASS] time.is_same_day(${base_ts}, ${next_day_ts}) = false (different days)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.is_same_day: expected false for different days, got true")
+        failed += 1
+    }
+
+    // ==================== Relative time ====================
+    println("  -- Relative time --")
+
+    // Test 27: relative time for "just now"
+    temp just_now_ts int = time.now()
+    temp relative_now string = time.relative(just_now_ts)
+    if relative_now == "just now" {
+        println("  [PASS] time.relative(${just_now_ts}) = '${relative_now}'")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.relative for now: expected 'just now', got '${relative_now}'")
+        failed += 1
+    }
+
+    // Test 28: relative time for past seconds
+    temp past_secs int = time.now() - 30
+    temp relative_secs string = time.relative(past_secs)
+    if len(relative_secs) > 0 && strings.contains(relative_secs,"seconds ago") {
+        println("  [PASS] time.relative(${past_secs}) = '${relative_secs}'")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.relative for 30s ago: got '${relative_secs}'")
+        failed += 1
+    }
+
+    // Test 29: relative time for past minutes
+    temp past_mins int = time.now() - 120  // 2 minutes ago
+    temp relative_mins string = time.relative(past_mins)
+    if len(relative_mins) > 0 && strings.contains(relative_mins,"minutes ago") {
+        println("  [PASS] time.relative(${past_mins}) = '${relative_mins}'")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.relative for 2m ago: got '${relative_mins}'")
+        failed += 1
+    }
+
+    // Test 30: relative time for future
+    temp future_secs int = time.now() + 60
+    temp relative_future string = time.relative(future_secs)
+    if len(relative_future) > 0 && strings.contains(relative_future,"in") {
+        println("  [PASS] time.relative(${future_secs}) = '${relative_future}' (future)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] time.relative for future: got '${relative_future}'")
+        failed += 1
+    }
+
 
     // Summary
     println("")

--- a/integration-tests/pass/stdlib/time.ez
+++ b/integration-tests/pass/stdlib/time.ez
@@ -220,7 +220,8 @@ do main() {
         println(" [PASS] time.from_unix(${unix_secs}) = ${ts_from_unix}")
         passed += 1
     } otherwise {
-        println(" [FAIL] time.from_unix: expected &{unix_secs}, got ${ts_from_unix}")
+        println(" [FAIL] time.from_unix: expected ${unix_secs}, got ${ts_from_unix}")
+        failed += 1
     }
 
     // Test 19: from_unix_ms converts Unix milliseconds to timestamp

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -1914,6 +1914,274 @@ func TestTimeNowMs(t *testing.T) {
 }
 
 // ============================================================================
+// Time Module Unix Functions Tests
+// ============================================================================
+
+func TestTimeFromUnix(t *testing.T) {
+	fromUnixFn := TimeBuiltins["time.from_unix"].Fn
+
+	knownUnix := big.NewInt(1577836800)
+	result := fromUnixFn(&object.Integer{Value: knownUnix})
+
+	ts, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("time.from_unix() returned %T, want Integer", result)
+	}
+
+	if ts.Value.Cmp(knownUnix) != 0 {
+		t.Errorf("time.from_unix() = %s, want %s", ts.Value.String(), knownUnix.String())
+	}
+}
+
+func TestTimeFromUnixMs(t *testing.T) {
+	fromUnixMsFn := TimeBuiltins["time.from_unix_ms"].Fn
+	knownUnixMs := big.NewInt(1577836800000)
+	result := fromUnixMsFn(&object.Integer{Value: knownUnixMs})
+
+	ts, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("time.from_unix_ms() returned %T, want Integer", result)
+	}
+	expectedSecond := big.NewInt(1577836800)
+
+	if ts.Value.Cmp(expectedSecond) != 0 {
+		t.Errorf("time.from_unix_ms() = %s, want %s", ts.Value.String(), expectedSecond.String())
+	}
+}
+
+func TestTimeToUnix(t *testing.T) {
+	toUnixFn := TimeBuiltins["time.to_unix"].Fn
+
+	knownUnix := big.NewInt(1577836800)
+	result := toUnixFn(&object.Integer{Value: knownUnix})
+
+	ts, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("time.to_unix() returned %T, want Integer", result)
+	}
+
+	if ts.Value.Cmp(knownUnix) != 0 {
+		t.Errorf("time.to_unix() = %s, want %s", ts.Value.String(), knownUnix.String())
+	}
+}
+
+func TestTimeToUnixMs(t *testing.T) {
+	toUnixMsFn := TimeBuiltins["time.to_unix_ms"].Fn
+
+	knownUnix := big.NewInt(1577836800)
+	result := toUnixMsFn(&object.Integer{Value: knownUnix})
+
+	ms, ok := result.(*object.Integer)
+	if !ok {
+		t.Fatalf("time.to_unix_ms() returned %T, want Integer", result)
+	}
+
+	expectedMs := big.NewInt(1577836800000)
+	if ms.Value.Cmp(expectedMs) != 0 {
+		t.Errorf("time.to_unix_ms() = %s, want %s", ms.Value.String(), expectedMs.String())
+	}
+}
+
+func TestTimeIsWeekend(t *testing.T) {
+	isWeekendFn := TimeBuiltins["time.is_weekend"].Fn
+
+	saturday := big.NewInt(1578096000)
+	result := isWeekendFn(&object.Integer{Value: saturday})
+
+	boolVal, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_weekend() returned %T, want Boolean", result)
+	}
+	if !boolVal.Value {
+		t.Errorf("time.is_weekend() returned false, want true")
+	}
+
+	sunday := big.NewInt(1578182400)
+	result = isWeekendFn(&object.Integer{Value: sunday})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_weekend() returned %T, want Boolean", result)
+	}
+	if !boolVal.Value {
+		t.Errorf("time.is_weekend() returned false, want true")
+	}
+
+	monday := big.NewInt(1578268800)
+	result = isWeekendFn(&object.Integer{Value: monday})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_weekend() returned %T, want Boolean", result)
+	}
+	if boolVal.Value {
+		t.Errorf("time.is_weekend() returned true, want false")
+	}
+
+}
+func TestTimeIsWeekday(t *testing.T) {
+	isWeekdayFn := TimeBuiltins["time.is_weekday"].Fn
+
+	monday := big.NewInt(1578268800)
+	result := isWeekdayFn(&object.Integer{Value: monday})
+	boolVal, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_weekday() returned %T, want Boolean", result)
+	}
+	if !boolVal.Value {
+		t.Errorf("time.is_weekday() returned false, want true")
+	}
+
+	tuesday := big.NewInt(1578355200)
+	result = isWeekdayFn(&object.Integer{Value: tuesday})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_weekday() returned %T, want Boolean", result)
+	}
+	if !boolVal.Value {
+		t.Errorf("time.is_weekday() returned false, want true")
+	}
+
+	saturday := big.NewInt(1578096000)
+	result = isWeekdayFn(&object.Integer{Value: saturday})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_weekday() returned %T, want Boolean", result)
+	}
+	if boolVal.Value {
+		t.Errorf("time.is_weekday() returned true, want false")
+	}
+}
+
+func TestTimeIsToday(t *testing.T) {
+	isTodayFn := TimeBuiltins["time.is_today"].Fn
+
+	// Test with current time - should be true
+	now := gotime.Now().Unix()
+	result := isTodayFn(&object.Integer{Value: big.NewInt(now)})
+
+	boolVal, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_today() returned %T, want Boolean", result)
+	}
+
+	if !boolVal.Value {
+		t.Errorf("time.is_today() for now = false, want true")
+	}
+
+	// Test with yesterday - should be false
+	yesterday := big.NewInt(now - 86400) // 24 hours ago
+	result = isTodayFn(&object.Integer{Value: yesterday})
+
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_today() returned %T, want Boolean", result)
+	}
+
+	if boolVal.Value {
+		t.Errorf("time.is_today() for yesterday = true, want false")
+	}
+}
+
+func TestTimeIsSameDay(t *testing.T) {
+	isSameDayFn := TimeBuiltins["time.is_same_day"].Fn
+
+	// Test same day (different times)
+	baseTime := big.NewInt(1577836800)
+	laterSameDay := big.NewInt(1577836800 + 3600)
+	result := isSameDayFn(&object.Integer{Value: baseTime}, &object.Integer{Value: laterSameDay})
+
+	boolVal, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_same_day() returned %T, want Boolean", result)
+	}
+
+	if !boolVal.Value {
+		t.Errorf("time.is_same_day() for same day = false, want true")
+	}
+
+	// Test different days
+	nextDay := big.NewInt(1577836800 + 86400)
+	result = isSameDayFn(&object.Integer{Value: baseTime}, &object.Integer{Value: nextDay})
+
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("time.is_same_day() returned %T, want Boolean", result)
+	}
+
+	if boolVal.Value {
+		t.Errorf("time.is_same_day() for different days = true, want false")
+	}
+}
+
+func TestTimeRelative(t *testing.T) {
+	relativeFn := TimeBuiltins["time.relative"].Fn
+
+	// Test "just now" - within last second
+	now := gotime.Now().Unix()
+	result := relativeFn(&object.Integer{Value: big.NewInt(now)})
+
+	strVal, ok := result.(*object.String)
+	if !ok {
+		t.Fatalf("time.relative() returned %T, want String", result)
+	}
+
+	if strVal.Value != "just now" {
+		t.Errorf("time.relative() for now = %q, want 'just now'", strVal.Value)
+	}
+
+	// Test "X seconds ago"
+	pastSeconds := big.NewInt(now - 30)
+	result = relativeFn(&object.Integer{Value: pastSeconds})
+
+	strVal, ok = result.(*object.String)
+	if !ok {
+		t.Fatalf("time.relative() returned %T, want String", result)
+	}
+
+	if !strings.Contains(strVal.Value, "seconds ago") {
+		t.Errorf("time.relative() for 30 seconds ago = %q, want 'X seconds ago'", strVal.Value)
+	}
+
+	// Test "X minutes ago"
+	pastMinutes := big.NewInt(now - 120) // 2 minutes ago
+	result = relativeFn(&object.Integer{Value: pastMinutes})
+
+	strVal, ok = result.(*object.String)
+	if !ok {
+		t.Fatalf("time.relative() returned %T, want String", result)
+	}
+
+	if !strings.Contains(strVal.Value, "minutes ago") {
+		t.Errorf("time.relative() for 2 minutes ago = %q, want 'X minutes ago'", strVal.Value)
+	}
+
+	// Test "X hours ago"
+	pastHours := big.NewInt(now - 7200) // 2 hours ago
+	result = relativeFn(&object.Integer{Value: pastHours})
+
+	strVal, ok = result.(*object.String)
+	if !ok {
+		t.Fatalf("time.relative() returned %T, want String", result)
+	}
+
+	if !strings.Contains(strVal.Value, "hours ago") {
+		t.Errorf("time.relative() for 2 hours ago = %q, want 'X hours ago'", strVal.Value)
+	}
+
+	// Test "in X seconds" (future)
+	futureSeconds := big.NewInt(now + 30)
+	result = relativeFn(&object.Integer{Value: futureSeconds})
+
+	strVal, ok = result.(*object.String)
+	if !ok {
+		t.Fatalf("time.relative() returned %T, want String", result)
+	}
+
+	if !strings.Contains(strVal.Value, "in") || !strings.Contains(strVal.Value, "seconds") {
+		t.Errorf("time.relative() for 30 seconds future = %q, want 'in X seconds'", strVal.Value)
+	}
+}
+
+// ============================================================================
 // Math Module Tests (more coverage)
 // ============================================================================
 

--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -5,6 +5,7 @@ package stdlib
 
 import (
 	"math/big"
+	"strconv"
 	"time"
 
 	"github.com/marshallburns/ez/pkg/object"
@@ -797,6 +798,199 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(604800)}
 		},
 		IsConstant: true,
+	},
+
+	"time.from_unix": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "time.from_unix() takes exactly 1 argument"}
+			}
+			secs, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.from_unix() requires an integer"}
+			}
+			t := time.Unix(secs.Value.Int64(), 0)
+			return &object.Integer{Value: big.NewInt(t.Unix())}
+		},
+	},
+
+	"time.from_unix_ms": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "time.from_unix_ms takes exactly 1 argument"}
+			}
+			ms, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.from_unix_ms requires an integer"}
+			}
+
+			t := time.UnixMilli(ms.Value.Int64())
+			return &object.Integer{Value: big.NewInt(t.Unix())}
+		},
+	},
+
+	"time.to_unix": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "time.to_unix takes extacly 1 argument"}
+			}
+			ts, ok := args[0].(*object.Integer)
+
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.to_unix require an integer timestamp"}
+			}
+			t := time.Unix(ts.Value.Int64(), 0)
+			return &object.Integer{Value: big.NewInt(t.Unix())}
+		},
+	},
+
+	"time.to_unix_ms": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "time.to_unix_ms takes extacly 1 argument"}
+			}
+
+			ts, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.to_unix_ms require an integer timestamp"}
+			}
+			t := time.Unix(ts.Value.Int64(), 0)
+			return &object.Integer{Value: big.NewInt(t.UnixMilli())}
+		},
+	},
+
+	"time.is_weekend": {
+		Fn: func(args ...object.Object) object.Object {
+			t := getTime(args)
+
+			wd := t.Weekday()
+			if wd == time.Sunday || wd == time.Saturday {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	"time.is_weekday": {
+		Fn: func(args ...object.Object) object.Object {
+			t := getTime(args)
+			wd := t.Weekday()
+			if wd >= time.Monday && wd <= time.Friday {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+
+	"time.is_today": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "time.is_today() take exactly 1 argument"}
+			}
+			ts, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.is_today() require an integer timestamp"}
+			}
+			t := time.Unix(ts.Value.Int64(), 0)
+			now := time.Now()
+
+			return &object.Boolean{Value: t.Year() == now.Year() && t.Month() == now.Month() && t.Day() == now.Day()}
+		},
+	},
+
+	"time.is_same_day": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return &object.Error{Code: "E7001", Message: "time.is_same_day() takes exactly 2 arguments"}
+			}
+			ts1, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.is_same_day() requires integer timestamps"}
+			}
+			ts2, ok := args[1].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.is_same_day() requires integer timestamps"}
+			}
+			t1 := time.Unix(ts1.Value.Int64(), 0)
+			t2 := time.Unix(ts2.Value.Int64(), 0)
+
+			return &object.Boolean{Value: t1.Year() == t2.Year() &&
+				t1.Month() == t2.Month() &&
+				t1.Day() == t2.Day()}
+		},
+	},
+
+	"time.relative": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "time.relative() takes exactly 1 argument"}
+			}
+			ts, ok := args[0].(*object.Integer)
+			if !ok {
+				return &object.Error{Code: "E7004", Message: "time.relative() requires an integer timestamp"}
+			}
+			t := time.Unix(ts.Value.Int64(), 0)
+			now := time.Now()
+			diff := now.Sub(t)
+			// Handle future times
+			if diff < 0 {
+				diff = -diff
+				if diff < time.Second {
+					return &object.String{Value: "just now"}
+				} else if diff < time.Minute {
+					secs := int(diff.Seconds())
+					return &object.String{Value: "in " + strconv.Itoa(secs) + " seconds"}
+				} else if diff < time.Hour {
+					mins := int(diff.Minutes())
+					if mins == 1 {
+						return &object.String{Value: "in 1 minute"}
+					}
+					return &object.String{Value: "in " + strconv.Itoa(mins) + " minutes"}
+
+				} else if diff < 24*time.Hour {
+					hours := int(diff.Hours())
+					if hours == 1 {
+						return &object.String{Value: "in 1 hour"}
+					}
+					return &object.String{Value: "in " + strconv.Itoa(hours) + " hours"}
+				} else {
+					days := int(diff.Hours() / 24)
+					if days == 1 {
+						return &object.String{Value: "in 1 day"}
+					}
+					return &object.String{Value: "in " + strconv.Itoa(days) + " days"}
+				}
+			}
+
+			// Handle past time
+			if diff < time.Second {
+				return &object.String{Value: "just now"}
+			} else if diff < time.Minute {
+				secs := int(diff.Seconds())
+				if secs == 1 {
+					return &object.String{Value: "1 second ago"}
+				}
+				return &object.String{Value: strconv.Itoa(secs) + " seconds ago"}
+			} else if diff < time.Hour {
+				mins := int(diff.Minutes())
+				if mins == 1 {
+					return &object.String{Value: "1 minute ago"}
+				}
+				return &object.String{Value: strconv.Itoa(mins) + " minutes ago"}
+			} else if diff < 24*time.Hour {
+				hours := int(diff.Hours())
+				if hours == 1 {
+					return &object.String{Value: "1 hour ago"}
+				}
+				return &object.String{Value: strconv.Itoa(hours) + " hours ago"}
+			} else {
+				days := int(diff.Hours() / 24)
+				if days == 1 {
+					return &object.String{Value: "1 day ago"}
+				}
+				return &object.String{Value: strconv.Itoa(days) + " days ago"}
+			}
+		},
 	},
 }
 

--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -817,11 +817,11 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.from_unix_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E7001", Message: "time.from_unix_ms takes exactly 1 argument"}
+				return &object.Error{Code: "E7001", Message: "time.from_unix_ms() takes exactly 1 argument"}
 			}
 			ms, ok := args[0].(*object.Integer)
 			if !ok {
-				return &object.Error{Code: "E7004", Message: "time.from_unix_ms requires an integer"}
+				return &object.Error{Code: "E7004", Message: "time.from_unix_ms() requires an integer"}
 			}
 
 			t := time.UnixMilli(ms.Value.Int64())
@@ -832,12 +832,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.to_unix": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E7001", Message: "time.to_unix takes extacly 1 argument"}
+				return &object.Error{Code: "E7001", Message: "time.to_unix() takes exactly 1 argument"}
 			}
 			ts, ok := args[0].(*object.Integer)
 
 			if !ok {
-				return &object.Error{Code: "E7004", Message: "time.to_unix require an integer timestamp"}
+				return &object.Error{Code: "E7004", Message: "time.to_unix() requires an integer timestamp"}
 			}
 			t := time.Unix(ts.Value.Int64(), 0)
 			return &object.Integer{Value: big.NewInt(t.Unix())}
@@ -847,12 +847,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.to_unix_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E7001", Message: "time.to_unix_ms takes extacly 1 argument"}
+				return &object.Error{Code: "E7001", Message: "time.to_unix_ms() takes exactly 1 argument"}
 			}
 
 			ts, ok := args[0].(*object.Integer)
 			if !ok {
-				return &object.Error{Code: "E7004", Message: "time.to_unix_ms require an integer timestamp"}
+				return &object.Error{Code: "E7004", Message: "time.to_unix_ms() requires an integer timestamp"}
 			}
 			t := time.Unix(ts.Value.Int64(), 0)
 			return &object.Integer{Value: big.NewInt(t.UnixMilli())}
@@ -885,11 +885,11 @@ var TimeBuiltins = map[string]*object.Builtin{
 	"time.is_today": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
-				return &object.Error{Code: "E7001", Message: "time.is_today() take exactly 1 argument"}
+				return &object.Error{Code: "E7001", Message: "time.is_today() takes exactly 1 argument"}
 			}
 			ts, ok := args[0].(*object.Integer)
 			if !ok {
-				return &object.Error{Code: "E7004", Message: "time.is_today() require an integer timestamp"}
+				return &object.Error{Code: "E7004", Message: "time.is_today() requires an integer timestamp"}
 			}
 			t := time.Unix(ts.Value.Int64(), 0)
 			now := time.Now()

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -6964,7 +6964,9 @@ func (tc *TypeChecker) isTimeFunction(name string) bool {
 		"parse": true, "sleep": true, "sleep_ms": true, "add_seconds": true,
 		"add_minutes": true, "add_hours": true, "add_days": true, "diff": true,
 		"diff_days": true, "is_before": true, "is_after": true, "make": true,
-		"days_in_month": true, "elapsed_ms": true,
+		"days_in_month": true, "elapsed_ms": true, "from_unix": true, "from_unix_ms": true,
+		"to_unix": true, "to_unix_ms": true, "is_weekend": true, "is_weekday": true, "is_today": true,
+		"is_same_day": true, "relative": true,
 	}
 	return timeFuncs[name]
 }
@@ -7922,6 +7924,21 @@ func (tc *TypeChecker) checkTimeModuleCall(funcName string, call *ast.CallExpres
 
 		// elapsed_ms
 		"elapsed_ms": {1, 1, []string{"int"}, "float"},
+
+		// Unix conversions
+		"from_unix":    {1, 1, []string{"int"}, "int"},
+		"from_unix_ms": {1, 1, []string{"int"}, "int"},
+		"to_unix":      {1, 1, []string{"int"}, "int"},
+		"to_unix_ms":   {1, 1, []string{"int"}, "int"},
+
+		// Date checks
+		"is_weekend":  {1, 1, []string{"int"}, "bool"},
+		"is_weekday":  {1, 1, []string{"int"}, "bool"},
+		"is_today":    {1, 1, []string{"int"}, "bool"},
+		"is_same_day": {2, 2, []string{"int", "int"}, "bool"},
+
+		// Relative time
+		"relative": {1, 1, []string{"int"}, "string"},
 	}
 
 	sig, exists := signatures[funcName]


### PR DESCRIPTION
Fixes #1023

This PR adds the missing Unix timestamp conversion functions and date utilities to the time module:

**Unix Timestamp Functions:**
- `time.from_unix(seconds)` - Create time from Unix timestamp (seconds)
- `time.from_unix_ms(milliseconds)` - Create time from Unix timestamp (milliseconds)
- `time.to_unix(timestamp)` - Convert time to Unix timestamp (seconds)
- `time.to_unix_ms(timestamp)` - Convert time to Unix timestamp (milliseconds)

**Date Check Functions:**
- `time.is_weekend(timestamp)` - Check if date falls on Saturday or Sunday
- `time.is_weekday(timestamp)` - Check if date falls on Monday-Friday
- `time.is_today(timestamp)` - Check if date is today
- `time.is_same_day(t1, t2)` - Check if two times are on same day

**Human-Readable Relative Time:**
- `time.relative(timestamp)` - Format time relative to now (e.g., "2 hours ago", "in 3 days", "just now")

**Testing:**
- Added Go unit tests in `pkg/stdlib/stdlib_test.go`
- Added EZ integration tests in `integration-tests/pass/stdlib/time.ez`
- All 30 tests passing ✅

**Example Usage:**
```ez
import @time

// Parse Unix timestamp from API
temp api_timestamp = 1705334400
temp t = time.from_unix(api_timestamp)

// Convert to Unix for API request
temp now = time.now()
temp unix_now = time.to_unix(now)

// Check if weekend
if time.is_weekend(time.now()) {
    println("It's the weekend!")
}

// Relative time for UI
temp posted_at = time.parse("2024-01-14T10:00:00Z", "YYYY-MM-DDTHH:mm:ssZ")
println(time.relative(posted_at))  // "2 hours ago"
```