### PR TITLE
feat(language): add map support for in/not_in operators

### DIFF
--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -141,6 +141,66 @@ do main() {
         failed += 1
     }
 
+    // ==================== IN/NOT_IN OPERATORS ====================
+    println("  -- in/not_in Operators --")
+
+    temp test_map map[string:int] = {"foo": 1, "bar": 2, "baz": 3}
+
+    // Test 12: 'in' with key that exists
+    if "foo" in test_map {
+        println("  [PASS] \"foo\" in test_map = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] \"foo\" in test_map: expected true")
+        failed += 1
+    }
+
+    // Test 13: 'in' with key that doesn't exist
+    if "missing" in test_map {
+        println("  [FAIL] \"missing\" in test_map: expected false")
+        failed += 1
+    } otherwise {
+        println("  [PASS] \"missing\" in test_map = false")
+        passed += 1
+    }
+
+    // Test 14: 'not_in' with key that doesn't exist
+    if "missing" not_in test_map {
+        println("  [PASS] \"missing\" not_in test_map = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] \"missing\" not_in test_map: expected true")
+        failed += 1
+    }
+
+    // Test 15: 'not_in' with key that exists
+    if "bar" not_in test_map {
+        println("  [FAIL] \"bar\" not_in test_map: expected false")
+        failed += 1
+    } otherwise {
+        println("  [PASS] \"bar\" not_in test_map = false")
+        passed += 1
+    }
+
+    // Test 16: 'in' with int keys
+    temp int_map map[int:string] = {1: "one", 2: "two", 3: "three"}
+    if 2 in int_map {
+        println("  [PASS] 2 in int_map = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] 2 in int_map: expected true")
+        failed += 1
+    }
+
+    // Test 17: 'not_in' with int keys
+    if 99 not_in int_map {
+        println("  [PASS] 99 not_in int_map = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] 99 not_in int_map: expected true")
+        failed += 1
+    }
+
     // Summary
     println("")
     println("Results: ${passed} passed, ${failed} failed")

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2656,11 +2656,20 @@ func evalInOperator(left, right Object, line, col int) Object {
 		return FALSE
 	}
 
+	// Handle map key membership check
+	if m, ok := right.(*Map); ok {
+		_, exists := m.Get(left)
+		if exists {
+			return TRUE
+		}
+		return FALSE
+	}
+
 	// Handle array membership check
 	arr, ok := right.(*Array)
 	if !ok {
 		return newErrorWithLocation("E3014", line, col,
-			"right operand of 'in' must be array or range, got %s", objectTypeToEZ(right))
+			"right operand of 'in' must be array, map, or range, got %s", objectTypeToEZ(right))
 	}
 
 	for _, elem := range arr.Elements {

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -3129,12 +3129,12 @@ func (tc *TypeChecker) checkInfixExpression(infix *ast.InfixExpression) {
 			)
 		}
 
-	case "in", "!in":
-		// Right side must be array or string
-		if !tc.isArrayType(rightType) && rightType != "string" {
+	case "in", "!in", "not_in":
+		// Right side must be array, string, or map
+		if !tc.isArrayType(rightType) && rightType != "string" && !tc.isMapType(rightType) {
 			tc.addError(
 				errors.E3002,
-				fmt.Sprintf("invalid operand for '%s': %s (expected array or string)", infix.Operator, rightType),
+				fmt.Sprintf("invalid operand for '%s': %s (expected array, string, or map)", infix.Operator, rightType),
 				line,
 				column,
 			)


### PR DESCRIPTION
## Summary
- Add support for using `in` and `not_in` operators with maps to check for key existence

## Changes
- Update typechecker to accept maps for `in`/`not_in` operators
- Update evaluator to check map key membership via `Map.Get()`
- Add integration tests for `in`/`not_in` with string and int key maps

## Example
```ez
temp myMap map[string:int] = {"a": 1, "b": 2}

if "a" in myMap {
    println("key exists")
}

if "z" not_in myMap {
    println("key missing")
}
```

Fixes #1007