### PR TITLE
fix(parser): allow nil as function return type

### DIFF
--- a/integration-tests/pass/core/functions.ez
+++ b/integration-tests/pass/core/functions.ez
@@ -212,6 +212,29 @@ do main() {
         failed += 1
     }
 
+    // ==================== NIL RETURN TYPE ====================
+    println("  -- Nil Return Type --")
+
+    // Test: function with -> nil return type
+    temp nilResult = returnsNil()
+    if nilResult == nil {
+        println("  [PASS] returnsNil() -> nil returns nil")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] returnsNil(): expected nil")
+        failed += 1
+    }
+
+    // Test: function with multiple return types including nil
+    temp val, err = getValueOrNil()
+    if val == 42 && err == nil {
+        println("  [PASS] getValueOrNil() -> (int, nil) works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] getValueOrNil(): val=${val}, err=${err}")
+        failed += 1
+    }
+
     // Summary
     println("")
     println("Results: ${passed} passed, ${failed} failed")
@@ -307,4 +330,12 @@ do add_score(&state GameState, points int) {
 
 do lose_life(&state GameState) {
     state.lives = state.lives - 1
+}
+
+do returnsNil() -> nil {
+    return nil
+}
+
+do getValueOrNil() -> (int, nil) {
+    return 42, nil
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1632,6 +1632,9 @@ func (p *Parser) parseFunctionDeclarationWithAttrs(attrs []*Attribute) *Function
 				return nil
 			}
 			stmt.ReturnTypes = []string{typeName}
+		} else if p.currentTokenMatches(NIL) {
+			// Single return type: nil
+			stmt.ReturnTypes = []string{"nil"}
 		} else {
 			// Invalid token after arrow
 			msg := fmt.Sprintf("expected return type after '->', got %s instead", p.currentToken.Type)
@@ -1871,13 +1874,16 @@ func (p *Parser) parseReturnTypes() []string {
 	p.nextToken() // move past (
 
 	for !p.currentTokenMatches(RPAREN) {
-		// Parse type name (can be IDENT or array type starting with LBRACKET)
+		// Parse type name (can be IDENT, array type starting with LBRACKET, or nil)
 		if p.currentTokenMatches(IDENT) || p.currentTokenMatches(LBRACKET) {
 			typeName := p.parseTypeName()
 			if typeName == "" {
 				return nil
 			}
 			types = append(types, typeName)
+		} else if p.currentTokenMatches(NIL) {
+			// nil return type
+			types = append(types, "nil")
 		} else {
 			msg := fmt.Sprintf("expected type name in return types, got %s", p.currentToken.Type)
 			p.addEZError(errors.E2002, msg, p.currentToken)


### PR DESCRIPTION
## Summary
- Add support for declaring `nil` as a return type annotation for functions

## Changes
- Handle NIL token in `parseFunctionDeclaration()` for single return types (`-> nil`)
- Handle NIL token in `parseReturnTypes()` for multiple return types (`-> (int, nil)`)
- Add integration tests

## Example
```ez
do returnsNil() -> nil {
    return nil
}

do getValue() -> (int, nil) {
    return 42, nil
}
```

Fixes #1044

Co-Authored-By: TechLateef <techlateef@gmail.com>