### PR TITLE
fix(typechecker): add E3041 check for global fixed-size array overflow

### DIFF
--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -950,6 +950,15 @@ do main() {
 	assertHasError(t, tc, errors.E3041)
 }
 
+func TestFixedSizeArrayOverflowGlobal(t *testing.T) {
+	input := `
+const arr [int, 3] = {0, 1, 2, 3}
+do main() {}
+`
+	tc := typecheck(t, input)
+	assertHasError(t, tc, errors.E3041)
+}
+
 // ============================================================================
 // Control Flow Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add E3041/W3003 array size validation to `checkGlobalVariableDeclaration`
- The fix from PR #1030 only applied to local variable declarations
- File-level fixed-size arrays can now properly detect overflow

## Test plan

- [x] Added `TestFixedSizeArrayOverflowGlobal` unit test
- [x] Ran typechecker test suite - all pass

Closes #1058