### PR TITLE
Fix nested mutability propagation (#1065 and #1066)

### DIFF
--- a/integration-tests/pass/core/arrays.ez
+++ b/integration-tests/pass/core/arrays.ez
@@ -75,6 +75,24 @@ do main() {
         failed += 1
     }
 
+    // ==================== NESTED MUTABILITY ====================
+    println("  -- Nested Mutability (Array in Struct in Array) --")
+
+    const Box struct {
+        values [int]
+    }
+
+    // Test 18: modify array inside struct inside array (Issue #1066)
+    temp boxes = {Box{values: {1, 2}}, Box{values: {3, 4}}}
+    boxes[0].values[1] = 99
+    if boxes[0].values[1] == 99 {
+        println("  [PASS] nested array modification: boxes[0].values[1] = 99")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] nested array modification: expected 99, got ${boxes[0].values[1]}")
+        failed += 1
+    }
+
     // ==================== FIXED SIZE ARRAYS ====================
     println("  -- Fixed Size Arrays --")
 

--- a/integration-tests/pass/core/arrays.ez
+++ b/integration-tests/pass/core/arrays.ez
@@ -5,6 +5,10 @@
 import @std, @arrays
 using std
 
+const Box struct {
+    values [int]
+}
+
 do main() {
     println("=== Arrays Test ===")
     temp passed int = 0
@@ -77,10 +81,6 @@ do main() {
 
     // ==================== NESTED MUTABILITY ====================
     println("  -- Nested Mutability (Array in Struct in Array) --")
-
-    const Box struct {
-        values [int]
-    }
 
     // Test 18: modify array inside struct inside array (Issue #1066)
     temp boxes = {Box{values: {1, 2}}, Box{values: {3, 4}}}

--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -2,8 +2,12 @@
  * maps.ez - Test map types and operations
  */
 
-import @std, @maps
+import @std, @maps, @arrays
 using std
+
+const Entry struct {
+    items [int]
+}
 
 do main() {
     println("=== Maps Test ===")
@@ -203,10 +207,6 @@ do main() {
 
     // ==================== NESTED MUTABILITY ====================
     println("  -- Nested Mutability (Array in Struct in Map) --")
-
-    const Entry struct {
-        items [int]
-    }
 
     // Test 18: modify array inside struct inside map (Issue #1065)
     temp m2 map[string:Entry] = {"key": Entry{items: {1, 2, 3}}}

--- a/integration-tests/pass/core/maps.ez
+++ b/integration-tests/pass/core/maps.ez
@@ -201,6 +201,24 @@ do main() {
         failed += 1
     }
 
+    // ==================== NESTED MUTABILITY ====================
+    println("  -- Nested Mutability (Array in Struct in Map) --")
+
+    const Entry struct {
+        items [int]
+    }
+
+    // Test 18: modify array inside struct inside map (Issue #1065)
+    temp m2 map[string:Entry] = {"key": Entry{items: {1, 2, 3}}}
+    arrays.append(m2["key"].items, 4)
+    if len(m2["key"].items) == 4 && m2["key"].items[3] == 4 {
+        println("  [PASS] nested array modification: arrays.append works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] nested array modification: expected length 4, got ${len(m2[\"key\"].items)}")
+        failed += 1
+    }
+
     // Summary
     println("")
     println("Results: ${passed} passed, ${failed} failed")

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -683,6 +683,18 @@ func Eval(node ast.Node, env *Environment) Object {
 				return newErrorWithLocation("E12003", node.Token.Line, node.Token.Column,
 					"key %s not found in map%s", index.Inspect(), keyList)
 			}
+			switch v := value.(type) {
+			case *Struct:
+				v.Mutable = mapObj.Mutable
+
+			case *Array:
+				v.Mutable = mapObj.Mutable
+
+			case *Map:
+				v.Mutable = mapObj.Mutable
+
+			}
+
 			return value
 		}
 
@@ -707,7 +719,19 @@ func Eval(node ast.Node, env *Environment) Object {
 					"index out of bounds: attempted to access index %s, but valid range is 0-%d",
 					idx.Value.String(), arrLen.Int64()-1)
 			}
-			return obj.Elements[idx.Value.Int64()]
+			value := obj.Elements[idx.Value.Int64()]
+
+			switch v := value.(type) {
+			case *Struct:
+				v.Mutable = obj.Mutable
+
+			case *Array:
+				v.Mutable = obj.Mutable
+
+			case *Map:
+				v.Mutable = obj.Mutable
+			}
+			return value
 
 		case *String:
 			// Convert to runes for proper UTF-8 character indexing

--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -53,7 +53,7 @@ var ArraysBuiltins = map[string]*object.Builtin{
 			if !arr.Mutable {
 				return &object.Error{
 					Message: "cannot modify immutable array (declared as const)",
-					Code:    "E4005",
+					Code:    "E5007",
 				}
 			}
 			if err := checkIterating(arr, "arrays.append"); err != nil {


### PR DESCRIPTION
## Description

This PR fixes nested mutability propagation issues where arrays nested inside structs (which are inside maps or arrays) were incorrectly treated as immutable.

## Changes

- **Mutability propagation**: Modified `evalIndexExpression` to propagate mutability from containers (maps/arrays) to nested values (structs/arrays/maps) when accessing via index expressions
- **Error code fix**: Changed error code in `arrays.append` from E4005 to E5007 to match the correct error category
- **Integration tests**: Added tests for both scenarios:
  - Array inside struct inside map (Issue #1065)
  - Array inside struct inside array (Issue #1066)
- **Test fixes**: Moved struct definitions to file level (structs cannot be declared inside functions) and added missing `@arrays` import

## Related Issues

Fixes #1065
Fixes #1066

## Testing

All integration tests pass successfully. The nested mutability tests verify that:
- `arrays.append()` works on arrays nested in structs inside maps
- Direct index assignment works on arrays nested in structs inside arrays