### PR TITLE
Fix global variable declaration missing validation checks (#1059)

### DIFF
--- a/integration-tests/fail/errors/E3001_global_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3001_global_type_mismatch.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E3001 - type-mismatch (global variable)
+ * Expected: "type mismatch" or "cannot assign"
+ * Tests that global variable declarations check type compatibility
+ */
+
+module test
+
+// Global variable with type mismatch - should trigger E3001
+const badGlobal int = "hello"
+
+do main() {
+}

--- a/integration-tests/fail/errors/E3018_global_scalar_to_array.ez
+++ b/integration-tests/fail/errors/E3018_global_scalar_to_array.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E3018 - scalar-to-array-assignment (global variable)
+ * Expected: "array type requires" or "cannot assign"
+ * Tests that global array declarations require array literals
+ */
+
+module test
+
+// Global array with scalar value - should trigger E3018
+const badArray [int] = 42
+
+do main() {
+}

--- a/integration-tests/fail/errors/E3025_global_byte_out_of_range.ez
+++ b/integration-tests/fail/errors/E3025_global_byte_out_of_range.ez
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E3025 - byte-value-out-of-range (global variable)
+ * Expected: "byte" or "0 and 255"
+ * Tests that global byte declarations check value range
+ */
+
+module test
+
+// Global byte with out of range value - should trigger E3025
+const badByte byte = 300
+
+do main() {
+}


### PR DESCRIPTION
## Summary
- Adds all missing validation checks to `checkGlobalVariableDeclaration` that were previously only present in local variable checking
- Adds integration tests for global variable type checking

## Changes
- **Shadowing checks**: E4012 (struct/enum), E4013 (function), E4014 (module), E4015 (used module function)
- **Type validation**: void type (E3038), float-based enum as map key (E3029)
- **Value validation**: type mismatch (E3001), scalar to array (E3018), byte range (E3025), sized integer ranges, byte array elements (E3026), multi-return assignment (E3040)
- **Expression validation**: calls `checkValueExpression` and `checkExpression`

## Test plan
- [x] All typechecker unit tests pass
- [x] Integration tests pass
- [x] New fail tests verify global variable errors are caught

Fixes #1059