### PR TITLE
test: add missing integration tests for error and warning codes

### DIFF
--- a/integration-tests/fail/errors/E13001_json_syntax_error.ez
+++ b/integration-tests/fail/errors/E13001_json_syntax_error.ez
@@ -1,0 +1,18 @@
+/*
+ * Error Test: E13001 - json-syntax-error
+ * Expected: "invalid JSON syntax"
+ * Note: This error is returned in tuple, so we use panic to propagate it
+ */
+
+import @json
+
+const Dummy struct {
+    x int
+}
+
+do main() {
+    temp result Dummy, err error = json.decode("{ invalid json }", Dummy)
+    if err != nil {
+        panic("${err}")
+    }
+}

--- a/integration-tests/fail/errors/E13003_json_invalid_map_key.ez
+++ b/integration-tests/fail/errors/E13003_json_invalid_map_key.ez
@@ -1,0 +1,16 @@
+/*
+ * Error Test: E13003 - json-invalid-map-key
+ * Expected: "JSON object keys must be strings"
+ */
+
+import @json
+
+do main() {
+    // Create a map with integer keys (invalid for JSON)
+    temp m map[int:string] = {1: "one", 2: "two"}
+
+    temp result string, err error = json.encode(m)
+    if err != nil {
+        panic("${err}")
+    }
+}

--- a/integration-tests/fail/errors/E13004_json_decode_requires_type.ez
+++ b/integration-tests/fail/errors/E13004_json_decode_requires_type.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E13004 - json-decode-requires-type
+ * Expected: "json.decode() requires a type argument"
+ */
+
+import @json
+
+do main() {
+    // json.decode with typed result requires type argument
+    temp result int, err error = json.decode("{\"x\": 1}")
+}

--- a/integration-tests/fail/errors/E14001_http_invalid_url.ez
+++ b/integration-tests/fail/errors/E14001_http_invalid_url.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E14001 - http-invalid-url
+ * Expected: "invalid url"
+ */
+
+import @http
+
+do main() {
+    // Invalid URL format
+    temp resp, err = http.get("not a valid url")
+}

--- a/integration-tests/fail/errors/E14004_http_invalid_method.ez
+++ b/integration-tests/fail/errors/E14004_http_invalid_method.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: E14004 - http-invalid-method
+ * Expected: "invalid HTTP method"
+ */
+
+import @http
+
+do main() {
+    // Invalid HTTP method
+    temp resp, err = http.request("INVALID", "http://example.com", nil, nil)
+}

--- a/integration-tests/fail/errors/E16001_invalid_base64.ez
+++ b/integration-tests/fail/errors/E16001_invalid_base64.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E16001 - invalid-base64
+ * Expected: "invalid base64"
+ */
+
+import @encoding
+
+do main() {
+    // Invalid base64 string (contains invalid characters)
+    temp result string, err error = encoding.base64_decode("not!valid@base64")
+    if err != nil {
+        panic("${err}")
+    }
+}

--- a/integration-tests/fail/errors/E16002_invalid_hex.ez
+++ b/integration-tests/fail/errors/E16002_invalid_hex.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E16002 - invalid-hex
+ * Expected: "invalid hex"
+ */
+
+import @encoding
+
+do main() {
+    // Invalid hex string (contains non-hex characters)
+    temp result string, err error = encoding.hex_decode("GHIJ")
+    if err != nil {
+        panic("${err}")
+    }
+}

--- a/integration-tests/fail/errors/E16003_invalid_url_encoding.ez
+++ b/integration-tests/fail/errors/E16003_invalid_url_encoding.ez
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E16003 - invalid-url-encoding
+ * Expected: "invalid URL encoding"
+ */
+
+import @encoding
+
+do main() {
+    // Invalid URL encoding (incomplete percent sequence)
+    temp result string, err error = encoding.url_decode("%ZZ")
+    if err != nil {
+        panic("${err}")
+    }
+}

--- a/integration-tests/pass/warnings/W1002_unused_import.ez
+++ b/integration-tests/pass/warnings/W1002_unused_import.ez
@@ -1,0 +1,11 @@
+/*
+ * Warning Test: W1002 - unused-import
+ * Expected: warning about module imported but not used
+ */
+
+import @std
+import @math  // This import is never used
+
+do main() {
+    std.println("hello")
+}

--- a/integration-tests/pass/warnings/W2007_shadows_global.ez
+++ b/integration-tests/pass/warnings/W2007_shadows_global.ez
@@ -1,0 +1,14 @@
+/*
+ * Warning Test: W2007 - shadows-global
+ * Expected: warning about variable shadowing a global
+ */
+
+import @std
+using std
+
+const MAX int = 100
+
+do main() {
+    temp MAX int = 50  // Shadows the global constant MAX
+    println(MAX)
+}

--- a/integration-tests/pass/warnings/W2009_nil_dereference_potential.ez
+++ b/integration-tests/pass/warnings/W2009_nil_dereference_potential.ez
@@ -1,0 +1,17 @@
+/*
+ * Warning Test: W2009 - nil-dereference-potential
+ * Expected: warning about accessing member on error type which may be nil
+ */
+
+import @std, @json
+using std
+
+const Person struct {
+    name string
+}
+
+do main() {
+    temp p Person, err error = json.decode("{\"name\": \"Alice\"}", Person)
+    // Accessing .code on error which may be nil
+    println(err.code)
+}

--- a/integration-tests/pass/warnings/W3003_array_size_mismatch.ez
+++ b/integration-tests/pass/warnings/W3003_array_size_mismatch.ez
@@ -1,0 +1,13 @@
+/*
+ * Warning Test: W3003 - array-size-mismatch
+ * Expected: warning about fixed-size array not fully initialized
+ */
+
+import @std
+using std
+
+do main() {
+    // Declare array with size 5 but only provide 3 elements
+    temp arr [int, 5] = {1, 2, 3}
+    println(arr)
+}


### PR DESCRIPTION
## Summary
Adds integration tests for previously untested error and warning codes.

### New Error Tests (8 tests)
- E13001 - json-syntax-error
- E13003 - json-invalid-map-key
- E13004 - json-decode-requires-type
- E14001 - http-invalid-url
- E14004 - http-invalid-method
- E16001 - invalid-base64
- E16002 - invalid-hex
- E16003 - invalid-url-encoding

### New Warning Tests (4 tests)
- W1002 - unused-import
- W2007 - shadows-global
- W2009 - nil-dereference-potential
- W3003 - array-size-mismatch

### Notes
Some error/warning codes could not be tested:
- E13002: Cannot be triggered (functions can't be passed as values)
- E15001: System-level crypto failure - not reliably testable
- E14002, E14003: Network errors - require external dependencies
- W1001, W1003, W1004, etc.: Not yet implemented in typechecker

Closes #1079

## Test plan
- [x] All new fail tests exit with error code
- [x] All new warning tests produce expected warning codes
- [x] Full integration test suite passes (except pre-existing flaky time test)