### PR TITLE
fix: `const ref()` now creates read-only view of referenced value

### DIFF
--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -240,8 +240,9 @@ func (fh *FileHandle) Inspect() string {
 // Reference represents a reference to a variable in another environment
 // Used for mutable (&) parameters to allow modifications to persist to the caller
 type Reference struct {
-	Env  *Environment // The environment where the original variable lives
-	Name string       // The variable name in that environment
+	Env     *Environment // The environment where the original variable lives
+	Name    string       // The variable name in that environment
+	Mutable bool         // Whether this reference allows modification (temp=true, const=false)
 
 	// For indexed expressions (arr[i], map[k]) - Container and Index are set
 	Container Object // The array/map object (nil for simple variable references)


### PR DESCRIPTION
## Summary
- Added `Mutable` field to Reference struct
- `const r = ref(x)` now creates a read-only view (cannot modify through r)
- `temp r = ref(x)` still allows modification
- `&` parameters are always mutable

## Test
```ez
temp arr [int] = {1, 2, 3}
const r = ref(arr)
arrays.append(r, 999)  // ERROR: cannot modify immutable array
```

Closes #1088