### PR TITLE
test: add integration tests for mutability features

### DIFF
--- a/integration-tests/fail/errors/E3027_const_to_mutable_param.ez
+++ b/integration-tests/fail/errors/E3027_const_to_mutable_param.ez
@@ -1,18 +1,13 @@
 /*
- * Error Test: E3023 - const-to-mutable-param
- * Expected: "cannot pass immutable variable" to mutable parameter
+ * E3027_const_to_mutable_param.ez
+ * Tests that passing const to & parameter fails with E3027
  */
 
-const Person struct {
-    name string
-    age int
-}
-
-do modify(&p Person) {
-    p.age = p.age + 1
+do modify(&arr [int]) {
+    arr[0] = 999
 }
 
 do main() {
-    const alice Person = Person{name: "Alice", age: 25}
-    modify(alice)  // ERROR: cannot pass const to & param
+    const nums [int, 3] = {1, 2, 3}
+    modify(nums)  // ERROR: cannot pass immutable to mutable parameter
 }

--- a/integration-tests/fail/errors/E5007_const_array_modification.ez
+++ b/integration-tests/fail/errors/E5007_const_array_modification.ez
@@ -1,0 +1,11 @@
+/*
+ * E5007_const_array_modification.ez
+ * Tests that modifying a const array fails with E5007
+ */
+
+import @arrays
+
+do main() {
+    const arr [int, 3] = {1, 2, 3}
+    arrays.append(arr, 4)  // ERROR: cannot modify immutable array
+}

--- a/integration-tests/fail/errors/E5007_const_ref_modification.ez
+++ b/integration-tests/fail/errors/E5007_const_ref_modification.ez
@@ -1,0 +1,12 @@
+/*
+ * E5007_const_ref_modification.ez
+ * Tests that modifying through a const ref fails with E5007
+ */
+
+import @arrays
+
+do main() {
+    temp arr [int] = {1, 2, 3}
+    const r = ref(arr)
+    arrays.append(r, 4)  // ERROR: cannot modify through const ref
+}

--- a/integration-tests/fail/errors/E5016_const_map_modification.ez
+++ b/integration-tests/fail/errors/E5016_const_map_modification.ez
@@ -1,0 +1,9 @@
+/*
+ * E5016_const_map_modification.ez
+ * Tests that modifying a const map fails with E5016
+ */
+
+do main() {
+    const m map[string:int] = {"a": 1}
+    m["b"] = 2  // ERROR: cannot modify immutable map
+}

--- a/integration-tests/fail/errors/E5017_const_struct_modification.ez
+++ b/integration-tests/fail/errors/E5017_const_struct_modification.ez
@@ -1,0 +1,14 @@
+/*
+ * E5016_const_struct_modification.ez
+ * Tests that modifying a const struct field fails with E5016
+ */
+
+const Point struct {
+    x int
+    y int
+}
+
+do main() {
+    const p = Point{x: 10, y: 20}
+    p.x = 999  // ERROR: cannot modify immutable struct
+}

--- a/integration-tests/pass/core/const_multi_return.ez
+++ b/integration-tests/pass/core/const_multi_return.ez
@@ -1,0 +1,84 @@
+/*
+ * const_multi_return.ez - Test const keyword with multi-return functions
+ *
+ * Tests that:
+ * - const a, b = func() syntax works
+ * - const values from multi-return are immutable
+ * - blank identifier works with const multi-return
+ */
+
+import @std
+using std
+
+do get_pair() -> (int, string) {
+    return 42, "hello"
+}
+
+do get_triple() -> (int, string, bool) {
+    return 1, "two", true
+}
+
+do main() {
+    println("=== Const Multi-Return Tests ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: const with 2-value return
+    const a, b = get_pair()
+    if a == 42 && b == "hello" {
+        println("  [PASS] const a, b = func() works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] const multi-return 2 values")
+        failed += 1
+    }
+
+    // Test 2: const with 3-value return
+    const x, y, z = get_triple()
+    if x == 1 && y == "two" && z == true {
+        println("  [PASS] const x, y, z = func() works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] const multi-return 3 values")
+        failed += 1
+    }
+
+    // Test 3: const with blank identifier
+    const val, _ = get_pair()
+    if val == 42 {
+        println("  [PASS] const with blank identifier works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] const with blank identifier")
+        failed += 1
+    }
+
+    // Test 4: const with multiple blanks
+    const _, middle, _ = get_triple()
+    if middle == "two" {
+        println("  [PASS] const with multiple blank identifiers works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] const with multiple blanks")
+        failed += 1
+    }
+
+    // Test 5: temp multi-return still works
+    temp ta, tb = get_pair()
+    if ta == 42 && tb == "hello" {
+        println("  [PASS] temp multi-return still works")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp multi-return")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/const_ref.ez
+++ b/integration-tests/pass/core/const_ref.ez
@@ -1,0 +1,109 @@
+/*
+ * const_ref.ez - Test const ref creates read-only view
+ *
+ * Tests that:
+ * - temp ref allows modification (existing behavior)
+ * - const ref can read the value
+ * - const ref sees changes made to original
+ * - & parameters work correctly (always mutable)
+ */
+
+import @std, @arrays
+using std
+
+const Point struct {
+    x int
+    y int
+}
+
+do modify_array(&arr [int]) {
+    arrays.append(arr, 999)
+}
+
+do modify_struct(&p Point) {
+    p.x = 999
+}
+
+do main() {
+    println("=== Const Ref Tests ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: temp ref allows modification
+    temp arr1 [int] = {1, 2, 3}
+    temp r1 = ref(arr1)
+    arrays.append(r1, 4)
+    if len(arr1) == 4 && arr1[3] == 4 {
+        println("  [PASS] temp ref allows modification")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp ref should allow modification")
+        failed += 1
+    }
+
+    // Test 2: const ref can read value
+    temp arr2 [int] = {10, 20, 30}
+    const r2 = ref(arr2)
+    if r2[0] == 10 && r2[1] == 20 && r2[2] == 30 {
+        println("  [PASS] const ref can read value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] const ref should be readable")
+        failed += 1
+    }
+
+    // Test 3: const ref sees changes to original
+    temp arr3 [int] = {1, 2, 3}
+    const r3 = ref(arr3)
+    arrays.append(arr3, 4)  // Modify original directly
+    if len(r3) == 4 && r3[3] == 4 {
+        println("  [PASS] const ref sees changes to original")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] const ref should see original changes")
+        failed += 1
+    }
+
+    // Test 4: & parameter works (always mutable)
+    temp arr4 [int] = {1, 2, 3}
+    modify_array(arr4)
+    if len(arr4) == 4 && arr4[3] == 999 {
+        println("  [PASS] & parameter allows modification")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] & parameter should allow modification")
+        failed += 1
+    }
+
+    // Test 5: & parameter with struct
+    temp p1 = Point{x: 10, y: 20}
+    modify_struct(p1)
+    if p1.x == 999 {
+        println("  [PASS] & parameter works with struct")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] & parameter should work with struct")
+        failed += 1
+    }
+
+    // Test 6: temp ref to struct allows modification
+    temp p2 = Point{x: 1, y: 2}
+    temp rp = ref(p2)
+    rp.x = 100
+    if p2.x == 100 {
+        println("  [PASS] temp ref to struct allows modification")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp ref to struct should allow modification")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/mutability_sync.ez
+++ b/integration-tests/pass/core/mutability_sync.ez
@@ -1,0 +1,95 @@
+/*
+ * mutability_sync.ez - Test temp/const mutability sync
+ *
+ * Tests that:
+ * - temp variables have mutable values (can modify arrays, maps, structs)
+ * - const variables have immutable values
+ * - temp/const overrides stdlib return value mutability
+ */
+
+import @std, @arrays
+using std
+
+const Person struct {
+    name string
+    age int
+}
+
+do get_array() -> [int] {
+    return {1, 2, 3}
+}
+
+do get_person() -> Person {
+    return Person{name: "Alice", age: 30}
+}
+
+do main() {
+    println("=== Mutability Sync Tests ===")
+    temp passed int = 0
+    temp failed int = 0
+
+    // Test 1: temp array from function is mutable
+    temp arr1 [int] = get_array()
+    arrays.append(arr1, 4)
+    if len(arr1) == 4 && arr1[3] == 4 {
+        println("  [PASS] temp array from function is mutable")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp array should be mutable")
+        failed += 1
+    }
+
+    // Test 2: temp array literal is mutable
+    temp arr2 [int] = {10, 20, 30}
+    arrays.append(arr2, 40)
+    if len(arr2) == 4 {
+        println("  [PASS] temp array literal is mutable")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp array literal should be mutable")
+        failed += 1
+    }
+
+    // Test 3: temp struct is mutable
+    temp p1 = get_person()
+    p1.name = "Bob"
+    if p1.name == "Bob" {
+        println("  [PASS] temp struct from function is mutable")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp struct should be mutable")
+        failed += 1
+    }
+
+    // Test 4: temp map is mutable
+    temp m1 map[string:int] = {"a": 1}
+    m1["b"] = 2
+    if m1["b"] == 2 {
+        println("  [PASS] temp map is mutable")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] temp map should be mutable")
+        failed += 1
+    }
+
+    // Test 5: copy() creates mutable copy
+    temp arr3 [int] = {1, 2, 3}
+    temp arr4 [int] = copy(arr3)
+    arrays.append(arr4, 4)
+    if len(arr4) == 4 && len(arr3) == 3 {
+        println("  [PASS] copy() creates independent mutable copy")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] copy() should create mutable copy")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}


### PR DESCRIPTION
## Summary
Adds integration tests for all the mutability features implemented in this branch.

### Passing Tests
- `mutability_sync.ez` - Tests temp/const value mutability sync
- `const_multi_return.ez` - Tests `const a, b = func()` syntax
- `const_ref.ez` - Tests const ref read-only view behavior

### Failing Tests
- `E5007_const_array_modification.ez` - const array cannot be modified
- `E5007_const_ref_modification.ez` - const ref cannot modify value
- `E3027_const_to_mutable_param.ez` - const cannot be passed to & param
- `E5016_const_map_modification.ez` - const map cannot be modified
- `E5017_const_struct_modification.ez` - const struct fields cannot be modified