### PR TITLE
fix: set correct file in runtime errors from builtin functions (#1094)

### DIFF
--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -1919,6 +1919,10 @@ func evalSingleCast(value Object, targetType string, line, col int) Object {
 			errObj.Line = line
 			errObj.Column = col
 		}
+		// Set file from current context if not already set (#1094)
+		if errObj.File == "" && globalEvalContext != nil {
+			errObj.File = globalEvalContext.CurrentFile
+		}
 	}
 	return result
 }
@@ -2961,6 +2965,10 @@ func evalMemberCall(member *ast.MemberExpression, args []ast.Expression, env *En
 				errObj.Line = member.Token.Line
 				errObj.Column = member.Token.Column
 			}
+			// Set file from current context if not already set (#1094)
+			if errObj.File == "" && globalEvalContext != nil {
+				errObj.File = globalEvalContext.CurrentFile
+			}
 		}
 		return result
 	}
@@ -3077,6 +3085,10 @@ func applyFunction(fn Object, args []Object, line, col int) Object {
 			if errObj.Line == 0 && errObj.Column == 0 {
 				errObj.Line = line
 				errObj.Column = col
+			}
+			// Set file from current context if not already set (#1094)
+			if errObj.File == "" && globalEvalContext != nil {
+				errObj.File = globalEvalContext.CurrentFile
 			}
 		}
 		return result


### PR DESCRIPTION
## Summary
- Fixed wrong file name in runtime error messages during multi-file evaluation
- Errors from builtin/stdlib functions now correctly show the file where they occurred

## Root Cause
When builtin functions returned errors, the code filled in Line and Column from the call site, but the File field was left empty. The error formatter then fell back to the main file.

## Fix
Set `errObj.File` from `globalEvalContext.CurrentFile` in all places where builtin error locations are filled in:
- `applyFunction` (direct builtin calls)
- `evalMemberExpression` (module.function() calls)  
- `evalCastExpression` (cast operations)

## Test plan
- [x] Verified fix with reproduction case from issue
- [x] Error now shows `lib/helpers.ez:10:19` instead of `main/main.ez:10:19`
- [x] All interpreter tests pass

Closes #1094