### PR TITLE
Fix enum values in arithmetic expressions

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -6876,6 +6876,9 @@ func (tc *TypeChecker) isNumericType(typeName string) bool {
 		"float", "f32", "f64", "byte":
 		return true
 	default:
+		if t, exists := tc.types[typeName]; exists && t.Kind == EnumType {
+			return t.EnumBaseType == "int" || t.EnumBaseType == "float"
+		}
 		return false
 	}
 }


### PR DESCRIPTION
Fixes #1106

Numeric enums (int/float based) are now recognized as numeric types for arithmetic operations.