### PR TITLE
Fix parent-path import variable type inference

### DIFF
--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -922,6 +922,11 @@ func runFile(filename string) {
 				fileTc.RegisterModuleFunction(modName, funcName, sig)
 			}
 		}
+		for modName, vars := range moduleVariables {
+			for varName, varType := range vars {
+				fileTc.RegisterModuleVariable(modName, varName, varType)
+			}
+		}
 
 		// For multi-file modules, register module-internal types/functions/variables (#722)
 		if pf.numFiles > 1 {


### PR DESCRIPTION
## Summary
- Fixes #1111
- Adds missing module variable registration in `runFile` Pass 2
- Variables from parent-path imports (e.g., `import lib "../library"`) now have correct type inference