### PR TITLE
Bugfixes/2-3-2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -194,6 +194,7 @@ General runtime errors
 | E5021 | panic | explicit panic called |
 | E5022 | assertion-failed | assertion condition was false |
 | E5023 | postfix-requires-integer | postfix operator needs integer operand |
+| E5024 | return-type-mismatch | return type mismatch |
 
 ## Import Errors (E6xxx)
 
@@ -422,4 +423,4 @@ Module-related warnings
 
 ## Summary
 
-**Total:** 265 error/warning codes
+**Total:** 266 error/warning codes

--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -922,6 +922,11 @@ func runFile(filename string) {
 				fileTc.RegisterModuleFunction(modName, funcName, sig)
 			}
 		}
+		for modName, vars := range moduleVariables {
+			for varName, varType := range vars {
+				fileTc.RegisterModuleVariable(modName, varName, varType)
+			}
+		}
 
 		// For multi-file modules, register module-internal types/functions/variables (#722)
 		if pf.numFiles > 1 {

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -193,6 +193,7 @@ var (
 	E5021 = ErrorCode{"E5021", "panic", "explicit panic called"}
 	E5022 = ErrorCode{"E5022", "assertion-failed", "assertion condition was false"}
 	E5023 = ErrorCode{"E5023", "postfix-requires-integer", "postfix operator needs integer operand"}
+	E5024 = ErrorCode{"E5024", "return-type-mismatch", "return type mismatch"}
 )
 
 // =============================================================================
@@ -464,7 +465,7 @@ var errorCodesByString = map[string]ErrorCode{
 	"E5006": E5006, "E5007": E5007, "E5008": E5008, "E5009": E5009, "E5010": E5010,
 	"E5011": E5011, "E5012": E5012, "E5013": E5013, "E5014": E5014, "E5015": E5015,
 	"E5016": E5016, "E5017": E5017, "E5018": E5018, "E5019": E5019, "E5020": E5020,
-	"E5021": E5021, "E5022": E5022, "E5023": E5023,
+	"E5021": E5021, "E5022": E5022, "E5023": E5023, "E5024": E5024,
 	// Import
 	"E6001": E6001, "E6002": E6002, "E6003": E6003, "E6004": E6004, "E6005": E6005,
 	"E6006": E6006, "E6007": E6007, "E6008": E6008, "E6009": E6009,

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3259,7 +3259,7 @@ func createTypeMismatchError(val Object, expectedType string, line, col int) *Er
 	}
 
 	// Generic type mismatch
-	return newErrorWithLocation("E5012", line, col,
+	return newErrorWithLocation("E5024", line, col,
 		"return type mismatch: expected %s, got %s", expectedType, actualType)
 }
 

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -573,7 +573,11 @@ func Eval(node ast.Node, env *Environment) Object {
 		if len(elements) == 1 && isError(elements[0]) {
 			return elements[0]
 		}
-		return &Array{Elements: elements, Mutable: true}
+		elementType := ""
+		if len(elements) > 0 {
+			elementType = objectTypeToEZ(elements[0])
+		}
+		return &Array{Elements: elements, Mutable: true, ElementType: elementType}
 
 	case *ast.MapValue:
 		return evalMapLiteral(node, env)

--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -6876,6 +6876,9 @@ func (tc *TypeChecker) isNumericType(typeName string) bool {
 		"float", "f32", "f64", "byte":
 		return true
 	default:
+		if t, exists := tc.types[typeName]; exists && t.Kind == EnumType {
+			return t.EnumBaseType == "int" || t.EnumBaseType == "float"
+		}
 		return false
 	}
 }


### PR DESCRIPTION
This pull request contains the following changes:

## Bug Fixes: 
- Fix array literal losing element type information(#1103)
- Fix postfix `++/--` operators not working on array elements, structs fields and maps(#1105)
- Fix enum values not being able to be used in arithmetic(#1106)
- Fix `E5012` from incorrectly being used for return type mismatch error/ Add `E5024`(#1104) 
- Fix parent path import variable type inference(#1111)
------

- Closes #1103 
- Closes #1104 
- Closes #1105 
- Closes #1106 
- Closes #1111 