### PR TITLE
chore: remove lowercase `error` type alias, keep only `Error`

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1098,7 +1098,7 @@ temp quotient, remainder = divide(17, 5)
 #### 8.3.3 Error Returns
 
 ```ez
-do parse(s string) -> (int, error) {
+do parse(s string) -> (int, Error) {
     if s == "" {
         return 0, error("empty string")
     }
@@ -1241,7 +1241,7 @@ The core module provides fundamental I/O, type conversion, and utility functions
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `input` | `() -> string` | Read line from stdin |
-| `read_int` | `() -> (int, error)` | Read integer from stdin |
+| `read_int` | `() -> (int, Error)` | Read integer from stdin |
 
 #### Type Conversion Functions
 
@@ -1271,7 +1271,7 @@ The core module provides fundamental I/O, type conversion, and utility functions
 | `copy` | `(value) -> T` | Create deep copy |
 | `new` | `(Type) -> Type` | Create zero-initialized instance |
 | `ref` | `(value) -> T` | Create reference to value |
-| `error` | `(message string) -> error` | Create error value |
+| `error` | `(message string) -> Error` | Create error value |
 | `assert` | `(condition bool, message string)` | Assert condition is true |
 | `panic` | `(message string) -> nil` | Terminate with error message |
 | `exit` | `(code int) -> nil` | Exit program with code |
@@ -1686,10 +1686,10 @@ Durations: `SECOND` (1), `MINUTE` (60), `HOUR` (3600), `DAY` (86400), `WEEK` (60
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `encode` | `(value) -> (string, error)` | Encode to JSON string |
-| `decode` | `(text string) -> (any, error)` | Decode to dynamic type |
-| `decode` | `(text string, Type) -> (Type, error)` | Decode to typed struct |
-| `pretty` | `(value, indent string) -> (string, error)` | Pretty print JSON |
+| `encode` | `(value) -> (string, Error)` | Encode to JSON string |
+| `decode` | `(text string) -> (any, Error)` | Decode to dynamic type |
+| `decode` | `(text string, Type) -> (Type, Error)` | Decode to typed struct |
+| `pretty` | `(value, indent string) -> (string, Error)` | Pretty print JSON |
 | `is_valid` | `(text string) -> bool` | Check if valid JSON |
 
 ### 10.9 IO Module (`@io`)
@@ -1698,16 +1698,16 @@ Durations: `SECOND` (1), `MINUTE` (60), `HOUR` (3600), `DAY` (86400), `WEEK` (60
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `read_file` | `(path string) -> (string, error)` | Read file as string |
-| `read_bytes` | `(path string) -> ([byte], error)` | Read file as bytes |
+| `read_file` | `(path string) -> (string, Error)` | Read file as string |
+| `read_bytes` | `(path string) -> ([byte], Error)` | Read file as bytes |
 
 #### File Writing
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `write_file` | `(path string, content string) -> (bool, error)` | Write file |
-| `write_bytes` | `(path string, data [byte]) -> (bool, error)` | Write bytes |
-| `append_file` | `(path string, content string) -> (bool, error)` | Append to file |
+| `write_file` | `(path string, content string) -> (bool, Error)` | Write file |
+| `write_bytes` | `(path string, data [byte]) -> (bool, Error)` | Write bytes |
+| `append_file` | `(path string, content string) -> (bool, Error)` | Append to file |
 
 #### File Operations
 
@@ -1718,22 +1718,22 @@ Durations: `SECOND` (1), `MINUTE` (60), `HOUR` (3600), `DAY` (86400), `WEEK` (60
 | `is_directory` | `(path string) -> bool` | Check if path is directory |
 | `is_readable` | `(path string) -> bool` | Check if readable |
 | `is_writable` | `(path string) -> bool` | Check if writable |
-| `file_size` | `(path string) -> (int, error)` | Get file size |
+| `file_size` | `(path string) -> (int, Error)` | Get file size |
 | `file_extension` | `(path string) -> string` | Get file extension |
 | `file_name` | `(path string) -> string` | Get file name |
 | `directory_name` | `(path string) -> string` | Get directory path |
-| `absolute_path` | `(path string) -> (string, error)` | Get absolute path |
-| `delete_file` | `(path string) -> (bool, error)` | Delete file |
+| `absolute_path` | `(path string) -> (string, Error)` | Get absolute path |
+| `delete_file` | `(path string) -> (bool, Error)` | Delete file |
 
 #### Directory Operations
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `list_directory` | `(path string) -> ([string], error)` | List directory contents |
-| `create_directory` | `(path string) -> (bool, error)` | Create directory |
-| `create_directories` | `(path string) -> (bool, error)` | Create recursively |
-| `delete_directory` | `(path string) -> (bool, error)` | Delete empty directory |
-| `delete_directory_recursive` | `(path string) -> (bool, error)` | Delete recursively |
+| `list_directory` | `(path string) -> ([string], Error)` | List directory contents |
+| `create_directory` | `(path string) -> (bool, Error)` | Create directory |
+| `create_directories` | `(path string) -> (bool, Error)` | Create recursively |
+| `delete_directory` | `(path string) -> (bool, Error)` | Delete empty directory |
+| `delete_directory_recursive` | `(path string) -> (bool, Error)` | Delete recursively |
 
 #### Path Functions
 
@@ -1748,9 +1748,9 @@ Durations: `SECOND` (1), `MINUTE` (60), `HOUR` (3600), `DAY` (86400), `WEEK` (60
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `get_env` | `(name string) -> (string, error)` | Get environment variable |
-| `set_env` | `(name string, value string) -> (bool, error)` | Set environment variable |
-| `unset_env` | `(name string) -> (bool, error)` | Unset environment variable |
+| `get_env` | `(name string) -> (string, Error)` | Get environment variable |
+| `set_env` | `(name string, value string) -> (bool, Error)` | Set environment variable |
+| `unset_env` | `(name string) -> (bool, Error)` | Unset environment variable |
 | `env` | `() -> map[string:string]` | Get all environment variables |
 
 #### System Information
@@ -1758,11 +1758,11 @@ Durations: `SECOND` (1), `MINUTE` (60), `HOUR` (3600), `DAY` (86400), `WEEK` (60
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `args` | `() -> [string]` | Get command-line arguments |
-| `cwd` | `() -> (string, error)` | Get current working directory |
-| `chdir` | `(path string) -> (bool, error)` | Change directory |
-| `hostname` | `() -> (string, error)` | Get machine hostname |
-| `username` | `() -> (string, error)` | Get current username |
-| `home_dir` | `() -> (string, error)` | Get home directory |
+| `cwd` | `() -> (string, Error)` | Get current working directory |
+| `chdir` | `(path string) -> (bool, Error)` | Change directory |
+| `hostname` | `() -> (string, Error)` | Get machine hostname |
+| `username` | `() -> (string, Error)` | Get current username |
+| `home_dir` | `() -> (string, Error)` | Get home directory |
 | `temp_dir` | `() -> string` | Get temporary directory |
 | `pid` | `() -> int` | Get process ID |
 | `ppid` | `() -> int` | Get parent process ID |
@@ -1783,12 +1783,12 @@ Durations: `SECOND` (1), `MINUTE` (60), `HOUR` (3600), `DAY` (86400), `WEEK` (60
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `get` | `(url string) -> (Response, error)` | GET request |
-| `post` | `(url string, body string) -> (Response, error)` | POST request |
-| `put` | `(url string, body string) -> (Response, error)` | PUT request |
-| `delete` | `(url string) -> (Response, error)` | DELETE request |
-| `patch` | `(url string, body string) -> (Response, error)` | PATCH request |
-| `head` | `(url string) -> (Response, error)` | HEAD request |
+| `get` | `(url string) -> (Response, Error)` | GET request |
+| `post` | `(url string, body string) -> (Response, Error)` | POST request |
+| `put` | `(url string, body string) -> (Response, Error)` | PUT request |
+| `delete` | `(url string) -> (Response, Error)` | DELETE request |
+| `patch` | `(url string, body string) -> (Response, Error)` | PATCH request |
+| `head` | `(url string) -> (Response, Error)` | HEAD request |
 
 #### Response Type
 
@@ -1816,11 +1816,11 @@ The `Response` struct contains:
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `base64_encode` | `(s string) -> string` | Encode to base64 |
-| `base64_decode` | `(s string) -> (string, error)` | Decode from base64 |
+| `base64_decode` | `(s string) -> (string, Error)` | Decode from base64 |
 | `hex_encode` | `(s string) -> string` | Encode to hex |
-| `hex_decode` | `(s string) -> (string, error)` | Decode from hex |
+| `hex_decode` | `(s string) -> (string, Error)` | Decode from hex |
 | `url_encode` | `(s string) -> string` | URL percent-encode |
-| `url_decode` | `(s string) -> (string, error)` | URL percent-decode |
+| `url_decode` | `(s string) -> (string, Error)` | URL percent-decode |
 
 ### 10.14 UUID Module (`@uuid`)
 
@@ -1840,8 +1840,8 @@ The `Response` struct contains:
 |----------|-----------|-------------|
 | `from_array` | `(arr [int]) -> [byte]` | Create from integer array |
 | `from_string` | `(s string) -> [byte]` | Create from UTF-8 string |
-| `from_hex` | `(hex string) -> ([byte], error)` | Decode hex string |
-| `from_base64` | `(b64 string) -> ([byte], error)` | Decode base64 string |
+| `from_hex` | `(hex string) -> ([byte], Error)` | Decode hex string |
+| `from_base64` | `(b64 string) -> ([byte], Error)` | Decode base64 string |
 | `to_string` | `(bytes [byte]) -> string` | Convert to UTF-8 string |
 | `to_array` | `(bytes [byte]) -> [int]` | Convert to integer array |
 | `to_hex` | `(bytes [byte]) -> string` | Encode to hex string |
@@ -1892,11 +1892,11 @@ A simple JSON-based key-value database.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `open` | `(path string) -> (Database, error)` | Open/create database |
-| `close` | `(db Database) -> error` | Close database |
-| `save` | `(db Database) -> error` | Save to disk |
+| `open` | `(path string) -> (Database, Error)` | Open/create database |
+| `close` | `(db Database) -> Error` | Close database |
+| `save` | `(db Database) -> Error` | Save to disk |
 | `set` | `(db Database, key string, value)` | Set key-value pair |
-| `get` | `(db Database, key string) -> (any, error)` | Get value by key |
+| `get` | `(db Database, key string) -> (any, Error)` | Get value by key |
 | `has` | `(db Database, key string) -> bool` | Check if key exists |
 | `delete` | `(db Database, key string) -> bool` | Delete key |
 | `clear` | `(db Database)` | Clear all entries |
@@ -1910,18 +1910,18 @@ A simple JSON-based key-value database.
 
 ### 11.1 Error Type
 
-The `error` type represents an error condition. Errors are created with the `error()` function:
+The `Error` type represents an error condition. Errors are created with the `error()` function:
 
 ```ez
-temp err error = error("something went wrong")
+temp err Error = error("something went wrong")
 ```
 
 ### 11.2 Error Returns
 
-Functions that may fail conventionally return a tuple with the result and an error:
+Functions that may fail conventionally return a tuple with the result and an Error:
 
 ```ez
-do read_file(path string) -> (string, error) {
+do read_file(path string) -> (string, Error) {
     if !file_exists(path) {
         return "", error("file not found")
     }

--- a/examples/db.ez
+++ b/examples/db.ez
@@ -9,7 +9,7 @@ const User struct {
 }
 
 do main() {
-    temp store Database, err error = db.open("mydb.ezdb")
+    temp store Database, err Error = db.open("mydb.ezdb")
     if err != nil {
         println("Failed: ${err.message}")
         return

--- a/examples/http.ez
+++ b/examples/http.ez
@@ -46,7 +46,7 @@ do main() {
 
     // URL utilities
     temp encoded string = http.encode_url("hello world")  // "hello%20world"
-    temp decoded string, decode_err error = http.decode_url(encoded)
+    temp decoded string, decode_err Error = http.decode_url(encoded)
     if decode_err != nil {
         println("${decode_err}")
         return

--- a/examples/json/json.ez
+++ b/examples/json/json.ez
@@ -26,7 +26,7 @@ do main() {
 
     // Step 1: Read the JSON file
     println("Reading data.json...")
-    temp content string, read_err error = io.read_file("examples/json/data.json")
+    temp content string, read_err Error = io.read_file("examples/json/data.json")
     if read_err != nil {
         println("Error reading file: ${read_err}")
         return
@@ -56,7 +56,7 @@ do main() {
 
     // Step 4: Encode data back to JSON string
     println("Re-encoding to JSON...")
-    temp encoded string, encode_err error = json.encode(data)
+    temp encoded string, encode_err Error = json.encode(data)
     if encode_err == nil {
         println("Compact JSON:")
         println(encoded)
@@ -71,7 +71,7 @@ do main() {
         "role": "developer"
     }
 
-    temp user_json string, user_err error = json.encode(user)
+    temp user_json string, user_err Error = json.encode(user)
     if user_err == nil {
         println("User JSON: ${user_json}")
     }
@@ -79,7 +79,7 @@ do main() {
 
     // Step 6: Pretty print with indentation
     println("Pretty printing...")
-    temp pretty string, pretty_err error = json.pretty(user, "    ")
+    temp pretty string, pretty_err Error = json.pretty(user, "    ")
     if pretty_err == nil {
         println(pretty)
     }
@@ -88,26 +88,26 @@ do main() {
     // Step 7: Encode different types
     println("Encoding different types:")
 
-    temp str_json string, e1 error = json.encode("hello world")
+    temp str_json string, e1 Error = json.encode("hello world")
     println("  String: ${str_json}")
 
-    temp num_json string, e2 error = json.encode(42)
+    temp num_json string, e2 Error = json.encode(42)
     println("  Number: ${num_json}")
 
-    temp bool_json string, e3 error = json.encode(true)
+    temp bool_json string, e3 Error = json.encode(true)
     println("  Boolean: ${bool_json}")
 
-    temp null_json string, e4 error = json.encode(nil)
+    temp null_json string, e4 Error = json.encode(nil)
     println("  Null: ${null_json}")
 
-    temp arr_json string, e5 error = json.encode({1, 2, 3, 4, 5})
+    temp arr_json string, e5 Error = json.encode({1, 2, 3, 4, 5})
     println("  Array: ${arr_json}")
     println("")
 
     // Step 8: Decode JSON into a typed struct
     println("Decoding into typed struct...")
     temp person_json string = "{\"name\": \"Bob\", \"email\": \"bob@example.com\", \"role\": \"designer\"}"
-    temp person Person, person_err error = json.decode(person_json, Person)
+    temp person Person, person_err Error = json.decode(person_json, Person)
     if person_err == nil {
         println("  Decoded Person:")
         println("    Name: ${person.name}")

--- a/integration-tests/fail/errors/E13001_json_syntax_error.ez
+++ b/integration-tests/fail/errors/E13001_json_syntax_error.ez
@@ -11,7 +11,7 @@ const Dummy struct {
 }
 
 do main() {
-    temp result Dummy, err error = json.decode("{ invalid json }", Dummy)
+    temp result Dummy, err Error = json.decode("{ invalid json }", Dummy)
     if err != nil {
         panic("${err}")
     }

--- a/integration-tests/fail/errors/E13003_json_invalid_map_key.ez
+++ b/integration-tests/fail/errors/E13003_json_invalid_map_key.ez
@@ -9,7 +9,7 @@ do main() {
     // Create a map with integer keys (invalid for JSON)
     temp m map[int:string] = {1: "one", 2: "two"}
 
-    temp result string, err error = json.encode(m)
+    temp result string, err Error = json.encode(m)
     if err != nil {
         panic("${err}")
     }

--- a/integration-tests/fail/errors/E13004_json_decode_requires_type.ez
+++ b/integration-tests/fail/errors/E13004_json_decode_requires_type.ez
@@ -7,5 +7,5 @@ import @json
 
 do main() {
     // json.decode with typed result requires type argument
-    temp result int, err error = json.decode("{\"x\": 1}")
+    temp result int, err Error = json.decode("{\"x\": 1}")
 }

--- a/integration-tests/fail/errors/E16001_invalid_base64.ez
+++ b/integration-tests/fail/errors/E16001_invalid_base64.ez
@@ -7,7 +7,7 @@ import @encoding
 
 do main() {
     // Invalid base64 string (contains invalid characters)
-    temp result string, err error = encoding.base64_decode("not!valid@base64")
+    temp result string, err Error = encoding.base64_decode("not!valid@base64")
     if err != nil {
         panic("${err}")
     }

--- a/integration-tests/fail/errors/E16002_invalid_hex.ez
+++ b/integration-tests/fail/errors/E16002_invalid_hex.ez
@@ -7,7 +7,7 @@ import @encoding
 
 do main() {
     // Invalid hex string (contains non-hex characters)
-    temp result string, err error = encoding.hex_decode("GHIJ")
+    temp result string, err Error = encoding.hex_decode("GHIJ")
     if err != nil {
         panic("${err}")
     }

--- a/integration-tests/fail/errors/E16003_invalid_url_encoding.ez
+++ b/integration-tests/fail/errors/E16003_invalid_url_encoding.ez
@@ -7,7 +7,7 @@ import @encoding
 
 do main() {
     // Invalid URL encoding (incomplete percent sequence)
-    temp result string, err error = encoding.url_decode("%ZZ")
+    temp result string, err Error = encoding.url_decode("%ZZ")
     if err != nil {
         panic("${err}")
     }

--- a/integration-tests/pass/core/error_handling.ez
+++ b/integration-tests/pass/core/error_handling.ez
@@ -5,8 +5,8 @@
 import @std
 using std
 
-// Function that can fail - uses error type (lowercase)
-do parse_int(s string) -> (int, error) {
+// Function that can fail - uses Error type
+do parse_int(s string) -> (int, Error) {
     if s == "" {
         return 0, error("empty string")
     }

--- a/integration-tests/pass/stdlib/bytes.ez
+++ b/integration-tests/pass/stdlib/bytes.ez
@@ -58,7 +58,7 @@ do main() {
     }
 
     // Test 5: from_hex
-    temp from_hex_result [byte], from_hex_err error = bytes.from_hex("4142")
+    temp from_hex_result [byte], from_hex_err Error = bytes.from_hex("4142")
     if from_hex_err == nil {
         temp from_hex_str string = bytes.to_string(from_hex_result)
         if from_hex_str == "AB" {
@@ -85,7 +85,7 @@ do main() {
     }
 
     // Test 7: from_base64
-    temp from_b64 [byte], from_b64_err error = bytes.from_base64("SGVsbG8=")
+    temp from_b64 [byte], from_b64_err Error = bytes.from_base64("SGVsbG8=")
     if from_b64_err == nil {
         temp from_b64_str string = bytes.to_string(from_b64)
         if from_b64_str == "Hello" {

--- a/integration-tests/pass/stdlib/db.ez
+++ b/integration-tests/pass/stdlib/db.ez
@@ -19,7 +19,7 @@ do main() {
     println("  -- Opening --")
 
     // Test 1: opening database
-    temp store Database, err error = db.open("mydb.ezdb")
+    temp store Database, err Error = db.open("mydb.ezdb")
     if err != nil {
         println("   [FAIL] db.open(string): unexpected error")
         failed += 1
@@ -184,7 +184,7 @@ do main() {
     println("  -- db.save --")
     
     // Test 1: Manual save to disk
-		temp save_err error = db.save(store)
+		temp save_err Error = db.save(store)
     if save_err == nil {
         println("   [PASS] db.save(database)")
         passed += 1
@@ -219,7 +219,7 @@ do main() {
     println("  -- db.update_key_name --")
 
     // Reopen the store for rename tests
-    temp rename_store Database, rename_err error = db.open("rename_test.ezdb")
+    temp rename_store Database, rename_err Error = db.open("rename_test.ezdb")
     if rename_err != nil {
         println("   [FAIL] db.update_key_name: could not open test database")
         failed += 1
@@ -270,7 +270,7 @@ do main() {
     println("  -- db.sort --")
 
     // Create a fresh database for sort tests
-    temp sort_store Database, sort_err error = db.open("sort_test.ezdb")
+    temp sort_store Database, sort_err Error = db.open("sort_test.ezdb")
     if sort_err != nil {
         println("   [FAIL] db.sort: could not open test database")
         failed += 1
@@ -372,7 +372,7 @@ do main() {
     // ==================== db.close ====================
     println("  -- db.close --")
 
-    temp close_err error = db.close(store)
+    temp close_err Error = db.close(store)
     if close_err == nil {
         println("   [PASS] db.close(database)")
         passed += 1

--- a/integration-tests/pass/stdlib/json.ez
+++ b/integration-tests/pass/stdlib/json.ez
@@ -30,7 +30,7 @@ do main() {
     println("  -- json.encode --")
 
     // Test 1: encode string
-    temp str_result string, str_err error = json.encode("hello")
+    temp str_result string, str_err Error = json.encode("hello")
     if str_err == nil {
         if str_result == "\"hello\"" {
             println("  [PASS] json.encode(string)")
@@ -45,7 +45,7 @@ do main() {
     }
 
     // Test 2: encode integer
-    temp int_result string, int_err error = json.encode(42)
+    temp int_result string, int_err Error = json.encode(42)
     if int_err == nil {
         if int_result == "42" {
             println("  [PASS] json.encode(int)")
@@ -60,7 +60,7 @@ do main() {
     }
 
     // Test 3: encode float
-    temp float_result string, float_err error = json.encode(3.14)
+    temp float_result string, float_err Error = json.encode(3.14)
     if float_err == nil {
         if float_result == "3.14" {
             println("  [PASS] json.encode(float)")
@@ -75,7 +75,7 @@ do main() {
     }
 
     // Test 4: encode boolean true
-    temp true_result string, true_err error = json.encode(true)
+    temp true_result string, true_err Error = json.encode(true)
     if true_err == nil {
         if true_result == "true" {
             println("  [PASS] json.encode(true)")
@@ -90,7 +90,7 @@ do main() {
     }
 
     // Test 5: encode boolean false
-    temp false_result string, false_err error = json.encode(false)
+    temp false_result string, false_err Error = json.encode(false)
     if false_err == nil {
         if false_result == "false" {
             println("  [PASS] json.encode(false)")
@@ -105,7 +105,7 @@ do main() {
     }
 
     // Test 6: encode nil
-    temp nil_result string, nil_err error = json.encode(nil)
+    temp nil_result string, nil_err Error = json.encode(nil)
     if nil_err == nil {
         if nil_result == "null" {
             println("  [PASS] json.encode(nil)")
@@ -121,7 +121,7 @@ do main() {
 
     // Test 7: encode array
     temp arr [int] = {1, 2, 3}
-    temp arr_result string, arr_err error = json.encode(arr)
+    temp arr_result string, arr_err Error = json.encode(arr)
     if arr_err == nil {
         if arr_result == "[1,2,3]" {
             println("  [PASS] json.encode(array)")
@@ -137,7 +137,7 @@ do main() {
 
     // Test 8: encode struct
     temp person Person = Person{name: "Alice", age: 30}
-    temp person_json string, person_json_err error = json.encode(person)
+    temp person_json string, person_json_err Error = json.encode(person)
     if person_json_err == nil {
         // JSON keys are sorted alphabetically
         if person_json == "{\"age\":30,\"name\":\"Alice\"}" {
@@ -156,7 +156,7 @@ do main() {
     println("  -- json.decode (typed) --")
 
     // Test 9: decode to typed struct
-    temp decoded_person Person, person_err error = json.decode("{\"name\": \"Alice\", \"age\": 30}", Person)
+    temp decoded_person Person, person_err Error = json.decode("{\"name\": \"Alice\", \"age\": 30}", Person)
     if person_err == nil {
         if decoded_person.name == "Alice" {
             if decoded_person.age == 30 {
@@ -176,7 +176,7 @@ do main() {
     }
 
     // Test 10: decode typed struct with missing field (should use zero value)
-    temp person2 Person, person2_err error = json.decode("{\"name\": \"Bob\"}", Person)
+    temp person2 Person, person2_err Error = json.decode("{\"name\": \"Bob\"}", Person)
     if person2_err == nil {
         if person2.age == 0 {
             println("  [PASS] json.decode(typed) missing field uses zero value")
@@ -191,7 +191,7 @@ do main() {
     }
 
     // Test 11: decode typed struct with bool field
-    temp task Task, task_err error = json.decode("{\"title\": \"Test\", \"completed\": true}", Task)
+    temp task Task, task_err Error = json.decode("{\"title\": \"Test\", \"completed\": true}", Task)
     if task_err == nil {
         if task.completed == true {
             println("  [PASS] json.decode(typed) with bool field")
@@ -206,7 +206,7 @@ do main() {
     }
 
     // Test 12: decode invalid JSON returns error
-    temp invalid_person Person, invalid_err error = json.decode("{invalid}", Person)
+    temp invalid_person Person, invalid_err Error = json.decode("{invalid}", Person)
     if invalid_err != nil {
         println("  [PASS] json.decode(invalid) returns error")
         passed += 1
@@ -216,7 +216,7 @@ do main() {
     }
 
     // Test 13: decode with extra fields (should be ignored)
-    temp extra_person Person, extra_err error = json.decode("{\"name\": \"Charlie\", \"age\": 25, \"extra\": \"ignored\"}", Person)
+    temp extra_person Person, extra_err Error = json.decode("{\"name\": \"Charlie\", \"age\": 25, \"extra\": \"ignored\"}", Person)
     if extra_err == nil {
         if extra_person.name == "Charlie" && extra_person.age == 25 {
             println("  [PASS] json.decode(typed) ignores extra fields")
@@ -273,7 +273,7 @@ do main() {
     println("  -- json.pretty --")
 
     // Test 18: pretty print array
-    temp pretty_arr string, pretty_arr_err error = json.pretty({1, 2}, "  ")
+    temp pretty_arr string, pretty_arr_err Error = json.pretty({1, 2}, "  ")
     if pretty_arr_err == nil {
         println("  [PASS] json.pretty(array)")
         passed += 1

--- a/integration-tests/pass/warnings/W2009_nil_dereference_potential.ez
+++ b/integration-tests/pass/warnings/W2009_nil_dereference_potential.ez
@@ -11,7 +11,7 @@ const Person struct {
 }
 
 do main() {
-    temp p Person, err error = json.decode("{\"name\": \"Alice\"}", Person)
+    temp p Person, err Error = json.decode("{\"name\": \"Alice\"}", Person)
     // Accessing .code on error which may be nil
     println(err.code)
 }

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -3364,10 +3364,6 @@ func typeMatches(obj Object, ezType string) bool {
 		return true
 	}
 
-	// error/Error are interchangeable (error is alias for Error struct)
-	if (actualType == "error" && ezType == "Error") || (actualType == "Error" && ezType == "error") {
-		return true
-	}
 
 	// Handle module-prefixed types (e.g., utils.Hero vs Hero)
 	// Strip module prefix and compare base type names

--- a/pkg/typechecker/typechecker_test.go
+++ b/pkg/typechecker/typechecker_test.go
@@ -6034,7 +6034,7 @@ func TestTypeExistsForBuiltins(t *testing.T) {
 		"u8", "u16", "u32", "u64",
 		"float", "f32", "f64",
 		"string", "bool", "char", "byte",
-		"nil", "error",
+		"nil", "Error",
 	}
 
 	for _, typeName := range builtinTypes {


### PR DESCRIPTION
## Summary

- Remove the lowercase `error` type alias, keeping only `Error` as the canonical struct type
- The `error()` builtin function remains unchanged - it creates `Error` values
- This enforces EZ's PascalCase naming convention for non-primitive types

## Breaking Change

Code using lowercase `error` as a type annotation must be updated:

```ez
// Before (no longer valid)
do foo() -> error { ... }
temp e error = error("msg")

// After
do foo() -> Error { ... }
temp e Error = error("msg")
```

## Test plan

- [x] All integration tests pass (354/355, 1 unrelated timing test)
- [x] Lowercase `error` type correctly rejected with "undefined type 'error'"
- [x] Uppercase `Error` type works correctly
- [x] `error()` function still creates Error values

Closes #1039