### PR TITLE
Fix race condition by removing global eval state

### DIFF
--- a/cmd/ez/main.go
+++ b/cmd/ez/main.go
@@ -1006,13 +1006,12 @@ func runFile(filename string) {
 		Loader:      loader,
 		CurrentFile: absPath,
 	}
-	interpreter.SetEvalContext(ctx)
 
 	env := interpreter.NewEnvironment()
-	result := interpreter.Eval(program, env)
+	result := interpreter.Eval(program, env, ctx)
 
 	// Print any module loading warnings
-	if ctx := interpreter.GetEvalContext(); ctx != nil && ctx.Loader != nil {
+	if ctx.Loader != nil {
 		for _, warning := range ctx.Loader.GetWarnings() {
 			fmt.Print(errors.FormatError(warning))
 		}
@@ -1028,12 +1027,12 @@ func runFile(filename string) {
 	if mainFn, ok := env.Get("main"); ok {
 		if fn, ok := mainFn.(*interpreter.Function); ok {
 			fnEnv := interpreter.NewEnclosedEnvironment(env)
-			mainResult := interpreter.Eval(fn.Body, fnEnv)
+			mainResult := interpreter.Eval(fn.Body, fnEnv, ctx)
 
 			// Execute ensure statements before returning (LIFO order)
 			ensures := fnEnv.ExecuteEnsures()
 			for _, ensureCall := range ensures {
-				interpreter.Eval(ensureCall, fnEnv)
+				interpreter.Eval(ensureCall, fnEnv, ctx)
 				// Note: We ignore errors from ensure statements to ensure cleanup always runs
 			}
 			fnEnv.ClearEnsures()

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -85,7 +85,10 @@ func execute(source string) bool {
 
 	// Evaluation
 	env := interpreter.NewEnvironment()
-	result := interpreter.Eval(program, env)
+	ctx := &interpreter.EvalContext{
+		CurrentFile: filename,
+	}
+	result := interpreter.Eval(program, env, ctx)
 
 	// Check for evaluation errors
 	if errObj, ok := result.(*interpreter.Error); ok {
@@ -97,12 +100,12 @@ func execute(source string) bool {
 	if mainFn, ok := env.Get("main"); ok {
 		if fn, ok := mainFn.(*interpreter.Function); ok {
 			fnEnv := interpreter.NewEnclosedEnvironment(env)
-			mainResult := interpreter.Eval(fn.Body, fnEnv)
+			mainResult := interpreter.Eval(fn.Body, fnEnv, ctx)
 
 			// Execute ensure statements before returning (LIFO order)
 			ensures := fnEnv.ExecuteEnsures()
 			for _, ensureCall := range ensures {
-				interpreter.Eval(ensureCall, fnEnv)
+				interpreter.Eval(ensureCall, fnEnv, ctx)
 			}
 			fnEnv.ClearEnsures()
 

--- a/pkg/interpreter/evaluator_test.go
+++ b/pkg/interpreter/evaluator_test.go
@@ -22,7 +22,10 @@ func testEval(input string) Object {
 	p := parser.New(l)
 	program := p.ParseProgram()
 	env := NewEnvironment()
-	return Eval(program, env)
+	ctx := &EvalContext{
+		CurrentFile: "<test>",
+	}
+	return Eval(program, env, ctx)
 }
 
 func testIntegerObject(t *testing.T, obj Object, expected int64) bool {
@@ -4738,26 +4741,6 @@ func TestExtractModuleName(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestEvalContext(t *testing.T) {
-	// Test SetEvalContext and GetEvalContext
-	ctx := &EvalContext{
-		CurrentFile: "test.ez",
-	}
-
-	SetEvalContext(ctx)
-	retrieved := GetEvalContext()
-
-	if retrieved == nil {
-		t.Fatal("GetEvalContext returned nil")
-	}
-	if retrieved.CurrentFile != "test.ez" {
-		t.Errorf("CurrentFile = %q, want %q", retrieved.CurrentFile, "test.ez")
-	}
-
-	// Clean up
-	SetEvalContext(nil)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Eliminates race condition caused by global `callDepth` and `globalEvalContext` variables
- Moves `CallDepth` into `EvalContext` struct and threads context through all evaluation functions
- Removes `SetEvalContext()` and `GetEvalContext()` global accessors

## Test plan
- [x] All interpreter tests pass with `-race` flag
- [x] 355/356 integration tests pass (one unrelated timing test failure)
- [x] Build succeeds for all packages

Closes #949