### PR TITLE
Add NaN/finite checks and float constants to math module

### DIFF
--- a/integration-tests/pass/stdlib/math.ez
+++ b/integration-tests/pass/stdlib/math.ez
@@ -246,10 +246,67 @@ do main() {
         failed += 1
     }
 
+    // Test 23: is_nan for normal value
+    if math.is_nan(3.14) == false {
+        println("  [PASS] math.is_nan(3.14) = false")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] math.is_nan(3.14): expected false")
+        failed += 1
+    }
+
+    // Test 24: is_finite for normal value
+    if math.is_finite(3.14) == true {
+        println("  [PASS] math.is_finite(3.14) = true")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] math.is_finite(3.14): expected true")
+        failed += 1
+    }
+
+    // Test 25: is_finite for INF
+    if math.is_finite(math.INF) == false {
+        println("  [PASS] math.is_finite(math.INF) = false")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] math.is_finite(math.INF): expected false")
+        failed += 1
+    }
+
+    // ==================== NEW CONSTANTS ====================
+    println("  -- New Constants --")
+
+    // Test 26: EPSILON is positive and very small
+    if math.EPSILON > 0.0 && math.EPSILON < 0.001 {
+        println("  [PASS] math.EPSILON is a small positive value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] math.EPSILON: got ${math.EPSILON}")
+        failed += 1
+    }
+
+    // Test 27: MAX_FLOAT is very large
+    if math.MAX_FLOAT > 1000000000.0 {
+        println("  [PASS] math.MAX_FLOAT is very large")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] math.MAX_FLOAT: got ${math.MAX_FLOAT}")
+        failed += 1
+    }
+
+    // Test 28: MIN_FLOAT is positive and very small
+    if math.MIN_FLOAT > 0.0 && math.MIN_FLOAT < 0.001 {
+        println("  [PASS] math.MIN_FLOAT is a small positive value")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] math.MIN_FLOAT: got ${math.MIN_FLOAT}")
+        failed += 1
+    }
+
     // ==================== RANDOM ====================
     println("  -- Random --")
 
-    // Test 23: random generates value in range
+    // Test 29: random generates value in range
     temp rand_val int = math.random(100)
     if rand_val >= 0 && rand_val < 100 {
         println("  [PASS] math.random(100) in range [0, 100)")
@@ -262,7 +319,7 @@ do main() {
     // ==================== LARGE INTEGER PRECISION ====================
     println("  -- Large Integer Precision --")
 
-    // Test 24: math.add preserves precision for large integers (> 2^53)
+    // Test 30: math.add preserves precision for large integers (> 2^53)
     temp big1 int = 9007199254740993
     temp big2 int = 9007199254740993
     temp native_add = big1 + big2
@@ -275,7 +332,7 @@ do main() {
         failed += 1
     }
 
-    // Test 25: math.mul preserves precision for large integers
+    // Test 31: math.mul preserves precision for large integers
     temp mul_result = math.mul(big1, 2)
     temp native_mul = big1 * 2
     if native_mul == mul_result {
@@ -286,7 +343,7 @@ do main() {
         failed += 1
     }
 
-    // Test 26: math.factorial works for n > 20 (was limited before)
+    // Test 32: math.factorial works for n > 20 (was limited before)
     temp fact_25 = math.factorial(25)
     temp expected_fact_25 int = 15511210043330985984000000
     if fact_25 == expected_fact_25 {

--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -739,6 +739,24 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 		IsConstant: true,
 	},
+	"math.EPSILON": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Float{Value: math.Nextafter(1.0, 2.0) - 1.0}
+		},
+		IsConstant: true,
+	},
+	"math.MAX_FLOAT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Float{Value: math.MaxFloat64}
+		},
+		IsConstant: true,
+	},
+	"math.MIN_FLOAT": {
+		Fn: func(args ...object.Object) object.Object {
+			return &object.Float{Value: math.SmallestNonzeroFloat64}
+		},
+		IsConstant: true,
+	},
 
 	// Special value checks
 	"math.is_inf": {
@@ -751,6 +769,36 @@ var MathBuiltins = map[string]*object.Builtin{
 				return err
 			}
 			if math.IsInf(val, 0) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+	"math.is_nan": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "math.is_nan() takes exactly 1 argument"}
+			}
+			val, err := getNumber(args[0])
+			if err != nil {
+				return err
+			}
+			if math.IsNaN(val) {
+				return object.TRUE
+			}
+			return object.FALSE
+		},
+	},
+	"math.is_finite": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Code: "E7001", Message: "math.is_finite() takes exactly 1 argument"}
+			}
+			val, err := getNumber(args[0])
+			if err != nil {
+				return err
+			}
+			if !math.IsNaN(val) && !math.IsInf(val, 0) {
 				return object.TRUE
 			}
 			return object.FALSE

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -2255,6 +2255,99 @@ func TestMathIsInfFunc(t *testing.T) {
 	}
 }
 
+func TestMathIsNanFunc(t *testing.T) {
+	isnanFn := MathBuiltins["math.is_nan"].Fn
+
+	// Test with NaN
+	result := isnanFn(&object.Float{Value: math.NaN()})
+	boolVal, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("math.is_nan() returned %T, want Boolean", result)
+	}
+	if !boolVal.Value {
+		t.Errorf("math.is_nan(NaN) returned false, want true")
+	}
+
+	// Test with normal number
+	result = isnanFn(&object.Float{Value: 3.14})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("math.is_nan() returned %T, want Boolean", result)
+	}
+	if boolVal.Value {
+		t.Errorf("math.is_nan(3.14) returned true, want false")
+	}
+}
+
+func TestMathIsFiniteFunc(t *testing.T) {
+	isfiniteFn := MathBuiltins["math.is_finite"].Fn
+
+	// Test with normal number
+	result := isfiniteFn(&object.Float{Value: 3.14})
+	boolVal, ok := result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("math.is_finite() returned %T, want Boolean", result)
+	}
+	if !boolVal.Value {
+		t.Errorf("math.is_finite(3.14) returned false, want true")
+	}
+
+	// Test with infinity
+	result = isfiniteFn(&object.Float{Value: math.Inf(1)})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("math.is_finite() returned %T, want Boolean", result)
+	}
+	if boolVal.Value {
+		t.Errorf("math.is_finite(+Inf) returned true, want false")
+	}
+
+	// Test with NaN
+	result = isfiniteFn(&object.Float{Value: math.NaN()})
+	boolVal, ok = result.(*object.Boolean)
+	if !ok {
+		t.Fatalf("math.is_finite() returned %T, want Boolean", result)
+	}
+	if boolVal.Value {
+		t.Errorf("math.is_finite(NaN) returned true, want false")
+	}
+}
+
+func TestMathNewConstants(t *testing.T) {
+	// EPSILON
+	epsFn := MathBuiltins["math.EPSILON"].Fn
+	epsResult := epsFn()
+	epsFloat, ok := epsResult.(*object.Float)
+	if !ok {
+		t.Fatalf("math.EPSILON returned %T, want Float", epsResult)
+	}
+	if epsFloat.Value <= 0 || epsFloat.Value >= 1e-10 {
+		t.Errorf("math.EPSILON = %v, want small positive value", epsFloat.Value)
+	}
+
+	// MAX_FLOAT
+	maxFn := MathBuiltins["math.MAX_FLOAT"].Fn
+	maxResult := maxFn()
+	maxFloat, ok := maxResult.(*object.Float)
+	if !ok {
+		t.Fatalf("math.MAX_FLOAT returned %T, want Float", maxResult)
+	}
+	if maxFloat.Value != math.MaxFloat64 {
+		t.Errorf("math.MAX_FLOAT = %v, want %v", maxFloat.Value, math.MaxFloat64)
+	}
+
+	// MIN_FLOAT
+	minFn := MathBuiltins["math.MIN_FLOAT"].Fn
+	minResult := minFn()
+	minFloat, ok := minResult.(*object.Float)
+	if !ok {
+		t.Fatalf("math.MIN_FLOAT returned %T, want Float", minResult)
+	}
+	if minFloat.Value != math.SmallestNonzeroFloat64 {
+		t.Errorf("math.MIN_FLOAT = %v, want %v", minFloat.Value, math.SmallestNonzeroFloat64)
+	}
+}
+
 func TestMathIsPrime(t *testing.T) {
 	isprimeFn := MathBuiltins["math.is_prime"].Fn
 


### PR DESCRIPTION
## Summary
- Add `math.is_nan()` and `math.is_finite()` functions for float validation
- Add `math.EPSILON`, `math.MAX_FLOAT`, `math.MIN_FLOAT` constants
- Unit tests and integration tests included

## Test plan
- [x] Unit tests pass for new functions and constants
- [x] Integration tests pass (32/32 in math.ez)
- [x] Full build succeeds

Closes #1024