### PR TITLE
docs(stdlib): add doc comments to all stdlib modules

### DIFF
--- a/pkg/stdlib/arrays.go
+++ b/pkg/stdlib/arrays.go
@@ -25,6 +25,8 @@ func checkIterating(arr *object.Array, funcName string) *object.Error {
 
 // ArraysBuiltins contains the arrays module functions
 var ArraysBuiltins = map[string]*object.Builtin{
+	// is_empty checks if an array has no elements.
+	// Returns true if the array is empty, false otherwise.
 	"arrays.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -41,6 +43,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// append adds one or more elements to the end of an array.
+	// Modifies array in-place. Takes array and values to append.
 	"arrays.append": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -64,6 +68,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// unshift adds one or more elements to the beginning of an array.
+	// Modifies array in-place. Takes array and values to prepend.
 	"arrays.unshift": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -91,6 +97,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// insert adds an element at a specific index in the array.
+	// Takes array, index, and value. Modifies array in-place.
 	"arrays.insert": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -125,6 +133,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// pop removes and returns the last element of an array.
+	// Modifies array in-place. Returns error if array is empty.
 	"arrays.pop": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -152,6 +162,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// shift removes and returns the first element of an array.
+	// Modifies array in-place. Returns error if array is empty.
 	"arrays.shift": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -179,8 +191,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// arrays.remove_at(arr, index) - Removes element at the specified index.
-	// Modifies array in-place, returns NIL.
+	// remove_at removes the element at a specific index.
+	// Takes array and index. Modifies array in-place.
 	"arrays.remove_at": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -213,9 +225,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// arrays.remove_value(arr, value) - Removes the FIRST occurrence of the specified VALUE.
-	// Use arrays.remove() if you need to remove by index instead.
-	// Modifies array in-place, returns NIL. Does nothing if value not found.
+	// remove_value removes the first occurrence of a value from an array.
+	// Takes array and value. Modifies array in-place, does nothing if not found.
 	"arrays.remove_value": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -246,8 +257,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// arrays.remove_all(arr, value) - Removes ALL occurrences of the specified VALUE.
-	// Modifies array in-place, returns NIL.
+	// remove_all removes all occurrences of a value from an array.
+	// Takes array and value. Modifies array in-place.
 	"arrays.remove_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -277,6 +288,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// clear removes all elements from an array.
+	// Takes an array. Modifies array in-place.
 	"arrays.clear": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -300,6 +313,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// get returns the element at a specific index.
+	// Takes array and index. Returns error if index is out of bounds.
 	"arrays.get": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -321,6 +336,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// first returns the first element of an array.
+	// Takes an array. Returns nil if array is empty.
 	"arrays.first": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -337,6 +354,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// last returns the last element of an array.
+	// Takes an array. Returns nil if array is empty.
 	"arrays.last": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -353,6 +372,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// set replaces the element at a specific index with a new value.
+	// Takes array, index, and value. Modifies array in-place.
 	"arrays.set": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -384,6 +405,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// slice returns a new array containing elements from start to end index.
+	// Takes array, start index, and optional end index. Supports negative indices.
 	"arrays.slice": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -433,6 +456,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// take returns a new array with the first n elements.
+	// Takes array and count. Returns fewer elements if array is smaller.
 	"arrays.take": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -459,6 +484,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// drop returns a new array with the first n elements removed.
+	// Takes array and count. Returns empty array if count exceeds length.
 	"arrays.drop": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -485,6 +512,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// contains checks if an array contains a specific value.
+	// Takes array and value. Returns true if found, false otherwise.
 	"arrays.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -503,6 +532,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// index returns the index of the first occurrence of a value.
+	// Takes array and value. Returns -1 if not found.
 	"arrays.index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -521,6 +552,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// last_index returns the index of the last occurrence of a value.
+	// Takes array and value. Returns -1 if not found.
 	"arrays.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -539,6 +572,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// count returns the number of occurrences of a value in an array.
+	// Takes array and value. Returns integer count.
 	"arrays.count": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -558,6 +593,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// reverse returns a new array with elements in reverse order.
+	// Takes an array. Does not modify the original array.
 	"arrays.reverse": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -577,6 +614,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// sort sorts an array in ascending order.
+	// Takes an array. Modifies array in-place.
 	"arrays.sort": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -608,6 +647,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// sort_desc sorts an array in descending order.
+	// Takes an array. Modifies array in-place.
 	"arrays.sort_desc": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -639,6 +680,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// shuffle randomly reorders the elements of an array.
+	// Takes an array. Modifies array in-place using Fisher-Yates algorithm.
 	"arrays.shuffle": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -668,6 +711,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// concat combines two or more arrays into a new array.
+	// Takes two or more arrays. Returns a new array with all elements.
 	"arrays.concat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -689,6 +734,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// zip combines two arrays into an array of pairs.
+	// Takes two arrays. Returns array of [a, b] pairs up to shorter length.
 	"arrays.zip": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -716,6 +763,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// flatten flattens a nested array by one level.
+	// Takes an array of arrays. Returns a new flat array.
 	"arrays.flatten": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -748,6 +797,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// unique returns a new array with duplicate values removed.
+	// Takes an array. Preserves the order of first occurrences.
 	"arrays.unique": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -771,6 +822,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// duplicates returns a new array containing only values that appear more than once.
+	// Takes an array. Returns one copy of each duplicate value.
 	"arrays.duplicates": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -801,6 +854,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// sum returns the sum of all numeric elements in an array.
+	// Takes a numeric array. Returns int if all integers, float otherwise.
 	"arrays.sum": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -832,6 +887,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// product returns the product of all numeric elements in an array.
+	// Takes a numeric array. Returns 1 for empty arrays.
 	"arrays.product": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -866,6 +923,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// min returns the minimum value in an array.
+	// Takes a non-empty array. Returns error if array is empty.
 	"arrays.min": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -889,6 +948,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// max returns the maximum value in an array.
+	// Takes a non-empty array. Returns error if array is empty.
 	"arrays.max": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -912,6 +973,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// avg returns the average of all numeric elements in an array.
+	// Takes a non-empty numeric array. Returns a float.
 	"arrays.avg": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -941,6 +1004,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// repeat creates a new array with a value repeated n times.
+	// Takes value and count. Returns array with n copies of value.
 	"arrays.repeat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -962,6 +1027,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// fill replaces all elements in an array with a specified value.
+	// Takes array and value. Modifies array in-place.
 	"arrays.fill": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -987,6 +1054,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// join concatenates array elements into a string with a separator.
+	// Takes array and separator string. Returns combined string.
 	"arrays.join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -1009,6 +1078,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// all_equal checks if all elements in an array are equal.
+	// Takes an array. Returns true for empty or single-element arrays.
 	"arrays.all_equal": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1031,6 +1102,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// chunk splits an array into smaller arrays of a specified size.
+	// Takes array and size. Returns array of arrays.
 	"arrays.chunk": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -1065,6 +1138,8 @@ var ArraysBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// equals checks if two arrays have the same elements in the same order.
+	// Takes two arrays. Returns true if equal, false otherwise.
 	"arrays.equals": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/binary.go
+++ b/pkg/stdlib/binary.go
@@ -12,7 +12,6 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-
 // Helper to convert EZ byte array to Go []byte with length validation
 func binaryBytesToSlice(arg object.Object, expected int, funcName string) ([]byte, *object.Struct) {
 	arr, ok := arg.(*object.Array)
@@ -122,7 +121,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 8-bit Encoding/Decoding (no endianness needed)
 	// ============================================================================
 
-	// Encodes an i8 to a single byte
+	// encode_i8 encodes a signed 8-bit integer to a byte array.
+	// Takes an i8 value. Returns ([byte], Error) tuple.
 	"binary.encode_i8": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -146,7 +146,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Decodes a single byte to an i8
+	// decode_i8 decodes a byte array to a signed 8-bit integer.
+	// Takes a 1-byte array. Returns (i8, Error) tuple.
 	"binary.decode_i8": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -164,7 +165,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Encodes a u8 to a single byte
+	// encode_u8 encodes an unsigned 8-bit integer to a byte array.
+	// Takes a u8 value. Returns ([byte], Error) tuple.
 	"binary.encode_u8": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -188,7 +190,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Decodes a single byte to a u8
+	// decode_u8 decodes a byte array to an unsigned 8-bit integer.
+	// Takes a 1-byte array. Returns (u8, Error) tuple.
 	"binary.decode_u8": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -209,6 +212,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 16-bit Encoding (Little Endian)
 	// ============================================================================
 
+	// encode_i16_to_little_endian encodes an i16 to little-endian byte array.
+	// Takes an i16 value. Returns ([byte], Error) tuple.
 	"binary.encode_i16_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -234,6 +239,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// decode_i16_from_little_endian decodes a little-endian byte array to i16.
+	// Takes a 2-byte array. Returns (i16, Error) tuple.
 	"binary.decode_i16_from_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -251,6 +258,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// encode_u16_to_little_endian encodes a u16 to little-endian byte array.
+	// Takes a u16 value. Returns ([byte], Error) tuple.
 	"binary.encode_u16_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -276,6 +285,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// decode_u16_from_little_endian decodes a little-endian byte array to u16.
+	// Takes a 2-byte array. Returns (u16, Error) tuple.
 	"binary.decode_u16_from_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -297,6 +308,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 16-bit Encoding (Big Endian)
 	// ============================================================================
 
+	// encode_i16_to_big_endian encodes an i16 to big-endian byte array.
+	// Takes an i16 value. Returns ([byte], Error) tuple.
 	"binary.encode_i16_to_big_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -385,6 +398,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 32-bit Encoding (Little Endian)
 	// ============================================================================
 
+	// encode_i32_to_little_endian encodes an i32 to little-endian byte array.
+	// Takes an i32 value. Returns ([byte], Error) tuple.
 	"binary.encode_i32_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -472,6 +487,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 32-bit Encoding (Big Endian)
 	// ============================================================================
 
+	// encode_i32_to_big_endian encodes an i32 to big-endian byte array.
+	// Takes an i32 value. Returns ([byte], Error) tuple.
 	"binary.encode_i32_to_big_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -559,6 +576,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 64-bit Encoding (Little Endian)
 	// ============================================================================
 
+	// encode_i64_to_little_endian encodes an i64 to little-endian byte array.
+	// Takes an i64 value. Returns ([byte], Error) tuple.
 	"binary.encode_i64_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -648,6 +667,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 64-bit Encoding (Big Endian)
 	// ============================================================================
 
+	// encode_i64_to_big_endian encodes an i64 to big-endian byte array.
+	// Takes an i64 value. Returns ([byte], Error) tuple.
 	"binary.encode_i64_to_big_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -737,6 +758,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 128-bit Encoding (Little Endian)
 	// ============================================================================
 
+	// encode_i128_to_little_endian encodes an i128 to little-endian byte array.
+	// Takes an i128 value. Returns ([byte], Error) tuple.
 	"binary.encode_i128_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -833,6 +856,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 128-bit Encoding (Big Endian)
 	// ============================================================================
 
+	// encode_i128_to_big_endian encodes an i128 to big-endian byte array.
+	// Takes an i128 value. Returns ([byte], Error) tuple.
 	"binary.encode_i128_to_big_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -925,6 +950,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 256-bit Encoding (Little Endian)
 	// ============================================================================
 
+	// encode_i256_to_little_endian encodes an i256 to little-endian byte array.
+	// Takes an i256 value. Returns ([byte], Error) tuple.
 	"binary.encode_i256_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1018,6 +1045,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// 256-bit Encoding (Big Endian)
 	// ============================================================================
 
+	// encode_i256_to_big_endian encodes an i256 to big-endian byte array.
+	// Takes an i256 value. Returns ([byte], Error) tuple.
 	"binary.encode_i256_to_big_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1109,6 +1138,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// Float Encoding (Little Endian)
 	// ============================================================================
 
+	// encode_f32_to_little_endian encodes an f32 to little-endian byte array.
+	// Takes an f32 value. Returns ([byte], Error) tuple.
 	"binary.encode_f32_to_little_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1199,6 +1230,8 @@ var BinaryBuiltins = map[string]*object.Builtin{
 	// Float Encoding (Big Endian)
 	// ============================================================================
 
+	// encode_f32_to_big_endian encodes an f32 to big-endian byte array.
+	// Takes an f32 value. Returns ([byte], Error) tuple.
 	"binary.encode_f32_to_big_endian": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/builtins.go
+++ b/pkg/stdlib/builtins.go
@@ -24,7 +24,6 @@ var stdinReader = bufio.NewReader(os.Stdin)
 // Track if stdin EOF has been encountered - subsequent reads will exit gracefully
 var stdinEOFReached = false
 
-
 // isImmutablePrimitive returns true if the object is an immutable primitive type.
 // These types don't need deep copying - they can be shared safely.
 // Note: Integer is excluded because big.Int is mutable.
@@ -189,7 +188,8 @@ func extractFloatValue(arg object.Object, targetType string) (float64, *object.E
 
 // StdBuiltins contains the core standard library functions
 var StdBuiltins = map[string]*object.Builtin{
-	// Prints values to standard output followed by a newline
+	// println prints values to standard output followed by a newline.
+	// Accepts any number of arguments, separated by spaces in output.
 	"std.println": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
@@ -209,8 +209,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Prints values to standard output WITHOUT a newline
-	// User must explicitly add \n for newlines
+	// print prints values to standard output without a trailing newline.
+	// Accepts any number of arguments, separated by spaces in output.
 	"std.print": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
@@ -229,7 +229,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Reads an integer from standard input
+	// read_int reads an integer from standard input.
+	// Returns (int, Error) tuple where Error is nil on success.
 	"read_int": {
 		Fn: func(args ...object.Object) object.Object {
 			// If EOF was already reached, exit gracefully to prevent infinite loops
@@ -292,8 +293,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the length of a string or array
-	// For strings, returns character count (not byte count) to properly support UTF-8
+	// len returns the length of a string, array, or map.
+	// For strings, returns character count (not byte count) for UTF-8 support.
 	"len": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -314,7 +315,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the type of the given object as a string
+	// typeof returns the type of a value as a string.
+	// Takes exactly one argument and returns its type name.
 	"typeof": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -324,7 +326,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to an integer
+	// int converts a value to an integer.
+	// Accepts int, float, string, char, byte, or enum values.
 	"int": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -439,7 +442,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a float
+	// float converts a value to a floating-point number.
+	// Accepts float, int, or string values.
 	"float": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -483,7 +487,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a string
+	// string converts any value to its string representation.
+	// Takes exactly one argument and returns its string form.
 	"string": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -493,7 +498,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a char (Unicode code point)
+	// char converts a value to a character (Unicode code point).
+	// Accepts char, int, float, byte, or single-character string.
 	"char": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -537,7 +543,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a byte (0-255)
+	// byte converts a value to a byte (0-255).
+	// Accepts byte, int, float, char, or numeric string.
 	"byte": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -605,7 +612,8 @@ var StdBuiltins = map[string]*object.Builtin{
 	// Sized Integer Conversion Functions
 	// ============================================================================
 
-	// Converts a value to an i8 (signed 8-bit integer, -128 to 127)
+	// i8 converts a value to a signed 8-bit integer.
+	// Range: -128 to 127. Returns error if value is out of range.
 	"i8": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -625,7 +633,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to an i16 (signed 16-bit integer, -32768 to 32767)
+	// i16 converts a value to a signed 16-bit integer.
+	// Range: -32768 to 32767. Returns error if value is out of range.
 	"i16": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -645,7 +654,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to an i32 (signed 32-bit integer)
+	// i32 converts a value to a signed 32-bit integer.
+	// Range: -2147483648 to 2147483647. Returns error if value is out of range.
 	"i32": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -667,7 +677,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to an i64 (signed 64-bit integer)
+	// i64 converts a value to a signed 64-bit integer.
+	// Range: -9223372036854775808 to 9223372036854775807.
 	"i64": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -689,7 +700,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to an i128 (signed 128-bit integer)
+	// i128 converts a value to a signed 128-bit integer.
+	// Range: -2^127 to 2^127-1. Returns error if value is out of range.
 	"i128": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -712,7 +724,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to an i256 (signed 256-bit integer)
+	// i256 converts a value to a signed 256-bit integer.
+	// Range: -2^255 to 2^255-1. Returns error if value is out of range.
 	"i256": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -735,7 +748,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a u8 (unsigned 8-bit integer, 0 to 255)
+	// u8 converts a value to an unsigned 8-bit integer.
+	// Range: 0 to 255. Returns error if value is out of range.
 	"u8": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -755,7 +769,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a u16 (unsigned 16-bit integer, 0 to 65535)
+	// u16 converts a value to an unsigned 16-bit integer.
+	// Range: 0 to 65535. Returns error if value is out of range.
 	"u16": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -775,7 +790,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a u32 (unsigned 32-bit integer, 0 to 4294967295)
+	// u32 converts a value to an unsigned 32-bit integer.
+	// Range: 0 to 4294967295. Returns error if value is out of range.
 	"u32": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -796,7 +812,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a u64 (unsigned 64-bit integer)
+	// u64 converts a value to an unsigned 64-bit integer.
+	// Range: 0 to 18446744073709551615. Returns error if value is out of range.
 	"u64": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -817,7 +834,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a u128 (unsigned 128-bit integer)
+	// u128 converts a value to an unsigned 128-bit integer.
+	// Range: 0 to 2^128-1. Returns error if value is out of range.
 	"u128": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -839,7 +857,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a u256 (unsigned 256-bit integer)
+	// u256 converts a value to an unsigned 256-bit integer.
+	// Range: 0 to 2^256-1. Returns error if value is out of range.
 	"u256": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -861,7 +880,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a float32
+	// f32 converts a value to a 32-bit floating-point number.
+	// Truncates precision to float32 range and precision.
 	"f32": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -877,7 +897,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts a value to a float64
+	// f64 converts a value to a 64-bit floating-point number.
+	// Provides full double-precision floating-point range.
 	"f64": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -891,7 +912,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Reads a line of input from standard input
+	// input reads a line of text from standard input.
+	// Returns the input as a string with trailing newline removed.
 	"input": {
 		Fn: func(args ...object.Object) object.Object {
 			// If EOF was already reached, exit gracefully to prevent infinite loops
@@ -911,8 +933,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates a deep copy of a value
-	// Primitives return themselves, structs/arrays/maps are recursively copied
+	// copy creates a deep copy of a value.
+	// Primitives return themselves; structs, arrays, and maps are recursively copied.
 	"copy": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -922,9 +944,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates a user-defined error with the given message
-	// Returns an Error struct with .message set to the argument and .code set to empty string
-	// This is different from object.Error which is a runtime error that halts execution
+	// error creates a user-defined error with the given message.
+	// Returns an Error struct with .message and .code fields (code is empty string).
 	"error": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -945,7 +966,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// EXIT_SUCCESS constant - returns 0 (global builtin, no import needed)
+	// EXIT_SUCCESS is a constant representing successful program termination (0).
+	// Global builtin, no import needed.
 	"EXIT_SUCCESS": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
@@ -953,7 +975,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// EXIT_FAILURE constant - returns 1 (global builtin, no import needed)
+	// EXIT_FAILURE is a constant representing failed program termination (1).
+	// Global builtin, no import needed.
 	"EXIT_FAILURE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
@@ -961,11 +984,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Exits the program with the given exit code (global builtin, no import needed)
-	// Example:
-	//   exit(0)            // exit successfully
-	//   exit(EXIT_SUCCESS) // same as above
-	//   exit(EXIT_FAILURE) // exit with error code 1
+	// exit terminates the program with the given exit code.
+	// Takes an integer exit code. Global builtin, no import needed.
 	"exit": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -980,7 +1000,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Sleeps for the given number of seconds
+	// sleep_seconds pauses execution for the given number of seconds.
+	// Takes a non-negative integer. Returns nil.
 	"std.sleep_seconds": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -998,7 +1019,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Sleeps for the given number of milliseconds
+	// sleep_milliseconds pauses execution for the given number of milliseconds.
+	// Takes a non-negative integer. Returns nil.
 	"std.sleep_milliseconds": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1016,7 +1038,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Sleeps for the given number of nanoseconds
+	// sleep_nanoseconds pauses execution for the given number of nanoseconds.
+	// Takes a non-negative integer. Returns nil.
 	"std.sleep_nanoseconds": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1034,10 +1057,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Terminates the program with an error message (global builtin, no import needed)
-	// Use panic() when something truly unrecoverable happens.
-	// Example:
-	//   panic("something went terribly wrong")
+	// panic terminates the program with an error message.
+	// Takes a string message. Global builtin, no import needed.
 	"panic": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1051,19 +1072,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Prints values to standard error (stderr) followed by a newline.
-	//
-	// Why use eprintln() instead of println()?
-	// - println() writes to "stdout" (standard output) - for normal program output
-	// - eprintln() writes to "stderr" (standard error) - for error messages and diagnostics
-	//
-	// Both display in your terminal by default, but they can be separated:
-	//   ./ez myprogram.ez > output.txt    # stdout goes to file, stderr still shows
-	//   ./ez myprogram.ez 2> errors.txt   # stderr goes to file, stdout still shows
-	//
-	// Example:
-	//   eprintln("Error: file not found")
-	//   eprintln("Warning:", "value is", 0)
+	// eprintln prints values to standard error (stderr) followed by a newline.
+	// Accepts any number of arguments, separated by spaces in output.
 	"std.eprintln": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
@@ -1081,14 +1091,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Prints values to standard error (stderr) WITHOUT a newline.
-	// Same as eprintln() but doesn't add a newline at the end.
-	// See eprintln() documentation for when to use stderr vs stdout.
-	//
-	// Example:
-	//   eprint("Loading...")
-	//   // do work
-	//   eprintln(" done!")  // Output: "Loading... done!"
+	// eprint prints values to standard error (stderr) without a trailing newline.
+	// Accepts any number of arguments, separated by spaces in output.
 	"std.eprint": {
 		Fn: func(args ...object.Object) object.Object {
 			for i, arg := range args {
@@ -1105,11 +1109,8 @@ var StdBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Asserts that a condition is true, otherwise terminates with an error (global builtin, no import needed)
-	// Use assert() to verify assumptions during development and catch bugs early.
-	// Example:
-	//   assert(x > 0, "x must be positive")
-	//   assert(len(items) > 0, "items cannot be empty")
+	// assert verifies a condition is true, otherwise terminates with an error.
+	// Takes a boolean condition and a string message. Global builtin, no import needed.
 	"assert": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/bytes.go
+++ b/pkg/stdlib/bytes.go
@@ -14,14 +14,14 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-
 // BytesBuiltins contains the bytes module functions for binary data operations
 var BytesBuiltins = map[string]*object.Builtin{
 	// ============================================================================
 	// Creation Functions
 	// ============================================================================
 
-	// Creates bytes from an array of integers (0-255)
+	// from_array creates a byte array from an array of integers.
+	// Takes array of integers (0-255). Returns byte array.
 	"bytes.from_array": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -52,7 +52,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates bytes from a UTF-8 encoded string
+	// from_string creates a byte array from a UTF-8 encoded string.
+	// Takes a string. Returns byte array with UTF-8 bytes.
 	"bytes.from_string": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -72,8 +73,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates bytes from a hexadecimal string
-	// Returns (bytes, error)
+	// from_hex creates a byte array from a hexadecimal string.
+	// Takes hex string. Returns ([byte], Error) tuple.
 	"bytes.from_hex": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -103,8 +104,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates bytes from a base64 encoded string
-	// Returns (bytes, error)
+	// from_base64 creates a byte array from a base64 encoded string.
+	// Takes base64 string. Returns ([byte], Error) tuple.
 	"bytes.from_base64": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -138,7 +139,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 	// Conversion Functions
 	// ============================================================================
 
-	// Converts bytes to UTF-8 string
+	// to_string converts a byte array to a UTF-8 string.
+	// Takes byte array. Returns string.
 	"bytes.to_string": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -170,7 +172,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts bytes to array of integers
+	// to_array converts a byte array to an array of integers.
+	// Takes byte array. Returns integer array.
 	"bytes.to_array": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -196,7 +199,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts bytes to lowercase hexadecimal string
+	// to_hex converts a byte array to a lowercase hexadecimal string.
+	// Takes byte array. Returns hex string.
 	"bytes.to_hex": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -210,7 +214,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts bytes to uppercase hexadecimal string
+	// to_hex_upper converts a byte array to an uppercase hexadecimal string.
+	// Takes byte array. Returns uppercase hex string.
 	"bytes.to_hex_upper": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -224,7 +229,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Converts bytes to base64 encoded string
+	// to_base64 converts a byte array to a base64 encoded string.
+	// Takes byte array. Returns base64 string.
 	"bytes.to_base64": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -242,7 +248,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 	// Operations
 	// ============================================================================
 
-	// Extracts a portion of bytes (end is exclusive, supports negative indices)
+	// slice extracts a portion of bytes from start to end index.
+	// Takes bytes, start, end. Supports negative indices. End is exclusive.
 	"bytes.slice": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -290,7 +297,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Concatenates two byte sequences
+	// concat joins two byte arrays into one.
+	// Takes two byte arrays. Returns combined byte array.
 	"bytes.concat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -312,7 +320,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Joins array of bytes with separator
+	// join combines multiple byte arrays with a separator.
+	// Takes array of byte arrays and separator. Returns combined bytes.
 	"bytes.join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -346,7 +355,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Splits bytes by separator
+	// split divides bytes into parts using a separator.
+	// Takes bytes and separator. Returns array of byte arrays.
 	"bytes.split": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -374,7 +384,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if bytes contain a pattern
+	// contains checks if bytes contain a byte pattern.
+	// Takes bytes and pattern. Returns true if found.
 	"bytes.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -396,7 +407,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Finds first index of pattern, or -1 if not found
+	// index finds the first occurrence of a pattern in bytes.
+	// Takes bytes and pattern. Returns index or -1 if not found.
 	"bytes.index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -415,7 +427,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Finds last index of pattern, or -1 if not found
+	// last_index finds the last occurrence of a pattern in bytes.
+	// Takes bytes and pattern. Returns index or -1 if not found.
 	"bytes.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -434,7 +447,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Counts non-overlapping occurrences of pattern
+	// count returns the number of non-overlapping pattern occurrences.
+	// Takes bytes and pattern. Returns integer count.
 	"bytes.count": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -453,7 +467,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Lexicographically compares two byte sequences (-1, 0, 1)
+	// compare lexicographically compares two byte arrays.
+	// Takes two byte arrays. Returns -1, 0, or 1.
 	"bytes.compare": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -472,7 +487,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if two byte sequences are equal
+	// equals checks if two byte arrays are identical.
+	// Takes two byte arrays. Returns true if equal.
 	"bytes.equals": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -498,7 +514,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 	// Inspection Functions
 	// ============================================================================
 
-	// Checks if bytes are empty (length 0)
+	// is_empty checks if a byte array has no elements.
+	// Takes byte array. Returns true if empty.
 	"bytes.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -516,7 +533,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if bytes start with prefix
+	// starts_with checks if bytes begin with a prefix.
+	// Takes bytes and prefix. Returns true if bytes start with prefix.
 	"bytes.starts_with": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -538,7 +556,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if bytes end with suffix
+	// ends_with checks if bytes end with a suffix.
+	// Takes bytes and suffix. Returns true if bytes end with suffix.
 	"bytes.ends_with": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -564,7 +583,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 	// Manipulation Functions
 	// ============================================================================
 
-	// Returns reversed copy of bytes
+	// reverse returns a new byte array with elements in reverse order.
+	// Takes byte array. Returns reversed copy.
 	"bytes.reverse": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -584,7 +604,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Repeats bytes N times
+	// repeat creates a new byte array by repeating bytes n times.
+	// Takes bytes and count. Returns repeated bytes.
 	"bytes.repeat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -611,7 +632,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Replaces all occurrences of old with new
+	// replace replaces all occurrences of old bytes with new bytes.
+	// Takes bytes, old pattern, new pattern. Returns modified bytes.
 	"bytes.replace": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -635,7 +657,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Replaces first N occurrences of old with new
+	// replace_n replaces the first n occurrences of old bytes with new bytes.
+	// Takes bytes, old, new, count. Returns modified bytes.
 	"bytes.replace_n": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 4 {
@@ -663,7 +686,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Removes leading and trailing bytes that appear in cutset
+	// trim removes leading and trailing bytes that appear in cutset.
+	// Takes bytes and cutset. Returns trimmed bytes.
 	"bytes.trim": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -683,7 +707,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Removes leading bytes that appear in cutset
+	// trim_left removes leading bytes that appear in cutset.
+	// Takes bytes and cutset. Returns left-trimmed bytes.
 	"bytes.trim_left": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -703,7 +728,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Removes trailing bytes that appear in cutset
+	// trim_right removes trailing bytes that appear in cutset.
+	// Takes bytes and cutset. Returns right-trimmed bytes.
 	"bytes.trim_right": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -723,7 +749,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Pads bytes on the left to reach specified length
+	// pad_left pads bytes on the left to reach specified length.
+	// Takes bytes, target length, pad byte. Returns padded bytes.
 	"bytes.pad_left": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -761,7 +788,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Pads bytes on the right to reach specified length
+	// pad_right pads bytes on the right to reach specified length.
+	// Takes bytes, target length, pad byte. Returns padded bytes.
 	"bytes.pad_right": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -802,7 +830,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 	// Bitwise Operations
 	// ============================================================================
 
-	// Bitwise AND of two byte sequences (must be same length)
+	// and performs bitwise AND on two equal-length byte arrays.
+	// Takes two byte arrays. Returns ([byte], Error) tuple.
 	"bytes.and": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -835,7 +864,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Bitwise OR of two byte sequences (must be same length)
+	// or performs bitwise OR on two equal-length byte arrays.
+	// Takes two byte arrays. Returns ([byte], Error) tuple.
 	"bytes.or": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -868,7 +898,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Bitwise XOR of two byte sequences (must be same length)
+	// xor performs bitwise XOR on two equal-length byte arrays.
+	// Takes two byte arrays. Returns ([byte], Error) tuple.
 	"bytes.xor": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -901,7 +932,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Bitwise NOT (complement) of bytes
+	// not performs bitwise NOT (complement) on a byte array.
+	// Takes byte array. Returns complemented bytes.
 	"bytes.not": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -924,7 +956,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 	// Utility Functions
 	// ============================================================================
 
-	// Fills all bytes with a single value
+	// fill creates a new byte array with all bytes set to a value.
+	// Takes byte array and fill value. Returns filled bytes.
 	"bytes.fill": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -947,7 +980,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates a copy of bytes
+	// copy creates a duplicate of a byte array.
+	// Takes byte array. Returns new byte array copy.
 	"bytes.copy": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -964,7 +998,8 @@ var BytesBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Fills all bytes with zero (for securely clearing sensitive data)
+	// zero creates a new byte array with all bytes set to zero.
+	// Takes byte array. Returns zeroed bytes (for clearing sensitive data).
 	"bytes.zero": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/crypto.go
+++ b/pkg/stdlib/crypto.go
@@ -16,7 +16,8 @@ import (
 
 // CryptoBuiltins contains the crypto module functions
 var CryptoBuiltins = map[string]*object.Builtin{
-	// crypto.sha256(data) - returns SHA-256 hash as lowercase hex string
+	// sha256 computes the SHA-256 hash of a string.
+	// Takes a string. Returns lowercase hex-encoded hash.
 	"crypto.sha256": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -33,7 +34,8 @@ var CryptoBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// crypto.sha512(data) - returns SHA-512 hash as lowercase hex string
+	// sha512 computes the SHA-512 hash of a string.
+	// Takes a string. Returns lowercase hex-encoded hash.
 	"crypto.sha512": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -50,8 +52,8 @@ var CryptoBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// crypto.md5(data) - returns MD5 hash as lowercase hex string
-	// Note: MD5 is cryptographically broken, use only for checksums/legacy
+	// md5 computes the MD5 hash of a string (legacy, not secure).
+	// Takes a string. Returns lowercase hex-encoded hash.
 	"crypto.md5": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -68,7 +70,8 @@ var CryptoBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// crypto.random_bytes(length) - returns cryptographically secure random bytes
+	// random_bytes generates cryptographically secure random bytes.
+	// Takes length as integer. Returns byte array.
 	"crypto.random_bytes": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -103,8 +106,8 @@ var CryptoBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// crypto.random_hex(length) - returns cryptographically secure random hex string
-	// length is the number of bytes, output will be 2*length characters
+	// random_hex generates cryptographically secure random hex string.
+	// Takes byte count. Returns hex string (2*length characters).
 	"crypto.random_hex": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/db.go
+++ b/pkg/stdlib/db.go
@@ -10,15 +10,14 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-// DBBuiltings contains the db module functions for database operations
+// DBBuiltins contains the db module functions for database operations
 var DBBuiltins = map[string]*object.Builtin{
 	// ============================================================================
 	// Database Management
 	// ============================================================================
 
-	// Opens database using provided path
-	// Creates new database file if it does not exist
-	// Returns (database, error) tuple - error is nil on success
+	// open opens or creates a database file at the given path.
+	// Takes path string (.ezdb). Returns (Database, Error) tuple.
 	"db.open": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -112,9 +111,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Closes the database and prevents further actions on the database
-	// Saves state of database to disk when closing
-	// Returns (error) - error is nil on success
+	// close closes a database and saves its state to disk.
+	// Takes Database. Returns nil on success, prevents further operations.
 	"db.close": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -146,8 +144,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Manual saving of database to disk
-	// Returns (error) - error is nil on success
+	// save manually persists the database state to disk.
+	// Takes Database. Returns nil on success.
 	"db.save": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -181,8 +179,8 @@ var DBBuiltins = map[string]*object.Builtin{
 	// Database Operations
 	// ============================================================================
 
-	// Sets a key value pair in database
-	// Returns nothing
+	// set stores a key-value pair in the database.
+	// Takes Database, key string, value string. Returns nil.
 	"db.set": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -214,8 +212,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns value associated with key if it exists
-	// Returns (string, bool) - string is empty if key does not exist
+	// get retrieves a value by key from the database.
+	// Takes Database, key. Returns (string, bool) where bool is found status.
 	"db.get": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -251,8 +249,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Removes key value pair from database
-	// Returns (bool) - false if key does not exist
+	// remove deletes a key-value pair from the database.
+	// Takes Database, key. Returns true if key existed.
 	"db.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -278,8 +276,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if key exists in database
-	// Returns (bool)
+	// contains checks if a key exists in the database.
+	// Takes Database, key. Returns true if key exists.
 	"db.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -305,8 +303,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Fetches array of keys present in database
-	// Returns ([string])
+	// keys returns an array of all keys in the database.
+	// Takes Database. Returns [string] array.
 	"db.keys": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -334,8 +332,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Fetches array of values present in database
-	// Returns ([any])
+	// values returns an array of all values in the database.
+	// Takes Database. Returns array of values.
 	"db.values": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -363,8 +361,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Fetches all key-value pairs in database
-	// Returns ([{key: string, value: any}])
+	// entries returns all key-value pairs as Entry structs.
+	// Takes Database. Returns array of {key, value} structs.
 	"db.entries": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -400,8 +398,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Fetches keys with prefix in database
-	// Returns ([string])
+	// prefix returns all keys that start with a given prefix.
+	// Takes Database, prefix string. Returns [string] array.
 	"db.prefix": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -437,8 +435,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Number of key value pairs in database
-	// Returns (int)
+	// count returns the number of key-value pairs in the database.
+	// Takes Database. Returns integer count.
 	"db.count": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -459,8 +457,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Clears all key value pairs in database
-	// Returns nothing
+	// clear removes all key-value pairs from the database.
+	// Takes Database. Returns nil.
 	"db.clear": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -482,8 +480,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if a database file exists at the given path
-	// Returns (bool)
+	// exists checks if a database file exists at the given path.
+	// Takes path string. Returns true if file exists.
 	"db.exists": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -504,8 +502,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Renames a key in the database
-	// Returns (bool) - false if old key does not exist
+	// update_key_name renames a key in the database.
+	// Takes Database, old key, new key. Returns true if old key existed.
 	"db.update_key_name": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -545,8 +543,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Sorts database keys by specified order
-	// Returns nothing
+	// sort reorders database entries by the specified sort order.
+	// Takes Database, order constant (e.g., db.ALPHA). Returns nil.
 	"db.sort": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -656,7 +654,8 @@ var DBBuiltins = map[string]*object.Builtin{
 	// Database Constants
 	// ============================================================================
 
-	// Sort order: keys alphabetically A-Z
+	// ALPHA is a sort order constant for keys alphabetically A-Z.
+	// Use with db.sort().
 	"db.ALPHA": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
@@ -664,7 +663,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: keys alphabetically Z-A
+	// ALPHA_DESC is a sort order constant for keys alphabetically Z-A.
+	// Use with db.sort().
 	"db.ALPHA_DESC": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
@@ -672,7 +672,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: values alphabetically A-Z
+	// VALUE_ALPHA is a sort order constant for values alphabetically A-Z.
+	// Use with db.sort().
 	"db.VALUE_ALPHA": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
@@ -680,7 +681,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: values alphabetically Z-A
+	// VALUE_ALPHA_DESC is a sort order constant for values alphabetically Z-A.
+	// Use with db.sort().
 	"db.VALUE_ALPHA_DESC": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3)}
@@ -688,7 +690,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: shortest keys first
+	// KEY_LEN is a sort order constant for shortest keys first.
+	// Use with db.sort().
 	"db.KEY_LEN": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(4)}
@@ -696,7 +699,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: longest keys first
+	// KEY_LEN_DESC is a sort order constant for longest keys first.
+	// Use with db.sort().
 	"db.KEY_LEN_DESC": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(5)}
@@ -704,7 +708,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: shortest values first
+	// VALUE_LEN is a sort order constant for shortest values first.
+	// Use with db.sort().
 	"db.VALUE_LEN": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(6)}
@@ -712,7 +717,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: longest values first
+	// VALUE_LEN_DESC is a sort order constant for longest values first.
+	// Use with db.sort().
 	"db.VALUE_LEN_DESC": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(7)}
@@ -720,7 +726,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: keys numerically ascending
+	// NUMERIC is a sort order constant for keys numerically ascending.
+	// Use with db.sort().
 	"db.NUMERIC": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(8)}
@@ -728,7 +735,8 @@ var DBBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Sort order: keys numerically descending
+	// NUMERIC_DESC is a sort order constant for keys numerically descending.
+	// Use with db.sort().
 	"db.NUMERIC_DESC": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(9)}

--- a/pkg/stdlib/encoding.go
+++ b/pkg/stdlib/encoding.go
@@ -11,10 +11,10 @@ import (
 	"github.com/marshallburns/ez/pkg/object"
 )
 
-
 // EncodingBuiltins contains the encoding module functions
 var EncodingBuiltins = map[string]*object.Builtin{
-	// encoding.base64_encode(data) - encodes string to base64
+	// base64_encode encodes a string to base64 format.
+	// Takes a string. Returns base64-encoded string.
 	"encoding.base64_encode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -31,7 +31,8 @@ var EncodingBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// encoding.base64_decode(data) - decodes base64 to string
+	// base64_decode decodes a base64-encoded string.
+	// Takes base64 string. Returns (string, Error) tuple.
 	"encoding.base64_decode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -58,7 +59,8 @@ var EncodingBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// encoding.hex_encode(data) - encodes string to hex
+	// hex_encode encodes a string to hexadecimal format.
+	// Takes a string. Returns hex-encoded string.
 	"encoding.hex_encode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -75,7 +77,8 @@ var EncodingBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// encoding.hex_decode(data) - decodes hex to string
+	// hex_decode decodes a hexadecimal-encoded string.
+	// Takes hex string. Returns (string, Error) tuple.
 	"encoding.hex_decode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -102,7 +105,8 @@ var EncodingBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// encoding.url_encode(data) - URL percent-encodes a string
+	// url_encode percent-encodes a string for use in URLs.
+	// Takes a string. Returns URL-encoded string.
 	"encoding.url_encode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -119,7 +123,8 @@ var EncodingBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// encoding.url_decode(data) - decodes URL percent-encoding
+	// url_decode decodes a URL percent-encoded string.
+	// Takes URL-encoded string. Returns (string, Error) tuple.
 	"encoding.url_decode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/http.go
+++ b/pkg/stdlib/http.go
@@ -41,6 +41,8 @@ var defaultClient = &http.Client{
 }
 
 var HttpBuiltins = map[string]*object.Builtin{
+	// get performs an HTTP GET request to the specified URL.
+	// Takes URL string. Returns (HttpResponse, Error) tuple.
 	"http.get": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -107,6 +109,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// post performs an HTTP POST request with a request body.
+	// Takes URL string and body string. Returns (HttpResponse, Error) tuple.
 	"http.post": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -178,6 +182,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// put performs an HTTP PUT request with a request body.
+	// Takes URL string and body string. Returns (HttpResponse, Error) tuple.
 	"http.put": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -249,6 +255,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// delete performs an HTTP DELETE request to the specified URL.
+	// Takes URL string. Returns (HttpResponse, Error) tuple.
 	"http.delete": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -315,6 +323,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// patch performs an HTTP PATCH request with a request body.
+	// Takes URL string and body string. Returns (HttpResponse, Error) tuple.
 	"http.patch": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -386,6 +396,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// request performs a configurable HTTP request with custom method, headers, and timeout.
+	// Takes method, URL, body, headers map, and timeout (seconds). Returns (HttpResponse, Error) tuple.
 	"http.request": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 5 {
@@ -504,6 +516,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// build_query encodes a map as a URL query string.
+	// Takes map[string:string]. Returns URL-encoded query string.
 	"http.build_query": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -532,6 +546,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// json_body encodes a map as a JSON string for use in request bodies.
+	// Takes a map. Returns JSON string.
 	"http.json_body": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -552,6 +568,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// head performs an HTTP HEAD request to retrieve headers without body.
+	// Takes URL string. Returns (HttpResponse, Error) tuple with empty body.
 	"http.head": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -608,6 +626,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// options performs an HTTP OPTIONS request to query supported methods.
+	// Takes URL string. Returns (HttpResponse, Error) tuple.
 	"http.options": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -674,6 +694,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// download fetches a URL and saves the content to a file.
+	// Takes URL string and file path. Returns (bytes_written, Error) tuple.
 	"http.download": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -745,6 +767,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// parse_url parses a URL string into its component parts.
+	// Takes URL string. Returns (URL struct, Error) tuple.
 	"http.parse_url": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -794,6 +818,8 @@ var HttpBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// build_url constructs a URL string from component parts.
+	// Takes URL struct with scheme, host, port, path, query, fragment. Returns URL string.
 	"http.build_url": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -853,8 +879,10 @@ var HttpBuiltins = map[string]*object.Builtin{
 
 	// ============================================================================
 	// HTTP Status Code Constants
+	// These constants provide standard HTTP status codes for response handling.
 	// ============================================================================
 
+	// OK is HTTP 200 status code indicating successful request.
 	"http.OK": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(OK)}
@@ -862,6 +890,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// CREATED is HTTP 201 status code indicating resource was created.
 	"http.CREATED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(CREATED)}
@@ -869,6 +898,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// ACCEPTED is HTTP 202 status code indicating request accepted for processing.
 	"http.ACCEPTED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(ACCEPTED)}
@@ -876,6 +906,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// NO_CONTENT is HTTP 204 status code indicating success with no response body.
 	"http.NO_CONTENT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(NO_CONTENT)}
@@ -883,6 +914,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// MOVED_PERMANENTLY is HTTP 301 status code indicating permanent redirect.
 	"http.MOVED_PERMANENTLY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(MOVED_PERMANENTLY)}
@@ -890,6 +922,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// FOUND is HTTP 302 status code indicating temporary redirect.
 	"http.FOUND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(FOUND)}
@@ -897,6 +930,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// NOT_MODIFIED is HTTP 304 status code indicating cached version is current.
 	"http.NOT_MODIFIED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(NOT_MODIFIED)}
@@ -904,6 +938,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// TEMPORARY_REDIRECT is HTTP 307 status code indicating temporary redirect preserving method.
 	"http.TEMPORARY_REDIRECT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(TEMPORARY_REDIRECT)}
@@ -911,6 +946,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// PERMANENT_REDIRECT is HTTP 308 status code indicating permanent redirect preserving method.
 	"http.PERMANENT_REDIRECT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(PERMANENT_REDIRECT)}
@@ -918,6 +954,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// BAD_REQUEST is HTTP 400 status code indicating malformed request.
 	"http.BAD_REQUEST": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(BAD_REQUEST)}
@@ -925,6 +962,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// UNAUTHORIZED is HTTP 401 status code indicating authentication required.
 	"http.UNAUTHORIZED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(UNAUTHORIZED)}
@@ -932,6 +970,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// PAYMENT_REQUIRED is HTTP 402 status code reserved for future use.
 	"http.PAYMENT_REQUIRED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(PAYMENT_REQUIRED)}
@@ -939,6 +978,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// FORBIDDEN is HTTP 403 status code indicating access denied.
 	"http.FORBIDDEN": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(FORBIDDEN)}
@@ -946,6 +986,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// NOT_FOUND is HTTP 404 status code indicating resource not found.
 	"http.NOT_FOUND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(NOT_FOUND)}
@@ -953,6 +994,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// METHOD_NOT_ALLOWED is HTTP 405 status code indicating method not supported.
 	"http.METHOD_NOT_ALLOWED": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(METHOD_NOT_ALLOWED)}
@@ -960,6 +1002,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// CONFLICT is HTTP 409 status code indicating request conflicts with server state.
 	"http.CONFLICT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(CONFLICT)}
@@ -967,6 +1010,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// INTERNAL_SERVER_ERROR is HTTP 500 status code indicating server error.
 	"http.INTERNAL_SERVER_ERROR": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(INTERNAL_SERVER_ERROR)}
@@ -974,6 +1018,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// BAD_GATEWAY is HTTP 502 status code indicating invalid upstream response.
 	"http.BAD_GATEWAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(BAD_GATEWAY)}
@@ -981,6 +1026,7 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// SERVICE_UNAVAILABLE is HTTP 503 status code indicating server temporarily unavailable.
 	"http.SERVICE_UNAVAILABLE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(SERVICE_UNAVAILABLE)}
@@ -988,7 +1034,6 @@ var HttpBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 }
-
 
 func newHttpResponse(status int, body string, headers *object.Map) *object.Struct {
 	return &object.Struct{

--- a/pkg/stdlib/io.go
+++ b/pkg/stdlib/io.go
@@ -96,8 +96,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// File Reading
 	// ============================================================================
 
-	// Reads the entire contents of a file as a string
-	// Returns (content, error) tuple - error is nil on success
+	// read_file reads the entire contents of a file as a string.
+	// Takes file path. Returns (content, Error) tuple.
 	"io.read_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -134,8 +134,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Reads the entire contents of a file as a byte array
-	// Returns (bytes, error) tuple - error is nil on success
+	// read_bytes reads the entire contents of a file as a byte array.
+	// Takes file path. Returns ([byte], Error) tuple.
 	"io.read_bytes": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -182,10 +182,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// File Writing
 	// ============================================================================
 
-	// Writes content to a file atomically, creating it if it doesn't exist or overwriting if it does
-	// Uses temp file + rename to ensure file is never left in a partial state
-	// Takes 2-3 arguments: path, content, and optional permissions (int, default 0644)
-	// Returns (success, error) tuple
+	// write_file writes content to a file atomically, creating or overwriting.
+	// Takes path, content, and optional permissions (default 0644). Returns (bool, Error) tuple.
 	"io.write_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -227,10 +225,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Writes bytes to a file atomically, creating it if it doesn't exist or overwriting if it does
-	// Uses temp file + rename to ensure file is never left in a partial state
-	// Takes 2-3 arguments: path, data (byte array), and optional permissions (int)
-	// Returns (success, error) tuple
+	// write_bytes writes a byte array to a file atomically, creating or overwriting.
+	// Takes path, byte array, and optional permissions. Returns (bool, Error) tuple.
 	"io.write_bytes": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -282,9 +278,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Appends content to a file, creating it if it doesn't exist
-	// Takes 2-3 arguments: path, content, and optional permissions (int, default 0644)
-	// Returns (success, error) tuple
+	// append_file appends content to a file, creating it if needed.
+	// Takes path, content, and optional permissions. Returns (bool, Error) tuple.
 	"io.append_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -340,8 +335,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// Convenience Functions
 	// ============================================================================
 
-	// Reads a file and returns its content as an array of lines
-	// Returns (lines, error) tuple where lines is an array of strings
+	// read_lines reads a file and returns its content as an array of lines.
+	// Takes file path. Returns ([string], Error) tuple.
 	"io.read_lines": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -393,9 +388,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Appends a line to a file, adding a newline at the end
-	// Takes 2-3 arguments: path, line, and optional permissions (int, default 0644)
-	// Returns (success, error) tuple
+	// append_line appends a line to a file with trailing newline.
+	// Takes path, line, and optional permissions. Returns (bool, Error) tuple.
 	"io.append_line": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -468,8 +462,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Expands ~ to home directory and cleans the path
-	// Returns the expanded path string
+	// expand_path expands ~ to home directory and cleans the path.
+	// Takes path string. Returns expanded path string.
 	"io.expand_path": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -505,7 +499,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// Path Existence and Type Checks
 	// ============================================================================
 
-	// Checks if a path exists (file or directory)
+	// exists checks if a path exists (file or directory).
+	// Takes path string. Returns bool.
 	"io.exists": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -533,7 +528,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if a path is a regular file
+	// is_file checks if a path is a regular file.
+	// Takes path string. Returns bool.
 	"io.is_file": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -560,7 +556,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if a path is a directory
+	// is_dir checks if a path is a directory.
+	// Takes path string. Returns bool.
 	"io.is_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -591,8 +588,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// File Operations
 	// ============================================================================
 
-	// Removes a file
-	// Returns (success, error) tuple
+	// remove removes a file (not directories).
+	// Takes file path. Returns (bool, Error) tuple.
 	"io.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -632,8 +629,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Removes an empty directory
-	// Returns (success, error) tuple
+	// remove_dir removes an empty directory.
+	// Takes directory path. Returns (bool, Error) tuple.
 	"io.remove_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -673,8 +670,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Removes a file or directory recursively (DANGEROUS - use with caution)
-	// Returns (success, error) tuple
+	// remove_all removes a file or directory recursively.
+	// Takes path. Returns (bool, Error) tuple. Use with caution.
 	"io.remove_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -716,8 +713,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Renames or moves a file or directory
-	// Returns (success, error) tuple
+	// rename renames or moves a file or directory.
+	// Takes old_path and new_path. Returns (bool, Error) tuple.
 	"io.rename": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -752,10 +749,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Copies a file from source to destination
-	// Takes 2-3 arguments: source, destination, and optional permissions (int)
-	// If permissions not specified, preserves source file's permissions
-	// Returns (success, error) tuple
+	// copy copies a file from source to destination.
+	// Takes source, destination, and optional permissions. Returns (bool, Error) tuple.
 	"io.copy": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -838,9 +833,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// Directory Operations
 	// ============================================================================
 
-	// Creates a directory (parent must exist)
-	// Takes 1-2 arguments: path, and optional permissions (int, default 0755)
-	// Returns (success, error) tuple
+	// mkdir creates a directory (parent must exist).
+	// Takes path and optional permissions (default 0755). Returns (bool, Error) tuple.
 	"io.mkdir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 || len(args) > 2 {
@@ -878,9 +872,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creates a directory and all parent directories as needed
-	// Takes 1-2 arguments: path, and optional permissions (int, default 0755)
-	// Returns (success, error) tuple
+	// mkdir_all creates a directory and all parent directories as needed.
+	// Takes path and optional permissions (default 0755). Returns (bool, Error) tuple.
 	"io.mkdir_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 || len(args) > 2 {
@@ -918,8 +911,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Lists the contents of a directory
-	// Returns (entries, error) tuple where entries is an array of filenames
+	// read_dir lists the contents of a directory.
+	// Takes directory path. Returns ([string], Error) tuple of filenames.
 	"io.read_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -956,8 +949,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// File Metadata
 	// ============================================================================
 
-	// Returns the size of a file in bytes
-	// Returns (size, error) tuple
+	// file_size returns the size of a file in bytes.
+	// Takes file path. Returns (int, Error) tuple.
 	"io.file_size": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -985,8 +978,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the modification time of a file as a Unix timestamp
-	// Returns (timestamp, error) tuple
+	// file_mod_time returns the modification time as a Unix timestamp.
+	// Takes file path. Returns (int, Error) tuple.
 	"io.file_mod_time": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1018,7 +1011,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// Path Utilities
 	// ============================================================================
 
-	// Joins path components using the OS-specific separator
+	// path_join joins path components using OS-specific separator.
+	// Takes one or more path strings. Returns joined path string.
 	"io.path_join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 {
@@ -1042,7 +1036,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the last element of a path (filename or directory name)
+	// path_base returns the last element of a path (filename or directory name).
+	// Takes path string. Returns base name string.
 	"io.path_base": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1062,7 +1057,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the directory portion of a path
+	// path_dir returns the directory portion of a path.
+	// Takes path string. Returns directory path string.
 	"io.path_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1082,7 +1078,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the file extension (including the dot)
+	// path_ext returns the file extension including the dot.
+	// Takes path string. Returns extension string (e.g., ".txt").
 	"io.path_ext": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1102,8 +1099,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the absolute path
-	// Returns (abs_path, error) tuple
+	// path_abs returns the absolute path.
+	// Takes path string. Returns (string, Error) tuple.
 	"io.path_abs": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1131,7 +1128,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Cleans a path (removes redundant separators, . and ..)
+	// path_clean cleans a path by removing redundant separators and dots.
+	// Takes path string. Returns cleaned path string.
 	"io.path_clean": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1151,7 +1149,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the OS-specific path separator
+	// path_separator returns the OS-specific path separator.
+	// Takes no arguments. Returns "/" on Unix or "\\" on Windows.
 	"io.path_separator": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.String{Value: string(filepath.Separator)}
@@ -1160,45 +1159,58 @@ var IOBuiltins = map[string]*object.Builtin{
 
 	// ============================================================================
 	// File Handle Constants
+	// These constants are used with io.open() to specify file access modes.
 	// ============================================================================
 
-	// File open mode constants
+	// READ_ONLY opens a file for reading only.
 	"io.READ_ONLY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_RDONLY))}
 		},
 		IsConstant: true,
 	},
+
+	// WRITE_ONLY opens a file for writing only.
 	"io.WRITE_ONLY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_WRONLY))}
 		},
 		IsConstant: true,
 	},
+
+	// READ_WRITE opens a file for reading and writing.
 	"io.READ_WRITE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_RDWR))}
 		},
 		IsConstant: true,
 	},
+
+	// APPEND opens a file for appending (writes go to end of file).
 	"io.APPEND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_APPEND))}
 		},
 		IsConstant: true,
 	},
+
+	// CREATE creates the file if it does not exist.
 	"io.CREATE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_CREATE))}
 		},
 		IsConstant: true,
 	},
+
+	// TRUNCATE truncates the file to zero length when opening.
 	"io.TRUNCATE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_TRUNC))}
 		},
 		IsConstant: true,
 	},
+
+	// EXCLUSIVE fails if file already exists when used with CREATE.
 	"io.EXCLUSIVE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.O_EXCL))}
@@ -1206,19 +1218,23 @@ var IOBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Seek whence constants
+	// SEEK_START seeks relative to the start of the file.
 	"io.SEEK_START": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(io.SeekStart))}
 		},
 		IsConstant: true,
 	},
+
+	// SEEK_CURRENT seeks relative to the current file position.
 	"io.SEEK_CURRENT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(io.SeekCurrent))}
 		},
 		IsConstant: true,
 	},
+
+	// SEEK_END seeks relative to the end of the file.
 	"io.SEEK_END": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(io.SeekEnd))}
@@ -1230,9 +1246,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// File Handle Operations
 	// ============================================================================
 
-	// Opens a file and returns a file handle
-	// Takes path and mode flags (combine with | operator)
-	// Returns (handle, error) tuple
+	// open opens a file and returns a file handle.
+	// Takes path, optional mode flags, and optional permissions. Returns (FileHandle, Error) tuple.
 	"io.open": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 || len(args) > 3 {
@@ -1285,8 +1300,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Reads n bytes from a file handle
-	// Returns (bytes, error) tuple
+	// read reads n bytes from a file handle.
+	// Takes handle and byte count. Returns ([byte], Error) tuple.
 	"io.read": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -1331,8 +1346,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Reads all remaining bytes from a file handle
-	// Returns (bytes, error) tuple
+	// read_all reads all remaining bytes from a file handle.
+	// Takes handle. Returns ([byte], Error) tuple.
 	"io.read_all": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1367,8 +1382,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Reads n bytes from a file handle as a string
-	// Returns (string, error) tuple
+	// read_string reads n bytes from a file handle as a string.
+	// Takes handle and byte count. Returns (string, Error) tuple.
 	"io.read_string": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -1407,9 +1422,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Writes data to a file handle
-	// Data can be a string or byte array
-	// Returns (bytes_written, error) tuple
+	// write writes data (string or byte array) to a file handle.
+	// Takes handle and data. Returns (bytes_written, Error) tuple.
 	"io.write": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -1458,8 +1472,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Seeks to a position in the file
-	// Returns (new_position, error) tuple
+	// seek moves the file position to a new location.
+	// Takes handle, offset, and whence (SEEK_START/CURRENT/END). Returns (position, Error) tuple.
 	"io.seek": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -1496,8 +1510,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the current position in the file
-	// Returns (position, error) tuple
+	// tell returns the current position in the file.
+	// Takes handle. Returns (position, Error) tuple.
 	"io.tell": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1527,8 +1541,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Flushes any buffered data to the file
-	// Returns (success, error) tuple
+	// flush flushes any buffered data to the file.
+	// Takes handle. Returns (bool, Error) tuple.
 	"io.flush": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1557,8 +1571,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Closes a file handle
-	// Returns (success, error) tuple
+	// close closes a file handle.
+	// Takes handle. Returns (bool, Error) tuple.
 	"io.close": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1594,8 +1608,8 @@ var IOBuiltins = map[string]*object.Builtin{
 	// Filesystem Utilities
 	// ============================================================================
 
-	// Finds files matching a glob pattern
-	// Returns ([string], error) tuple - array of matching paths
+	// glob finds files matching a glob pattern.
+	// Takes pattern string (e.g., "*.txt"). Returns ([string], Error) tuple.
 	"io.glob": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1627,8 +1641,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Recursively walks a directory tree, returning all file paths
-	// Returns ([string], error) tuple - array of all file paths
+	// walk recursively walks a directory tree, returning all file paths.
+	// Takes directory path. Returns ([string], Error) tuple.
 	"io.walk": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1673,8 +1687,8 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Checks if a path is a symbolic link
-	// Returns bool (false for non-existent paths, not an error)
+	// is_symlink checks if a path is a symbolic link.
+	// Takes path string. Returns bool.
 	"io.is_symlink": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -1699,7 +1713,6 @@ var IOBuiltins = map[string]*object.Builtin{
 		},
 	},
 }
-
 
 // CreateStdlibErrorResult wraps a Go error into an EZ (nil, Error) return tuple
 func CreateStdlibErrorResult(err error, operation string) *object.ReturnValue {

--- a/pkg/stdlib/json.go
+++ b/pkg/stdlib/json.go
@@ -14,8 +14,8 @@ import (
 
 // JsonBuiltins contains the json module functions
 var JsonBuiltins = map[string]*object.Builtin{
-	// json.encode(value) -> (string, error)
-	// Serializes an EZ value to a JSON string
+	// encode serializes an EZ value to a JSON string.
+	// Takes any value. Returns (string, Error) tuple.
 	"json.encode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -37,11 +37,8 @@ var JsonBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// json.decode(text string) -> (any, error)
-	// json.decode(text string, Type) -> (Type, error)
-	// Parses a JSON string into EZ types.
-	// With 1 arg: returns dynamic types (maps, arrays, primitives)
-	// With 2 args: returns a typed struct instance
+	// decode parses a JSON string into EZ types.
+	// Takes JSON string and optional Type. Returns (value, Error) tuple.
 	"json.decode": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 || len(args) > 2 {
@@ -94,8 +91,8 @@ var JsonBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// json.pretty(value, indent string) -> (string, error)
-	// Serializes an EZ value to a formatted JSON string with indentation
+	// pretty serializes a value to formatted JSON with indentation.
+	// Takes value and indent string. Returns (string, Error) tuple.
 	"json.pretty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -122,8 +119,8 @@ var JsonBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// json.is_valid(text string) -> bool
-	// Checks if a string is valid JSON (pure function, no error tuple)
+	// is_valid checks if a string is valid JSON syntax.
+	// Takes string. Returns bool.
 	"json.is_valid": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -148,7 +145,6 @@ type jsonError struct {
 	code    string
 	message string
 }
-
 
 // encodeToJSON converts an EZ object to a JSON string
 func encodeToJSON(obj object.Object, seen map[uintptr]bool) (string, *jsonError) {

--- a/pkg/stdlib/maps.go
+++ b/pkg/stdlib/maps.go
@@ -11,6 +11,8 @@ import (
 
 // MapsBuiltins contains the maps module functions
 var MapsBuiltins = map[string]*object.Builtin{
+	// is_empty checks if a map has no entries.
+	// Takes a map. Returns bool.
 	"maps.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -27,6 +29,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// contains checks if a key exists in the map.
+	// Takes map and key. Returns bool.
 	"maps.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -50,6 +54,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// get retrieves a value by key, with optional default.
+	// Takes map, key, and optional default. Returns value or nil/default.
 	"maps.get": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -77,6 +83,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// set adds or updates a key-value pair in the map.
+	// Takes map, key, and value. Returns nil. Mutates the map.
 	"maps.set": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -101,6 +109,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// clear removes all entries from the map.
+	// Takes a map. Returns nil. Mutates the map.
 	"maps.clear": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -122,6 +132,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// keys returns an array of all keys in the map.
+	// Takes a map. Returns array of keys.
 	"maps.keys": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -139,6 +151,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// values returns an array of all values in the map.
+	// Takes a map. Returns array of values.
 	"maps.values": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -156,6 +170,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// merge combines multiple maps into a new map.
+	// Takes two or more maps. Returns new merged map.
 	"maps.merge": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -181,6 +197,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// contains_value checks if a value exists in the map.
+	// Takes map and value. Returns bool.
 	"maps.contains_value": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -200,6 +218,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// equals checks if two maps have identical key-value pairs.
+	// Takes two maps. Returns bool.
 	"maps.equals": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -225,6 +245,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// get_or_set returns existing value or sets and returns default.
+	// Takes map, key, and default. Returns value. May mutate the map.
 	"maps.get_or_set": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -255,7 +277,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// remove is an alias for delete
+	// remove deletes a key-value pair from the map.
+	// Takes map and key. Returns bool indicating if key existed.
 	"maps.remove": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -283,6 +306,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// update merges source maps into target map in-place.
+	// Takes target map and one or more source maps. Returns nil. Mutates target.
 	"maps.update": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -313,6 +338,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// to_array converts a map to an array of [key, value] pairs.
+	// Takes a map. Returns array of arrays.
 	"maps.to_array": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -334,6 +361,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// from_array creates a map from an array of [key, value] pairs.
+	// Takes array of pairs. Returns new map.
 	"maps.from_array": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -366,6 +395,8 @@ var MapsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// invert swaps keys and values, creating a new map.
+	// Takes a map. Returns new map with values as keys.
 	"maps.invert": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/math.go
+++ b/pkg/stdlib/math.go
@@ -14,7 +14,13 @@ import (
 
 // MathBuiltins contains the math module functions
 var MathBuiltins = map[string]*object.Builtin{
-	// Basic arithmetic
+	// ============================================================================
+	// Basic Arithmetic
+	// add, sub, mul, div, mod perform basic math operations.
+	// ============================================================================
+
+	// add adds two numbers together.
+	// Takes two numbers. Returns sum (int if both int, else float).
 	"math.add": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -31,6 +37,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: a + b}
 		},
 	},
+
+	// sub subtracts the second number from the first.
+	// Takes two numbers. Returns difference.
 	"math.sub": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -47,6 +56,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: a - b}
 		},
 	},
+
+	// mul multiplies two numbers.
+	// Takes two numbers. Returns product.
 	"math.mul": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -63,6 +75,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: a * b}
 		},
 	},
+
+	// div divides the first number by the second.
+	// Takes two numbers. Returns quotient as float.
 	"math.div": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -78,6 +93,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: a / b}
 		},
 	},
+
+	// mod returns the remainder of division.
+	// Takes two numbers. Returns modulo.
 	"math.mod": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -101,7 +119,12 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Absolute and sign
+	// ============================================================================
+	// Absolute Value and Sign
+	// ============================================================================
+
+	// abs returns the absolute value of a number.
+	// Takes one number. Returns non-negative value.
 	"math.abs": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -120,6 +143,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+
+	// sign returns the sign of a number: -1, 0, or 1.
+	// Takes one number. Returns int.
 	"math.sign": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -141,6 +167,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(0)}
 		},
 	},
+
+	// neg returns the negation of a number.
+	// Takes one number. Returns negated value.
 	"math.neg": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -160,7 +189,12 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Min/Max
+	// ============================================================================
+	// Min/Max/Clamp
+	// ============================================================================
+
+	// min returns the smallest of the given numbers.
+	// Takes two or more numbers. Returns minimum value.
 	"math.min": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -201,6 +235,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: minVal}
 		},
 	},
+
+	// max returns the largest of the given numbers.
+	// Takes two or more numbers. Returns maximum value.
 	"math.max": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 {
@@ -241,6 +278,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: maxVal}
 		},
 	},
+
+	// clamp constrains a value between min and max bounds.
+	// Takes value, min, max. Returns clamped value.
 	"math.clamp": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -277,7 +317,13 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Rounding
+	// floor, ceil, round, trunc convert floats to integers.
+	// ============================================================================
+
+	// floor rounds down to the nearest integer.
+	// Takes one number. Returns int.
 	"math.floor": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -290,6 +336,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(int64(math.Floor(val)))}
 		},
 	},
+
+	// ceil rounds up to the nearest integer.
+	// Takes one number. Returns int.
 	"math.ceil": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -302,6 +351,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(int64(math.Ceil(val)))}
 		},
 	},
+
+	// round rounds to the nearest integer.
+	// Takes one number. Returns int.
 	"math.round": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -314,6 +366,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(int64(math.Round(val)))}
 		},
 	},
+
+	// trunc truncates toward zero.
+	// Takes one number. Returns int.
 	"math.trunc": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -327,7 +382,13 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Powers and roots
+	// ============================================================================
+	// Powers and Roots
+	// pow, sqrt, cbrt, hypot, exp, exp2 for exponentiation.
+	// ============================================================================
+
+	// pow raises base to the power of exponent.
+	// Takes base and exponent. Returns result.
 	"math.pow": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -352,6 +413,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: result}
 		},
 	},
+
+	// sqrt returns the square root of a number.
+	// Takes one non-negative number. Returns float.
 	"math.sqrt": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -367,6 +431,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Sqrt(val)}
 		},
 	},
+
+	// cbrt returns the cube root of a number.
+	// Takes one number. Returns float.
 	"math.cbrt": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -379,6 +446,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Cbrt(val)}
 		},
 	},
+
+	// hypot returns sqrt(a*a + b*b), the hypotenuse.
+	// Takes two numbers. Returns float.
 	"math.hypot": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -391,6 +461,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Hypot(a, b)}
 		},
 	},
+
+	// exp returns e raised to the power x.
+	// Takes one number. Returns float.
 	"math.exp": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -403,6 +476,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Exp(val)}
 		},
 	},
+
+	// exp2 returns 2 raised to the power x.
+	// Takes one number. Returns float.
 	"math.exp2": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -416,7 +492,13 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Logarithms
+	// log, log2, log10, log_base for logarithmic functions.
+	// ============================================================================
+
+	// log returns the natural logarithm (base e).
+	// Takes one positive number. Returns float.
 	"math.log": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -432,6 +514,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Log(val)}
 		},
 	},
+
+	// log2 returns the base-2 logarithm.
+	// Takes one positive number. Returns float.
 	"math.log2": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -447,6 +532,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Log2(val)}
 		},
 	},
+
+	// log10 returns the base-10 logarithm.
+	// Takes one positive number. Returns float.
 	"math.log10": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -462,6 +550,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Log10(val)}
 		},
 	},
+
+	// log_base returns the logarithm with arbitrary base.
+	// Takes value and base. Returns float.
 	"math.log_base": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -486,7 +577,13 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Trigonometry
+	// sin, cos, tan, asin, acos, atan, atan2 (radians).
+	// ============================================================================
+
+	// sin returns the sine of an angle in radians.
+	// Takes one number. Returns float.
 	"math.sin": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -499,6 +596,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Sin(val)}
 		},
 	},
+
+	// cos returns the cosine of an angle in radians.
+	// Takes one number. Returns float.
 	"math.cos": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -511,6 +611,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Cos(val)}
 		},
 	},
+
+	// tan returns the tangent of an angle in radians.
+	// Takes one number. Returns float.
 	"math.tan": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -523,6 +626,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Tan(val)}
 		},
 	},
+
+	// asin returns the arcsine in radians.
+	// Takes value between -1 and 1. Returns float.
 	"math.asin": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -538,6 +644,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Asin(val)}
 		},
 	},
+
+	// acos returns the arccosine in radians.
+	// Takes value between -1 and 1. Returns float.
 	"math.acos": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -553,6 +662,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Acos(val)}
 		},
 	},
+
+	// atan returns the arctangent in radians.
+	// Takes one number. Returns float.
 	"math.atan": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -565,6 +677,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Atan(val)}
 		},
 	},
+
+	// atan2 returns the angle from the x-axis to point (x, y).
+	// Takes y and x coordinates. Returns float in radians.
 	"math.atan2": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -578,7 +693,13 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Hyperbolic
+	// ============================================================================
+	// Hyperbolic Functions
+	// sinh, cosh, tanh for hyperbolic trigonometry.
+	// ============================================================================
+
+	// sinh returns the hyperbolic sine.
+	// Takes one number. Returns float.
 	"math.sinh": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -591,6 +712,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Sinh(val)}
 		},
 	},
+
+	// cosh returns the hyperbolic cosine.
+	// Takes one number. Returns float.
 	"math.cosh": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -603,6 +727,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: math.Cosh(val)}
 		},
 	},
+
+	// tanh returns the hyperbolic tangent.
+	// Takes one number. Returns float.
 	"math.tanh": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -616,7 +743,12 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Angle conversion
+	// ============================================================================
+	// Angle Conversion
+	// ============================================================================
+
+	// deg_to_rad converts degrees to radians.
+	// Takes degrees. Returns radians as float.
 	"math.deg_to_rad": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -629,6 +761,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: val * math.Pi / 180}
 		},
 	},
+
+	// rad_to_deg converts radians to degrees.
+	// Takes radians. Returns degrees as float.
 	"math.rad_to_deg": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -642,7 +777,12 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Random
+	// ============================================================================
+	// Random Number Generation
+	// ============================================================================
+
+	// random generates a random number.
+	// No args: float [0,1). One arg: int [0,max). Two args: int [min,max).
 	"math.random": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
@@ -669,6 +809,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Error{Code: "E7001", Message: "math.random() takes 0, 1, or 2 arguments"}
 		},
 	},
+
+	// random_float generates a random float.
+	// No args: float [0,1). Two args: float [min,max).
 	"math.random_float": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
@@ -684,73 +827,100 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Constants
+	// ============================================================================
+	// Mathematical Constants
+	// PI, E, PHI, SQRT2, LN2, LN10, TAU, INF, NEG_INF, EPSILON, MAX_FLOAT, MIN_FLOAT.
+	// ============================================================================
+
+	// PI is the ratio of circle circumference to diameter (~3.14159).
 	"math.PI": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Pi}
 		},
 		IsConstant: true,
 	},
+
+	// E is Euler's number, the base of natural logarithms (~2.71828).
 	"math.E": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.E}
 		},
 		IsConstant: true,
 	},
+
+	// PHI is the golden ratio (~1.61803).
 	"math.PHI": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Phi}
 		},
 		IsConstant: true,
 	},
+
+	// SQRT2 is the square root of 2 (~1.41421).
 	"math.SQRT2": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Sqrt2}
 		},
 		IsConstant: true,
 	},
+
+	// LN2 is the natural logarithm of 2 (~0.69315).
 	"math.LN2": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Ln2}
 		},
 		IsConstant: true,
 	},
+
+	// LN10 is the natural logarithm of 10 (~2.30259).
 	"math.LN10": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Ln10}
 		},
 		IsConstant: true,
 	},
+
+	// TAU is 2*PI, the ratio of circumference to radius (~6.28319).
 	"math.TAU": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: 2 * math.Pi}
 		},
 		IsConstant: true,
 	},
+
+	// INF is positive infinity.
 	"math.INF": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Inf(1)}
 		},
 		IsConstant: true,
 	},
+
+	// NEG_INF is negative infinity.
 	"math.NEG_INF": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Inf(-1)}
 		},
 		IsConstant: true,
 	},
+
+	// EPSILON is the smallest float64 difference from 1.
 	"math.EPSILON": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.Nextafter(1.0, 2.0) - 1.0}
 		},
 		IsConstant: true,
 	},
+
+	// MAX_FLOAT is the largest representable float64.
 	"math.MAX_FLOAT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.MaxFloat64}
 		},
 		IsConstant: true,
 	},
+
+	// MIN_FLOAT is the smallest positive non-zero float64.
 	"math.MIN_FLOAT": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Float{Value: math.SmallestNonzeroFloat64}
@@ -758,7 +928,12 @@ var MathBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Special value checks
+	// ============================================================================
+	// Special Value Checks
+	// ============================================================================
+
+	// is_inf checks if a number is infinite.
+	// Takes one number. Returns bool.
 	"math.is_inf": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -774,6 +949,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return object.FALSE
 		},
 	},
+
+	// is_nan checks if a number is NaN (not a number).
+	// Takes one number. Returns bool.
 	"math.is_nan": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -789,6 +967,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return object.FALSE
 		},
 	},
+
+	// is_finite checks if a number is finite (not infinite or NaN).
+	// Takes one number. Returns bool.
 	"math.is_finite": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -805,7 +986,13 @@ var MathBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Additional useful functions
+	// ============================================================================
+	// Utility Functions
+	// sum, avg, factorial, gcd, lcm, is_prime, is_even, is_odd, lerp, map_range, distance.
+	// ============================================================================
+
+	// sum adds all given numbers together.
+	// Takes zero or more numbers. Returns sum.
 	"math.sum": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
@@ -838,6 +1025,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: sum}
 		},
 	},
+
+	// avg returns the arithmetic mean of the given numbers.
+	// Takes one or more numbers. Returns float.
 	"math.avg": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
@@ -854,6 +1044,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: sum / float64(len(args))}
 		},
 	},
+
+	// factorial computes n! (n factorial).
+	// Takes non-negative integer. Returns int.
 	"math.factorial": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -886,6 +1079,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+
+	// gcd returns the greatest common divisor of two numbers.
+	// Takes two numbers. Returns int.
 	"math.gcd": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -909,6 +1105,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(ai)}
 		},
 	},
+
+	// lcm returns the least common multiple of two numbers.
+	// Takes two numbers. Returns int.
 	"math.lcm": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -942,6 +1141,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt((ai * bi) / ta)}
 		},
 	},
+
+	// is_prime checks if a number is prime.
+	// Takes one number. Returns bool.
 	"math.is_prime": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -969,6 +1171,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return object.TRUE
 		},
 	},
+
+	// is_even checks if a number is even.
+	// Takes one number. Returns bool.
 	"math.is_even": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -984,6 +1189,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return object.FALSE
 		},
 	},
+
+	// is_odd checks if a number is odd.
+	// Takes one number. Returns bool.
 	"math.is_odd": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -999,6 +1207,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return object.FALSE
 		},
 	},
+
+	// lerp performs linear interpolation between two values.
+	// Takes a, b, and t (0-1). Returns a + t*(b-a).
 	"math.lerp": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -1019,6 +1230,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: a + t*(b-a)}
 		},
 	},
+
+	// map_range maps a value from one range to another.
+	// Takes value, in_min, in_max, out_min, out_max. Returns mapped float.
 	"math.map_range": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 5 {
@@ -1051,6 +1265,9 @@ var MathBuiltins = map[string]*object.Builtin{
 			return &object.Float{Value: result}
 		},
 	},
+
+	// distance calculates the Euclidean distance between two 2D points.
+	// Takes x1, y1, x2, y2. Returns float.
 	"math.distance": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 4 {

--- a/pkg/stdlib/os.go
+++ b/pkg/stdlib/os.go
@@ -25,8 +25,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	// Environment Variables
 	// ============================================================================
 
-	// Gets an environment variable by name
-	// Returns (value, error) tuple - error is non-nil if variable is not set
+	// get_env retrieves an environment variable by name.
+	// Takes variable name. Returns (string, Error) tuple.
 	"os.get_env": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -51,8 +51,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Sets an environment variable (process-scoped only)
-	// Returns true on success, (false, error) on failure
+	// set_env sets an environment variable (process-scoped only).
+	// Takes name and value. Returns (bool, Error) tuple.
 	"os.set_env": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -82,8 +82,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Unsets an environment variable
-	// Returns true on success, (false, error) on failure
+	// unset_env removes an environment variable.
+	// Takes variable name. Returns (bool, Error) tuple.
 	"os.unset_env": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -109,7 +109,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns all environment variables as a map
+	// env returns all environment variables as a map.
+	// Takes no arguments. Returns map[string:string].
 	"os.env": {
 		Fn: func(args ...object.Object) object.Object {
 			envMap := object.NewMap()
@@ -125,8 +126,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns command-line arguments as an array
-	// First element is the program name/path
+	// args returns command-line arguments as an array.
+	// Takes no arguments. Returns [string] (first element is program name).
 	"os.args": {
 		Fn: func(args ...object.Object) object.Object {
 			// Use CommandLineArgs if set, otherwise fall back to os.Args
@@ -142,7 +143,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	// Process / System
 	// ============================================================================
 
-	// Exits the program with the given status code
+	// exit terminates the program with a status code.
+	// Takes optional int exit code (default 0). Does not return.
 	"os.exit": {
 		Fn: func(args ...object.Object) object.Object {
 			code := 0
@@ -158,8 +160,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the current working directory
-	// Returns (path, error) tuple
+	// cwd returns the current working directory.
+	// Takes no arguments. Returns (string, Error) tuple.
 	"os.cwd": {
 		Fn: func(args ...object.Object) object.Object {
 			cwd, err := os.Getwd()
@@ -176,8 +178,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Changes the current working directory
-	// Returns (success, error) tuple
+	// chdir changes the current working directory.
+	// Takes path string. Returns (bool, Error) tuple.
 	"os.chdir": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -203,8 +205,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the hostname of the machine
-	// Returns (hostname, error) tuple
+	// hostname returns the system's hostname.
+	// Takes no arguments. Returns (string, Error) tuple.
 	"os.hostname": {
 		Fn: func(args ...object.Object) object.Object {
 			hostname, err := os.Hostname()
@@ -221,8 +223,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the current user's username
-	// Returns (username, error) tuple
+	// username returns the current user's name.
+	// Takes no arguments. Returns (string, Error) tuple.
 	"os.username": {
 		Fn: func(args ...object.Object) object.Object {
 			currentUser, err := user.Current()
@@ -239,8 +241,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the current user's home directory
-	// Returns (path, error) tuple
+	// home_dir returns the current user's home directory.
+	// Takes no arguments. Returns (string, Error) tuple.
 	"os.home_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			homeDir, err := os.UserHomeDir()
@@ -257,21 +259,24 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the system's temporary directory
+	// temp_dir returns the system's temporary directory.
+	// Takes no arguments. Returns path string.
 	"os.temp_dir": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.String{Value: os.TempDir()}
 		},
 	},
 
-	// Returns the process ID of the current process
+	// pid returns the current process ID.
+	// Takes no arguments. Returns int.
 	"os.pid": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.Getpid()))}
 		},
 	},
 
-	// Returns the parent process ID
+	// ppid returns the parent process ID.
+	// Takes no arguments. Returns int.
 	"os.ppid": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(os.Getppid()))}
@@ -280,21 +285,26 @@ var OSBuiltins = map[string]*object.Builtin{
 
 	// ============================================================================
 	// Platform Detection
+	// OS constants: MAC_OS=0, LINUX=1, WINDOWS=2.
 	// ============================================================================
 
-	// OS Constants - use these for comparison with CURRENT_OS
+	// MAC_OS is the constant for macOS (value 0).
 	"os.MAC_OS": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
 		},
 		IsConstant: true,
 	},
+
+	// LINUX is the constant for Linux (value 1).
 	"os.LINUX": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
 		IsConstant: true,
 	},
+
+	// WINDOWS is the constant for Windows (value 2).
 	"os.WINDOWS": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
@@ -302,7 +312,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Returns the current OS as a constant (matches os.MAC_OS, os.LINUX, or os.WINDOWS)
+	// CURRENT_OS returns the current OS as a constant.
+	// Compare with MAC_OS, LINUX, or WINDOWS.
 	"os.CURRENT_OS": {
 		Fn: func(args ...object.Object) object.Object {
 			switch runtime.GOOS {
@@ -319,23 +330,24 @@ var OSBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Returns the operating system name as a string
-	// Possible values: "darwin", "linux", "windows", "freebsd", etc.
+	// platform returns the OS name string (e.g., "darwin", "linux", "windows").
+	// Takes no arguments. Returns string.
 	"os.platform": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.String{Value: runtime.GOOS}
 		},
 	},
 
-	// Returns the CPU architecture
-	// Possible values: "amd64", "arm64", "386", "arm", etc.
+	// arch returns the CPU architecture (e.g., "amd64", "arm64").
+	// Takes no arguments. Returns string.
 	"os.arch": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.String{Value: runtime.GOARCH}
 		},
 	},
 
-	// Returns true if running on Windows
+	// is_windows returns true if running on Windows.
+	// Takes no arguments. Returns bool.
 	"os.is_windows": {
 		Fn: func(args ...object.Object) object.Object {
 			if runtime.GOOS == "windows" {
@@ -345,7 +357,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns true if running on Linux
+	// is_linux returns true if running on Linux.
+	// Takes no arguments. Returns bool.
 	"os.is_linux": {
 		Fn: func(args ...object.Object) object.Object {
 			if runtime.GOOS == "linux" {
@@ -355,7 +368,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns true if running on macOS
+	// is_macos returns true if running on macOS.
+	// Takes no arguments. Returns bool.
 	"os.is_macos": {
 		Fn: func(args ...object.Object) object.Object {
 			if runtime.GOOS == "darwin" {
@@ -365,7 +379,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Returns the number of CPUs available
+	// num_cpu returns the number of available CPUs.
+	// Takes no arguments. Returns int.
 	"os.num_cpu": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(int64(runtime.NumCPU()))}
@@ -376,8 +391,7 @@ var OSBuiltins = map[string]*object.Builtin{
 	// Platform Constants
 	// ============================================================================
 
-	// Returns the line separator for the current platform
-	// "\r\n" on Windows, "\n" on Unix-like systems
+	// line_separator is the platform-specific line ending ("\r\n" or "\n").
 	"os.line_separator": {
 		Fn: func(args ...object.Object) object.Object {
 			if runtime.GOOS == "windows" {
@@ -388,8 +402,7 @@ var OSBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
-	// Returns the null device path for the current platform
-	// "NUL" on Windows, "/dev/null" on Unix-like systems
+	// dev_null is the platform-specific null device ("NUL" or "/dev/null").
 	"os.dev_null": {
 		Fn: func(args ...object.Object) object.Object {
 			if runtime.GOOS == "windows" {
@@ -404,9 +417,8 @@ var OSBuiltins = map[string]*object.Builtin{
 	// Command Execution
 	// ============================================================================
 
-	// Runs a shell command and returns (exit_code, error)
-	// Commands run through the system shell (/bin/sh -c on Unix, cmd /c on Windows)
-	// Note: User input should be sanitized before passing to this function
+	// exec runs a shell command and returns the exit code.
+	// Takes command string. Returns (int, Error) tuple.
 	"os.exec": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -451,10 +463,8 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Runs a shell command and returns (output, error)
-	// Captures both stdout and stderr combined
-	// Output has trailing whitespace trimmed
-	// Note: User input should be sanitized before passing to this function
+	// exec_output runs a shell command and returns its output.
+	// Takes command string. Returns (string, Error) tuple.
 	"os.exec_output": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -498,4 +508,3 @@ var OSBuiltins = map[string]*object.Builtin{
 		},
 	},
 }
-

--- a/pkg/stdlib/random.go
+++ b/pkg/stdlib/random.go
@@ -12,8 +12,8 @@ import (
 
 // RandomBuiltins contains the random module functions
 var RandomBuiltins = map[string]*object.Builtin{
-	// random.float() - returns float [0.0, 1.0)
-	// random.float(min, max) - returns float [min, max)
+	// float generates a random floating-point number.
+	// No args: returns [0.0, 1.0). Two args: returns [min, max).
 	"random.float": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
@@ -36,8 +36,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.int(max) - returns int [0, max)
-	// random.int(min, max) - returns int [min, max)
+	// int generates a random integer.
+	// One arg: returns [0, max). Two args: returns [min, max).
 	"random.int": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 1 {
@@ -67,7 +67,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.bool() - returns true or false with 50/50 probability
+	// bool returns true or false with 50/50 probability.
+	// Takes no arguments. Returns bool.
 	"random.bool": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 0 {
@@ -80,7 +81,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.byte() - returns random byte [0, 255]
+	// byte returns a random byte value [0, 255].
+	// Takes no arguments. Returns byte.
 	"random.byte": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 0 {
@@ -90,8 +92,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.char() - returns random printable ASCII char [32, 126]
-	// random.char(min, max) - returns random char in given range
+	// char returns a random character.
+	// No args: printable ASCII [32,126]. Two args: char in [min,max].
 	"random.char": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) == 0 {
@@ -130,7 +132,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.choice(array) - returns random element from array
+	// choice returns a random element from an array.
+	// Takes an array. Returns random element.
 	"random.choice": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -147,7 +150,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.shuffle(array) - returns new array with elements in random order
+	// shuffle returns a new array with elements in random order.
+	// Takes an array. Returns new shuffled array.
 	"random.shuffle": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -172,7 +176,8 @@ var RandomBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// random.sample(array, n) - returns array of n unique random elements
+	// sample returns n unique random elements from an array.
+	// Takes array and count. Returns new array of sampled elements.
 	"random.sample": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {

--- a/pkg/stdlib/strings.go
+++ b/pkg/stdlib/strings.go
@@ -14,6 +14,12 @@ import (
 
 // StringsBuiltins contains the strings module functions
 var StringsBuiltins = map[string]*object.Builtin{
+	// ============================================================================
+	// Case Conversion
+	// ============================================================================
+
+	// upper converts a string to uppercase.
+	// Takes a string. Returns string.
 	"strings.upper": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -27,6 +33,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// lower converts a string to lowercase.
+	// Takes a string. Returns string.
 	"strings.lower": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -40,6 +48,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// Trimming
+	// ============================================================================
+
+	// trim removes leading and trailing whitespace from a string.
+	// Takes a string. Returns string.
 	"strings.trim": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -53,6 +67,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// Search Operations
+	// ============================================================================
+
+	// contains checks if a string contains a substring.
+	// Takes string and substring. Returns bool.
 	"strings.contains": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -73,6 +93,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// String Manipulation
+	// ============================================================================
+
+	// split divides a string into an array by a separator.
+	// Takes string and separator. Returns array of strings.
 	"strings.split": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -95,6 +121,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// join concatenates array elements into a string with a separator.
+	// Takes array and separator. Returns string.
 	"strings.join": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -121,6 +149,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// replace replaces all occurrences of old with new in a string.
+	// Takes string, old, and new. Returns string.
 	"strings.replace": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -142,6 +172,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// index finds the first occurrence of a substring.
+	// Takes string and substring. Returns int (-1 if not found).
 	"strings.index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -159,6 +191,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// starts_with checks if a string starts with a prefix.
+	// Takes string and prefix. Returns bool.
 	"strings.starts_with": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -179,6 +213,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ends_with checks if a string ends with a suffix.
+	// Takes string and suffix. Returns bool.
 	"strings.ends_with": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -199,6 +235,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// repeat repeats a string n times.
+	// Takes string and count. Returns string.
 	"strings.repeat": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -219,6 +257,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// slice extracts a portion of a string by index.
+	// Takes string, start, and optional end. Returns string.
 	"strings.slice": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -271,6 +311,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// trim_left removes leading whitespace from a string.
+	// Takes a string. Returns string.
 	"strings.trim_left": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -284,6 +326,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// trim_right removes trailing whitespace from a string.
+	// Takes a string. Returns string.
 	"strings.trim_right": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -297,6 +341,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// pad_left pads a string on the left to reach a target width.
+	// Takes string, width, and optional pad char. Returns string.
 	"strings.pad_left": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -333,6 +379,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// pad_right pads a string on the right to reach a target width.
+	// Takes string, width, and optional pad char. Returns string.
 	"strings.pad_right": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 2 || len(args) > 3 {
@@ -369,6 +417,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// reverse reverses the characters in a string.
+	// Takes a string. Returns string.
 	"strings.reverse": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -386,6 +436,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// count counts non-overlapping occurrences of a substring.
+	// Takes string and substring. Returns int.
 	"strings.count": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -403,6 +455,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// String Checks
+	// ============================================================================
+
+	// is_empty checks if a string is empty or contains only whitespace.
+	// Takes a string. Returns bool.
 	"strings.is_empty": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -419,6 +477,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// Character Operations
+	// ============================================================================
+
+	// chars splits a string into an array of characters.
+	// Takes a string. Returns array of chars.
 	"strings.chars": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -437,6 +501,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// from_chars creates a string from an array of characters.
+	// Takes array of chars. Returns string.
 	"strings.from_chars": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -463,6 +529,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// last_index finds the last occurrence of a substring.
+	// Takes string and substring. Returns int (-1 if not found).
 	"strings.last_index": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -480,6 +548,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// capitalize uppercases the first character of a string.
+	// Takes a string. Returns string.
 	"strings.capitalize": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -498,6 +568,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// title converts a string to title case (capitalize each word).
+	// Takes a string. Returns string.
 	"strings.title": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -522,6 +594,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// replace_n replaces the first n occurrences of old with new.
+	// Takes string, old, new, and count. Returns string.
 	"strings.replace_n": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 4 {
@@ -547,6 +621,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// is_numeric checks if a string contains only digits.
+	// Takes a string. Returns bool.
 	"strings.is_numeric": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -568,6 +644,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// is_alpha checks if a string contains only letters.
+	// Takes a string. Returns bool.
 	"strings.is_alpha": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -589,6 +667,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// truncate shortens a string to a max length with a suffix.
+	// Takes string, max length, and suffix. Returns string.
 	"strings.truncate": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 3 {
@@ -629,6 +709,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// compare compares two strings lexicographically.
+	// Takes two strings. Returns int (-1, 0, or 1).
 	"strings.compare": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -646,6 +728,12 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// Type Conversion
+	// ============================================================================
+
+	// to_int parses a string as an integer.
+	// Takes a string. Returns int or Error.
 	"strings.to_int": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -665,6 +753,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// to_float parses a string as a floating-point number.
+	// Takes a string. Returns float or Error.
 	"strings.to_float": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -684,6 +774,8 @@ var StringsBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// to_bool parses a string as a boolean.
+	// Takes a string ("true"/"false"/"1"/"0"/etc). Returns bool or Error.
 	"strings.to_bool": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/time.go
+++ b/pkg/stdlib/time.go
@@ -13,24 +13,40 @@ import (
 
 // TimeBuiltins contains the time module functions
 var TimeBuiltins = map[string]*object.Builtin{
-	// Current time
+	// ============================================================================
+	// Current Time
+	// ============================================================================
+
+	// now returns the current Unix timestamp in seconds.
+	// Takes no arguments. Returns int.
 	"time.now": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(time.Now().Unix())}
 		},
 	},
+
+	// now_ms returns the current Unix timestamp in milliseconds.
+	// Takes no arguments. Returns int.
 	"time.now_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(time.Now().UnixMilli())}
 		},
 	},
+
+	// now_ns returns the current Unix timestamp in nanoseconds.
+	// Takes no arguments. Returns int.
 	"time.now_ns": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(time.Now().UnixNano())}
 		},
 	},
 
-	// Sleep/delay
+	// ============================================================================
+	// Sleep/Delay
+	// ============================================================================
+
+	// sleep pauses execution for the specified number of seconds.
+	// Takes seconds (int or float). Returns nil.
 	"time.sleep": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -47,6 +63,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return object.NIL
 		},
 	},
+	// sleep_ms pauses execution for the specified number of milliseconds.
+	// Takes milliseconds (int). Returns nil.
 	"time.sleep_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -61,61 +79,88 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Time components
+	// ============================================================================
+	// Time Components
+	// ============================================================================
+
+	// year extracts the year from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Year()))}
 		},
 	},
+	// month extracts the month (1-12) from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.month": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Month()))}
 		},
 	},
+
+	// day extracts the day of month (1-31) from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.day": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Day()))}
 		},
 	},
+	// hour extracts the hour (0-23) from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.hour": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Hour()))}
 		},
 	},
+
+	// minute extracts the minute (0-59) from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.minute": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Minute()))}
 		},
 	},
+	// second extracts the second (0-59) from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.second": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Second()))}
 		},
 	},
+
+	// weekday extracts the day of week (0=Sunday, 6=Saturday).
+	// Takes optional timestamp. Returns int.
 	"time.weekday": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.Integer{Value: big.NewInt(int64(t.Weekday()))}
 		},
 	},
+	// weekday_name returns the name of the weekday (e.g., "Monday").
+	// Takes optional timestamp. Returns string.
 	"time.weekday_name": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.String{Value: t.Weekday().String()}
 		},
 	},
+
+	// month_name returns the name of the month (e.g., "January").
+	// Takes optional timestamp. Returns string.
 	"time.month_name": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.String{Value: t.Month().String()}
 		},
 	},
+	// day_of_year extracts the day of year (1-366) from a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.day_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -123,9 +168,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Formatting
-	// time.format(format) - formats current time
-	// time.format(format, timestamp) - formats given timestamp
+	// ============================================================================
+
+	// format formats a timestamp using a format string.
+	// Takes format and optional timestamp. Returns string.
 	"time.format": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 1 || len(args) > 2 {
@@ -158,18 +206,25 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.String{Value: t.Format(goFormat)}
 		},
 	},
+	// iso formats a timestamp as ISO 8601 (RFC 3339).
+	// Takes optional timestamp. Returns string.
 	"time.iso": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.String{Value: t.Format(time.RFC3339)}
 		},
 	},
+
+	// date formats a timestamp as YYYY-MM-DD.
+	// Takes optional timestamp. Returns string.
 	"time.date": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
 			return &object.String{Value: t.Format("2006-01-02")}
 		},
 	},
+	// clock formats a timestamp as HH:MM:SS.
+	// Takes optional timestamp. Returns string.
 	"time.clock": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -177,7 +232,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Parsing
+	// ============================================================================
+
+	// parse parses a time string into a Unix timestamp.
+	// Takes string and format. Returns int or Error.
 	"time.parse": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -201,7 +261,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Creating timestamps
+	// ============================================================================
+	// Creating Timestamps
+	// ============================================================================
+
+	// make creates a timestamp from year, month, day, and optional time.
+	// Takes year, month, day, and optional hour, minute, second. Returns int.
 	"time.make": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) < 3 || len(args) > 6 {
@@ -250,7 +315,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Arithmetic
+	// ============================================================================
+
+	// add_seconds adds seconds to a timestamp.
+	// Takes timestamp and seconds. Returns int.
 	"time.add_seconds": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -268,6 +338,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// add_minutes adds minutes to a timestamp.
+	// Takes timestamp and minutes. Returns int.
 	"time.add_minutes": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -285,6 +357,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// add_hours adds hours to a timestamp.
+	// Takes timestamp and hours. Returns int.
 	"time.add_hours": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -302,6 +376,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// add_days adds days to a timestamp.
+	// Takes timestamp and days. Returns int.
 	"time.add_days": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -319,6 +395,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// add_weeks adds weeks to a timestamp.
+	// Takes timestamp and weeks. Returns int.
 	"time.add_weeks": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -336,6 +414,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// add_months adds months to a timestamp (handles month-end correctly).
+	// Takes timestamp and months. Returns int.
 	"time.add_months": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -380,6 +460,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(result.Unix())}
 		},
 	},
+	// add_years adds years to a timestamp.
+	// Takes timestamp and years. Returns int.
 	"time.add_years": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -399,7 +481,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Differences
+	// ============================================================================
+
+	// diff calculates the difference in seconds between two timestamps.
+	// Takes two timestamps. Returns int.
 	"time.diff": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -417,6 +504,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// diff_days calculates the difference in days between two timestamps.
+	// Takes two timestamps. Returns int.
 	"time.diff_days": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -434,6 +523,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// diff_hours calculates the difference in hours between two timestamps.
+	// Takes two timestamps. Returns int.
 	"time.diff_hours": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -451,6 +542,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	// diff_minutes calculates the difference in minutes between two timestamps.
+	// Takes two timestamps. Returns int.
 	"time.diff_minutes": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -469,7 +562,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Comparisons
+	// ============================================================================
+
+	// is_before checks if the first timestamp is before the second.
+	// Takes two timestamps. Returns bool.
 	"time.is_before": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -489,6 +587,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return object.FALSE
 		},
 	},
+	// is_after checks if the first timestamp is after the second.
+	// Takes two timestamps. Returns bool.
 	"time.is_after": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -509,13 +609,21 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Timezone
+	// ============================================================================
+
+	// timezone returns the local timezone name (e.g., "EST").
+	// Takes no arguments. Returns string.
 	"time.timezone": {
 		Fn: func(args ...object.Object) object.Object {
 			name, _ := time.Now().Zone()
 			return &object.String{Value: name}
 		},
 	},
+
+	// utc_offset returns the local UTC offset in seconds.
+	// Takes no arguments. Returns int.
 	"time.utc_offset": {
 		Fn: func(args ...object.Object) object.Object {
 			_, offset := time.Now().Zone()
@@ -523,7 +631,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Special checks
+	// ============================================================================
+	// Special Checks
+	// ============================================================================
+
+	// is_leap_year checks if a year is a leap year.
+	// Takes optional year. Returns bool.
 	"time.is_leap_year": {
 		Fn: func(args ...object.Object) object.Object {
 			var year int
@@ -542,6 +655,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return object.FALSE
 		},
 	},
+	// days_in_month returns the number of days in a month.
+	// Takes optional year and month. Returns int.
 	"time.days_in_month": {
 		Fn: func(args ...object.Object) object.Object {
 			var year, month int
@@ -569,7 +684,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Start/end of periods
+	// ============================================================================
+	// Start/End of Periods
+	// ============================================================================
+
+	// start_of_day returns the timestamp for midnight of that day.
+	// Takes optional timestamp. Returns int.
 	"time.start_of_day": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -577,6 +697,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(start.Unix())}
 		},
 	},
+	// end_of_day returns the timestamp for 23:59:59 of that day.
+	// Takes optional timestamp. Returns int.
 	"time.end_of_day": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -584,6 +706,9 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(end.Unix())}
 		},
 	},
+
+	// start_of_month returns the timestamp for the first day of the month.
+	// Takes optional timestamp. Returns int.
 	"time.start_of_month": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -591,6 +716,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(start.Unix())}
 		},
 	},
+	// end_of_month returns the timestamp for the last day of the month.
+	// Takes optional timestamp. Returns int.
 	"time.end_of_month": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -598,6 +725,9 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(end.Unix())}
 		},
 	},
+
+	// start_of_year returns the timestamp for January 1st of that year.
+	// Takes optional timestamp. Returns int.
 	"time.start_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -605,6 +735,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(start.Unix())}
 		},
 	},
+	// end_of_year returns the timestamp for December 31st of that year.
+	// Takes optional timestamp. Returns int.
 	"time.end_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -613,7 +745,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Calendar utilities
+	// ============================================================================
+	// Calendar Utilities
+	// ============================================================================
+
+	// quarter returns the quarter (1-4) for a timestamp.
+	// Takes optional timestamp. Returns int.
 	"time.quarter": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -622,6 +759,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 			return &object.Integer{Value: big.NewInt(int64(quarter))}
 		},
 	},
+	// week_of_year returns the ISO week number (1-53).
+	// Takes optional timestamp. Returns int.
 	"time.week_of_year": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -630,12 +769,19 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// Timing/benchmarking
+	// ============================================================================
+	// Timing/Benchmarking
+	// ============================================================================
+
+	// tick returns a high-resolution timestamp in nanoseconds for timing.
+	// Takes no arguments. Returns int.
 	"time.tick": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(time.Now().UnixNano())}
 		},
 	},
+	// elapsed_ms calculates elapsed time in milliseconds since a tick.
+	// Takes a start tick. Returns float.
 	"time.elapsed_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -650,43 +796,56 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
 	// Weekday Constants
+	// ============================================================================
+
+	// SUNDAY weekday constant (0).
 	"time.SUNDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(0)}
 		},
 		IsConstant: true,
 	},
+	// MONDAY weekday constant (1).
 	"time.MONDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
 		IsConstant: true,
 	},
+
+	// TUESDAY weekday constant (2).
 	"time.TUESDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
 		},
 		IsConstant: true,
 	},
+	// WEDNESDAY weekday constant (3).
 	"time.WEDNESDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3)}
 		},
 		IsConstant: true,
 	},
+
+	// THURSDAY weekday constant (4).
 	"time.THURSDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(4)}
 		},
 		IsConstant: true,
 	},
+	// FRIDAY weekday constant (5).
 	"time.FRIDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(5)}
 		},
 		IsConstant: true,
 	},
+
+	// SATURDAY weekday constant (6).
 	"time.SATURDAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(6)}
@@ -694,73 +853,93 @@ var TimeBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// ============================================================================
 	// Month Constants
+	// ============================================================================
+
+	// JANUARY month constant (1).
 	"time.JANUARY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
 		IsConstant: true,
 	},
+	// FEBRUARY month constant (2).
 	"time.FEBRUARY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(2)}
 		},
 		IsConstant: true,
 	},
+
+	// MARCH month constant (3).
 	"time.MARCH": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3)}
 		},
 		IsConstant: true,
 	},
+	// APRIL month constant (4).
 	"time.APRIL": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(4)}
 		},
 		IsConstant: true,
 	},
+
+	// MAY month constant (5).
 	"time.MAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(5)}
 		},
 		IsConstant: true,
 	},
+	// JUNE month constant (6).
 	"time.JUNE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(6)}
 		},
 		IsConstant: true,
 	},
+
+	// JULY month constant (7).
 	"time.JULY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(7)}
 		},
 		IsConstant: true,
 	},
+	// AUGUST month constant (8).
 	"time.AUGUST": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(8)}
 		},
 		IsConstant: true,
 	},
+
+	// SEPTEMBER month constant (9).
 	"time.SEPTEMBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(9)}
 		},
 		IsConstant: true,
 	},
+	// OCTOBER month constant (10).
 	"time.OCTOBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(10)}
 		},
 		IsConstant: true,
 	},
+
+	// NOVEMBER month constant (11).
 	"time.NOVEMBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(11)}
 		},
 		IsConstant: true,
 	},
+	// DECEMBER month constant (12).
 	"time.DECEMBER": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(12)}
@@ -768,31 +947,41 @@ var TimeBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// ============================================================================
 	// Duration Constants (in seconds)
+	// ============================================================================
+
+	// SECOND duration constant (1 second).
 	"time.SECOND": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(1)}
 		},
 		IsConstant: true,
 	},
+	// MINUTE duration constant (60 seconds).
 	"time.MINUTE": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(60)}
 		},
 		IsConstant: true,
 	},
+
+	// HOUR duration constant (3600 seconds).
 	"time.HOUR": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(3600)}
 		},
 		IsConstant: true,
 	},
+	// DAY duration constant (86400 seconds).
 	"time.DAY": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(86400)}
 		},
 		IsConstant: true,
 	},
+
+	// WEEK duration constant (604800 seconds).
 	"time.WEEK": {
 		Fn: func(args ...object.Object) object.Object {
 			return &object.Integer{Value: big.NewInt(604800)}
@@ -800,6 +989,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		IsConstant: true,
 	},
 
+	// ============================================================================
+	// Unix Conversion
+	// ============================================================================
+
+	// from_unix converts a Unix timestamp (seconds) to a timestamp.
+	// Takes seconds. Returns int.
 	"time.from_unix": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -814,6 +1009,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// from_unix_ms converts a Unix timestamp (milliseconds) to a timestamp.
+	// Takes milliseconds. Returns int.
 	"time.from_unix_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -829,6 +1026,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// to_unix converts a timestamp to Unix seconds.
+	// Takes timestamp. Returns int.
 	"time.to_unix": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -844,6 +1043,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// to_unix_ms converts a timestamp to Unix milliseconds.
+	// Takes timestamp. Returns int.
 	"time.to_unix_ms": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -859,6 +1060,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// Day Checks
+	// ============================================================================
+
+	// is_weekend checks if a timestamp falls on Saturday or Sunday.
+	// Takes optional timestamp. Returns bool.
 	"time.is_weekend": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -871,6 +1078,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// is_weekday checks if a timestamp falls on Monday through Friday.
+	// Takes optional timestamp. Returns bool.
 	"time.is_weekday": {
 		Fn: func(args ...object.Object) object.Object {
 			t := getTime(args)
@@ -882,6 +1091,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// is_today checks if a timestamp falls on today's date.
+	// Takes timestamp. Returns bool.
 	"time.is_today": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -898,6 +1109,8 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// is_same_day checks if two timestamps fall on the same calendar day.
+	// Takes two timestamps. Returns bool.
 	"time.is_same_day": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 2 {
@@ -920,6 +1133,12 @@ var TimeBuiltins = map[string]*object.Builtin{
 		},
 	},
 
+	// ============================================================================
+	// Relative Time
+	// ============================================================================
+
+	// relative formats a timestamp as a human-readable relative time.
+	// Takes timestamp. Returns string (e.g., "2 hours ago").
 	"time.relative": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/pkg/stdlib/uuid.go
+++ b/pkg/stdlib/uuid.go
@@ -17,7 +17,8 @@ var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]
 
 // UUIDBuiltins contains the uuid module functions
 var UUIDBuiltins = map[string]*object.Builtin{
-	// uuid.create() - generates a new UUID v4 (random)
+	// create generates a new random UUID v4.
+	// Takes no arguments. Returns UUID string (e.g., "550e8400-e29b-41d4-a716-446655440000").
 	"uuid.create": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 0 {
@@ -33,7 +34,8 @@ var UUIDBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// uuid.create_compact() - generates a new UUID v4 without hyphens
+	// create_compact generates a new UUID v4 without hyphens.
+	// Takes no arguments. Returns 32-character hex string.
 	"uuid.create_compact": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 0 {
@@ -51,7 +53,8 @@ var UUIDBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// uuid.is_valid(str) - checks if a string is a valid UUID
+	// is_valid checks if a string is a valid UUID format.
+	// Takes a string. Returns bool.
 	"uuid.is_valid": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {
@@ -70,7 +73,7 @@ var UUIDBuiltins = map[string]*object.Builtin{
 		},
 	},
 
-	// uuid.NIL - the nil UUID constant
+	// NIL is the nil UUID constant (all zeros).
 	"uuid.NIL": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 0 {


### PR DESCRIPTION
## Summary
- Adds uniform two-line doc comments to all stdlib modules
- Organizes functions into logical sections with header comments
- Documents parameter types and return values for each function

**Modules documented:**
- @std, @arrays, @binary, @bytes, @crypto, @db
- @encoding, @http, @io, @json, @maps, @math
- @os, @random, @strings, @time, @uuid

Closes #633

## Test plan
- [x] Build passes (`go build ./...`)
- [x] No functional changes, documentation only