### PR TITLE
feat: Add named return variables support (#1131)

### DIFF
--- a/integration-tests/fail/errors/E2002_named_return_no_parens.ez
+++ b/integration-tests/fail/errors/E2002_named_return_no_parens.ez
@@ -1,0 +1,14 @@
+/* Test: Named return without parentheses
+ * Expected: E2002 error - named returns must be enclosed in parentheses
+ */
+
+import & use @std
+
+do getName() -> name string {
+    name = "Alice"
+    return name
+}
+
+do main() {
+    println(getName())
+}

--- a/integration-tests/fail/errors/E2012_duplicate_return_param.ez
+++ b/integration-tests/fail/errors/E2012_duplicate_return_param.ez
@@ -1,0 +1,14 @@
+/* Test: Duplicate return parameter name
+ * Expected: E2012 error - duplicate parameter name
+ */
+
+import & use @std
+
+do getValues() -> (name string, name int) {
+    return "test", 42
+}
+
+do main() {
+    temp n string, i int = getValues()
+    println(n)
+}

--- a/integration-tests/fail/errors/E2012_return_param_conflicts_input.ez
+++ b/integration-tests/fail/errors/E2012_return_param_conflicts_input.ez
@@ -1,0 +1,13 @@
+/* Test: Return parameter conflicts with input parameter
+ * Expected: E2012 error - parameter name already used
+ */
+
+import & use @std
+
+do process(name string) -> (name string) {
+    return name
+}
+
+do main() {
+    println(process("test"))
+}

--- a/integration-tests/fail/errors/E3012_named_return_type_mismatch.ez
+++ b/integration-tests/fail/errors/E3012_named_return_type_mismatch.ez
@@ -1,0 +1,13 @@
+/* Test: Named return with wrong type
+ * Expected: E3012 error - return type mismatch
+ */
+
+import & use @std
+
+do getName() -> (name string) {
+    return 42
+}
+
+do main() {
+    println(getName())
+}

--- a/integration-tests/fail/errors/E3013_named_return_count_mismatch.ez
+++ b/integration-tests/fail/errors/E3013_named_return_count_mismatch.ez
@@ -1,0 +1,14 @@
+/* Test: Named return with wrong number of values
+ * Expected: E3013 error - wrong number of return values
+ */
+
+import & use @std
+
+do getValues() -> (age int, name string) {
+    return 42
+}
+
+do main() {
+    temp a int, n string = getValues()
+    println(a)
+}

--- a/integration-tests/pass/named_returns/basic_named_return.ez
+++ b/integration-tests/pass/named_returns/basic_named_return.ez
@@ -1,0 +1,14 @@
+/* Test: Basic named return variable
+ * Expected: passes with output "Alice"
+ */
+
+import & use @std
+
+do getUserName() -> (name string) {
+    name = "Alice"
+    return name
+}
+
+do main() {
+    println(getUserName())
+}

--- a/integration-tests/pass/named_returns/mixed_shared_type.ez
+++ b/integration-tests/pass/named_returns/mixed_shared_type.ez
@@ -1,0 +1,19 @@
+/* Test: Mixed shared type named return variables
+ * Expected: passes with output "Alice", "NYC", "30"
+ */
+
+import & use @std
+
+do getFullInfo() -> (name, city string, age int) {
+    name = "Alice"
+    city = "NYC"
+    age = 30
+    return name, city, age
+}
+
+do main() {
+    temp n string, c string, a int = getFullInfo()
+    println(n)
+    println(c)
+    println(a)
+}

--- a/integration-tests/pass/named_returns/modification.ez
+++ b/integration-tests/pass/named_returns/modification.ez
@@ -1,0 +1,18 @@
+/* Test: Named return variable modification
+ * Expected: passes with output "25"
+ */
+
+import & use @std
+
+do calculate() -> (result int) {
+    result = 10
+    result = result * 2
+    if result > 15 {
+        result = result + 5
+    }
+    return result
+}
+
+do main() {
+    println(calculate())
+}

--- a/integration-tests/pass/named_returns/multi_named_return.ez
+++ b/integration-tests/pass/named_returns/multi_named_return.ez
@@ -1,0 +1,17 @@
+/* Test: Multiple named return variables with different types
+ * Expected: passes with output "25" and "Bob"
+ */
+
+import & use @std
+
+do getPersonInfo() -> (age int, name string) {
+    age = 25
+    name = "Bob"
+    return age, name
+}
+
+do main() {
+    temp a int, n string = getPersonInfo()
+    println(a)
+    println(n)
+}

--- a/integration-tests/pass/named_returns/shared_type_named_return.ez
+++ b/integration-tests/pass/named_returns/shared_type_named_return.ez
@@ -1,0 +1,17 @@
+/* Test: Named return variables sharing a type
+ * Expected: passes with output "John" and "Doe"
+ */
+
+import & use @std
+
+do getNames() -> (first, last string) {
+    first = "John"
+    last = "Doe"
+    return first, last
+}
+
+do main() {
+    temp f string, l string = getNames()
+    println(f)
+    println(l)
+}

--- a/integration-tests/pass/named_returns/zero_value_init.ez
+++ b/integration-tests/pass/named_returns/zero_value_init.ez
@@ -1,0 +1,28 @@
+/* Test: Named return zero value initialization
+ * Expected: passes with output "0", "", "false", "0.0"
+ */
+
+import & use @std
+
+do getZeroInt() -> (count int) {
+    return count
+}
+
+do getZeroString() -> (text string) {
+    return text
+}
+
+do getZeroBool() -> (flag bool) {
+    return flag
+}
+
+do getZeroFloat() -> (value float) {
+    return value
+}
+
+do main() {
+    println(getZeroInt())
+    println(getZeroString())
+    println(getZeroBool())
+    println(getZeroFloat())
+}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -436,13 +436,14 @@ func (c *ContinueStatement) TokenLiteral() string { return c.Token.Literal }
 
 // FunctionDeclaration represents do func_name(params) -> return_type { }
 type FunctionDeclaration struct {
-	Token       Token
-	Name        *Label
-	Parameters  []*Parameter
-	ReturnTypes []string // can be multiple for multi-return
-	Body        *BlockStatement
-	Attributes  []*Attribute // #suppress(...) attributes
-	Visibility  Visibility   // Public (default), Private, or PrivateModule
+	Token        Token
+	Name         *Label
+	Parameters   []*Parameter
+	ReturnTypes  []string       // can be multiple for multi-return
+	ReturnParams []*ReturnParam // named return parameters (nil if using unnamed returns)
+	Body         *BlockStatement
+	Attributes   []*Attribute // #suppress(...) attributes
+	Visibility   Visibility   // Public (default), Private, or PrivateModule
 }
 
 func (f *FunctionDeclaration) statementNode()       {}
@@ -454,6 +455,12 @@ type Parameter struct {
 	TypeName     string
 	Mutable      bool       // true if declared with & prefix
 	DefaultValue Expression // nil if no default value
+}
+
+// ReturnParam represents a named return parameter
+type ReturnParam struct {
+	Name     *Label
+	TypeName string
 }
 
 // ImportItem represents a single module import with optional alias

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -414,6 +414,7 @@ var (
 	W2008 = ErrorCode{"W2008", "integer-overflow-potential", "integer arithmetic may overflow"}
 	W2009 = ErrorCode{"W2009", "nil-dereference-potential", "accessing member on potentially nil value"}
 	W2010 = ErrorCode{"W2010", "chained-nil-access", "chained member access on nullable struct type"}
+	W2011 = ErrorCode{"W2011", "named-return-unused", "function declares named return variable but returns different value"}
 
 	// Code Quality Warnings (W3xxx)
 	W3001 = ErrorCode{"W3001", "empty-block", "block statement is empty"}

--- a/pkg/interpreter/evaluator_test.go
+++ b/pkg/interpreter/evaluator_test.go
@@ -437,6 +437,143 @@ r
 	testIntegerObject(t, evaluated, 120)
 }
 
+func TestNamedReturnBasic(t *testing.T) {
+	input := `
+do getNumber() -> (result int) {
+	result = 42
+	return result
+}
+temp r int = getNumber()
+r
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 42)
+}
+
+func TestNamedReturnZeroValue(t *testing.T) {
+	// Named return variables are auto-initialized to zero values
+	input := `
+do getZero() -> (count int) {
+	return count
+}
+temp r int = getZero()
+r
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 0)
+}
+
+func TestNamedReturnMultiple(t *testing.T) {
+	input := `
+do getPersonInfo() -> (age int, name string) {
+	age = 25
+	name = "Alice"
+	return age, name
+}
+temp a int, n string = getPersonInfo()
+a
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 25)
+}
+
+func TestNamedReturnSharedType(t *testing.T) {
+	input := `
+do getNames() -> (first, last string) {
+	first = "John"
+	last = "Doe"
+	return first, last
+}
+temp f string, l string = getNames()
+f
+`
+	evaluated := testEval(input)
+	testStringObject(t, evaluated, "John")
+}
+
+func TestNamedReturnMixedSharedTypes(t *testing.T) {
+	input := `
+do getFullInfo() -> (name, city string, age int) {
+	name = "Bob"
+	city = "NYC"
+	age = 30
+	return name, city, age
+}
+temp n string, c string, a int = getFullInfo()
+a
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 30)
+}
+
+func TestNamedReturnModification(t *testing.T) {
+	// Named return variables can be modified
+	input := `
+do calculate() -> (result int) {
+	result = 10
+	result = result * 2
+	if result > 15 {
+		result = result + 5
+	}
+	return result
+}
+temp r int = calculate()
+r
+`
+	evaluated := testEval(input)
+	testIntegerObject(t, evaluated, 25)
+}
+
+func TestNamedReturnDifferentVariable(t *testing.T) {
+	// Can return a different variable of the same type (warning emitted but valid)
+	input := `
+do getName() -> (name string) {
+	temp other string = "Hello"
+	return other
+}
+temp r string = getName()
+r
+`
+	evaluated := testEval(input)
+	testStringObject(t, evaluated, "Hello")
+}
+
+func TestNamedReturnStringZeroValue(t *testing.T) {
+	input := `
+do getEmpty() -> (s string) {
+	return s
+}
+temp r string = getEmpty()
+r
+`
+	evaluated := testEval(input)
+	testStringObject(t, evaluated, "")
+}
+
+func TestNamedReturnBoolZeroValue(t *testing.T) {
+	input := `
+do getFalse() -> (b bool) {
+	return b
+}
+temp r bool = getFalse()
+r
+`
+	evaluated := testEval(input)
+	testBooleanObject(t, evaluated, false)
+}
+
+func TestNamedReturnFloatZeroValue(t *testing.T) {
+	input := `
+do getZeroFloat() -> (f float) {
+	return f
+}
+temp r float = getZeroFloat()
+r
+`
+	evaluated := testEval(input)
+	testFloatObject(t, evaluated, 0.0)
+}
+
 // ============================================================================
 // Array Tests
 // ============================================================================
@@ -5545,8 +5682,8 @@ func TestIdentifierEvaluation(t *testing.T) {
 			expected: int64(42),
 		},
 		{
-			name: "nil literal",
-			input: `nil`,
+			name:     "nil literal",
+			input:    `nil`,
 			expected: nil,
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds support for named return variables in function declarations
- Single named return: `do f() -> (name string)`
- Multiple named returns: `do f() -> (age int, name string)`
- Shared type syntax: `do f() -> (first, last string)`
- Mixed types: `do f() -> (name, city string, age int)`
- Named return variables are auto-initialized to zero values
- Warning W2011 emitted when returning a different variable than declared

## Test plan

- [x] Unit tests added for parser, evaluator, and typechecker
- [x] Integration pass tests for all syntax variants
- [x] Integration fail tests for error cases (duplicate names, type mismatch, etc.)
- [x] Manual verification of all spec examples

Closes #1131