### PR TITLE
feat(typechecker): add W1005 warning for typed blank identifiers

### DIFF
--- a/integration-tests/pass/warnings/W1005_typed_blank_identifier.ez
+++ b/integration-tests/pass/warnings/W1005_typed_blank_identifier.ez
@@ -1,0 +1,34 @@
+// Test: W1005 typed-blank-identifier warning
+// Typed blank identifiers should trigger W1005 warning but still run successfully
+
+import & use @std
+
+do returnTwo() -> (int, string) {
+    return 42, "hello"
+}
+
+do returnThree() -> (int, string, bool) {
+    return 1, "two", true
+}
+
+do main() {
+    // Test 1: typed blank after named - should warn for the typed blank
+    temp x int, _ string = returnTwo()
+    println(x)
+
+    // Test 2: all typed blanks - should warn for both
+    temp _ int, _ string = returnTwo()
+    println("discarded both")
+
+    // Test 3: typed blank in the middle
+    temp a int, _ string, c bool = returnThree()
+    println(a)
+    println(c)
+
+    // These should NOT warn (untyped blanks):
+    temp y, _ = returnTwo()
+    println(y)
+
+    temp _, z = returnTwo()
+    println(z)
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -402,6 +402,7 @@ var (
 	W1002 = ErrorCode{"W1002", "unused-import", "module imported but not used"}
 	W1003 = ErrorCode{"W1003", "unused-function", "function declared but not called"}
 	W1004 = ErrorCode{"W1004", "unused-parameter", "parameter declared but not used"}
+	W1005 = ErrorCode{"W1005", "typed-blank-identifier", "blank identifier does not require type annotation"}
 
 	// Potential Bug Warnings (W2xxx)
 	W2001 = ErrorCode{"W2001", "unreachable-code", "code will never execute"}


### PR DESCRIPTION
## Summary
- Add W1005 warning when blank identifier `_` is used with a type annotation (e.g., `temp _ int = ...`)
- Type annotations on blank identifiers are unnecessary since the value is discarded
- Warning can be suppressed with `#suppress("W1005")`

## Test plan
- [x] Unit tests pass for parser and typechecker
- [x] Integration test added: `integration-tests/pass/warnings/W1005_typed_blank_identifier.ez`
- [x] Warning fires for typed blanks in single and multi-return declarations
- [x] Warning suppression works with `#suppress("W1005")`
- [x] Untyped blanks do not trigger warning