### PR TITLE
fix(parser): validate `#doc` attribute placement

### DIFF
--- a/integration-tests/fail/errors/E2058_doc_in_function.ez
+++ b/integration-tests/fail/errors/E2058_doc_in_function.ez
@@ -1,0 +1,8 @@
+// Test: E2058 - #doc inside function body (invalid target)
+import & use @std
+
+do main() {
+    #doc("This should fail - cannot use #doc inside function")
+    temp x int = 5
+    println(x)
+}

--- a/integration-tests/fail/errors/E2058_doc_on_variable.ez
+++ b/integration-tests/fail/errors/E2058_doc_on_variable.ez
@@ -1,0 +1,9 @@
+// Test: E2058 - #doc on variable (invalid target)
+import & use @std
+
+#doc("This should fail - variables cannot be documented")
+temp globalVar int = 42
+
+do main() {
+    println(globalVar)
+}

--- a/integration-tests/fail/errors/E2059_doc_at_eof.ez
+++ b/integration-tests/fail/errors/E2059_doc_at_eof.ez
@@ -1,0 +1,8 @@
+// Test: E2059 - #doc at end of file (orphaned)
+import & use @std
+
+do main() {
+    println("hello")
+}
+
+#doc("This should fail - orphaned at EOF")

--- a/integration-tests/fail/errors/E2059_doc_before_import.ez
+++ b/integration-tests/fail/errors/E2059_doc_before_import.ez
@@ -1,0 +1,7 @@
+// Test: E2059 - #doc before import (orphaned)
+#doc("This should fail - must precede a declaration")
+import & use @std
+
+do main() {
+    println("hello")
+}

--- a/integration-tests/fail/errors/E2060_doc_duplicate.ez
+++ b/integration-tests/fail/errors/E2060_doc_duplicate.ez
@@ -1,0 +1,8 @@
+// Test: E2060 - multiple #doc on same declaration
+import & use @std
+
+#doc("First doc")
+#doc("Second doc - this should fail")
+do main() {
+    println("hello")
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -94,6 +94,9 @@ var (
 	E2055 = ErrorCode{"E2055", "strict-invalid-target", "#strict can only be applied to when statements"}
 	E2056 = ErrorCode{"E2056", "executable-at-file-scope", "executable statement not allowed at file scope"}
 	E2057 = ErrorCode{"E2057", "invalid-interpolation-syntax", "invalid string interpolation syntax"}
+	E2058 = ErrorCode{"E2058", "doc-invalid-target", "#doc can only be applied to functions, structs, or enums"}
+	E2059 = ErrorCode{"E2059", "doc-orphaned", "#doc must be followed by a declaration"}
+	E2060 = ErrorCode{"E2060", "doc-duplicate", "only one #doc attribute is allowed per declaration"}
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Add validation for `#doc` attribute to ensure it's only used in valid locations.

### New Error Codes
- **E2058** `doc-invalid-target`: `#doc` can only be applied to functions, structs, or enums
- **E2059** `doc-orphaned`: `#doc` must be followed by a declaration  
- **E2060** `doc-duplicate`: Only one `#doc` attribute per declaration

### What's Validated
| Scenario | Error |
|----------|-------|
| `#doc` on `temp` variable | E2058 |
| `#doc` on `const` variable | E2058 |
| `#doc` inside function body | E2058 |
| `#doc` at end of file | E2059 |
| `#doc` before import | E2059 |
| Multiple `#doc` on same declaration | E2060 |

### Valid Usage (unchanged)
- `#doc` on functions ✅
- `#doc` on structs ✅
- `#doc` on enums ✅

## Test plan
- [x] Unit tests pass
- [x] Integration tests added for all error cases
- [x] Valid `#doc` usage still works
- [x] `ez doc` command still generates documentation correctly