### PR TITLE
fix: complete tuple type inference for all stdlib modules (#1138)

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -6476,6 +6476,12 @@ func (tc *TypeChecker) getModuleMultiReturnTypes(moduleName, funcName string, ar
 		case "groups_all":
 			return []string{"[[string]]", "Error"}
 		}
+
+	case "encoding":
+		switch funcName {
+		case "base64_decode", "hex_decode", "url_decode":
+			return []string{"string", "Error"}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds the `encoding` module (base64_decode, hex_decode, url_decode) to `getModuleMultiReturnTypes`, completing coverage of all tuple-returning stdlib modules
- Combined with #1137, all stdlib modules now properly infer types for untyped tuple bindings

## Coverage

All tuple-returning modules are now registered:
io, json, os, bytes, binary, db, http, csv, regex, **encoding**

Modules without tuple returns (std, math, arrays, strings, time, maps, crypto, random, uuid) don't need entries.

## Test plan

- [x] `temp decoded, err = encoding.base64_decode(...)` properly infers types
- [x] All other modules' untyped tuple bindings still work
- [x] Full test suite passes (`go test ./...`)

Closes #1138