### PR TITLE
feat: add optional index variable to `for_each` loops (#1139)

### DIFF
--- a/examples/basic/control_flow.ez
+++ b/examples/basic/control_flow.ez
@@ -57,6 +57,14 @@ do main() {
         println("  - ${fruit}")
     }
 
+    // for_each with index
+    println("")
+    println("-- For_each with index --")
+    println("Numbered fruits:")
+    for_each i, fruit in fruits {
+        println("  ${i}: ${fruit}")
+    }
+
     // for_each with string
     println("")
     println("Letters in 'EZ':")

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -389,8 +389,10 @@ func (fs *ForStatement) statementNode()       {}
 func (fs *ForStatement) TokenLiteral() string { return fs.Token.Literal }
 
 // ForEachStatement represents for_each item in collection { }
+// or for_each i, item in collection { }
 type ForEachStatement struct {
 	Token      Token
+	Index      *Label // optional index variable
 	Variable   *Label
 	Collection Expression
 	Body       *BlockStatement

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -2065,7 +2065,10 @@ func evalForEachStatement(node *ast.ForEachStatement, env *Environment, ctx *Eva
 		arr.IteratingCount++
 		defer func() { arr.IteratingCount-- }()
 
-		for _, elem := range arr.Elements {
+		for idx, elem := range arr.Elements {
+			if node.Index != nil {
+				loopEnv.Set(node.Index.Value, &Integer{Value: big.NewInt(int64(idx))}, true)
+			}
 			loopEnv.Set(node.Variable.Value, elem, true) // loop vars are mutable
 
 			result := Eval(node.Body, loopEnv, ctx)
@@ -2083,8 +2086,11 @@ func evalForEachStatement(node *ast.ForEachStatement, env *Environment, ctx *Eva
 
 	// Handle strings (iterate over characters)
 	if str, ok := collection.(*String); ok {
-		for _, ch := range str.Value {
+		for idx, ch := range str.Value {
 			charObj := &Char{Value: ch}
+			if node.Index != nil {
+				loopEnv.Set(node.Index.Value, &Integer{Value: big.NewInt(int64(idx))}, true)
+			}
 			loopEnv.Set(node.Variable.Value, charObj, true) // loop vars are mutable
 
 			result := Eval(node.Body, loopEnv, ctx)


### PR DESCRIPTION
## Summary
- Adds optional index variable support to `for_each` loops: `for_each i, item in collection`
- Works with both arrays and strings, and supports blank identifiers in either position
- Changes span AST, parser, evaluator, and typechecker

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual test with arrays, strings, and blank identifiers