### PR TITLE
fix(stdlib/arrays): `arrays.join` no longer wraps string elements in quotes (#1144)

### DIFF
--- a/pkg/stdlib/arrays_test.go
+++ b/pkg/stdlib/arrays_test.go
@@ -571,9 +571,7 @@ func TestArraysJoinUnit(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected string, got %T: %v", result, result)
 	}
-	// JoinObjects uses Inspect() which includes quotes for strings
-	// So the result is '"a", "b", "c"' not 'a, b, c'
-	expected := "\"a\", \"b\", \"c\""
+	expected := "a, b, c"
 	if strVal.Value != expected {
 		t.Errorf("expected '%s', got '%s'", expected, strVal.Value)
 	}

--- a/pkg/stdlib/helpers.go
+++ b/pkg/stdlib/helpers.go
@@ -13,20 +13,30 @@ import (
 // String Building Utilities
 // =============================================================================
 
-// JoinObjects joins object Inspect() values with a separator efficiently.
+// objectDisplayValue returns the display string for an object.
+// For strings, this returns the raw value without quotes.
+// For all other types, this returns the Inspect() representation.
+func objectDisplayValue(obj object.Object) string {
+	if s, ok := obj.(*object.String); ok {
+		return s.Value
+	}
+	return obj.Inspect()
+}
+
+// JoinObjects joins object display values with a separator efficiently.
 func JoinObjects(elements []object.Object, sep string) string {
 	if len(elements) == 0 {
 		return ""
 	}
 	if len(elements) == 1 {
-		return elements[0].Inspect()
+		return objectDisplayValue(elements[0])
 	}
 
 	var sb strings.Builder
-	sb.WriteString(elements[0].Inspect())
+	sb.WriteString(objectDisplayValue(elements[0]))
 	for _, el := range elements[1:] {
 		sb.WriteString(sep)
-		sb.WriteString(el.Inspect())
+		sb.WriteString(objectDisplayValue(el))
 	}
 	return sb.String()
 }

--- a/pkg/stdlib/stdlib_test.go
+++ b/pkg/stdlib/stdlib_test.go
@@ -4979,9 +4979,8 @@ func TestArraysJoin(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected String, got %T", result)
 	}
-	// The join function includes quotes around string elements
-	if strVal.Value != `"a","b","c"` {
-		t.Errorf("expected '\"a\",\"b\",\"c\"', got '%s'", strVal.Value)
+	if strVal.Value != "a,b,c" {
+		t.Errorf("expected 'a,b,c', got '%s'", strVal.Value)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `arrays.join()` was using `Inspect()` to convert elements to strings, which wraps `string` values in quotes via `%q`
- Added `objectDisplayValue()` helper that returns raw `.Value` for strings and `Inspect()` for all other types
- Updated `JoinObjects()` to use this helper
- Fixed corresponding unit and integration tests

Closes #1144

## Test plan
- [x] `go test ./...` passes
- [x] Manual verification: `arrays.join({"hello", "world", "foo"}, "-")` now returns `hello-world-foo` instead of `"hello"-"world"-"foo"`