### PR TITLE
fix: allow enum constants in `when/is` when value is explicitly typed (#1143)

### DIFF
--- a/pkg/typechecker/typechecker.go
+++ b/pkg/typechecker/typechecker.go
@@ -4651,7 +4651,12 @@ func (tc *TypeChecker) checkWhenStatement(whenStmt *ast.WhenStatement, expectedR
 				// Allow enum type matching
 				if !strings.HasPrefix(caseType, valueType) && !strings.HasSuffix(caseType, "."+valueType) {
 					// Allow int case values when matching against enum types (enums have int underlying values)
-					if !(isEnumType && caseType == "int") {
+					// Also allow enum case values when matching against int (e.g., temp dir int = Direction.SOUTH)
+					caseIsEnumWithIntBase := false
+					if caseEnumInfo, isCaseEnum := tc.GetType(caseType); isCaseEnum && caseEnumInfo.Kind == EnumType {
+						caseIsEnumWithIntBase = caseEnumInfo.EnumBaseType == valueType
+					}
+					if !(isEnumType && caseType == "int") && !caseIsEnumWithIntBase {
 						line, col := tc.getExpressionPosition(caseValue)
 						tc.addError(
 							errors.E3001,


### PR DESCRIPTION
## Summary
- When a variable is explicitly typed as `int` (or `string`) but holds an enum value, `when/is` cases using enum constants now type-check correctly
- The typechecker already allowed `int` cases against enum-typed values; this adds the symmetric check — enum cases against the enum's underlying base type

## Example that previously failed
```ez
const Direction enum { NORTH  EAST  SOUTH  WEST }

do main() {
    temp dir int = Direction.SOUTH
    when dir {
        is Direction.SOUTH { println("south") }  // was E3001, now works
        default { println("other") }
    }
}
```

Closes #1143

## Test plan
- [x] `go test ./...` passes
- [x] Int enum constants in `when/is` against `int` variable — works
- [x] String enum constants in `when/is` against `string` variable — works
- [x] Existing enum behavior (inferred type, `#strict`, duplicate detection) — unchanged