### PR TITLE
feat(ezc): compiler scaffold with end-to-end hello world

### DIFF
--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -1,0 +1,69 @@
+# EZC Makefile
+#
+# Copyright (c) 2025-Present Marshall A Burns
+# Licensed under the MIT License. See LICENSE for details.
+
+CC ?= cc
+CFLAGS = -std=c11 -Wall -Wextra -Wpedantic -Wno-unused-parameter
+LDFLAGS = -lm
+
+# Build mode
+ifdef DEBUG
+	CFLAGS += -g -O0 -DDEBUG
+else
+	CFLAGS += -O2
+endif
+
+# Source files (compiler only, not runtime/stdlib which are compiled into user binaries)
+SRC = src/main.c \
+      src/util/arena.c \
+      src/util/buf.c \
+      src/lexer/token.c \
+      src/lexer/lexer.c \
+      src/parser/ast.c \
+      src/parser/parser.c \
+      src/codegen/codegen.c
+
+OBJ = $(SRC:.c=.o)
+BIN = ezc
+
+# Include paths for compiler source
+INCLUDES = -Isrc
+
+.PHONY: all build clean install test
+
+all: build
+
+build: $(BIN)
+
+$(BIN): $(OBJ)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+clean:
+	rm -f $(OBJ) $(BIN)
+
+install: build
+	install -d /usr/local/bin
+	install -m 755 $(BIN) /usr/local/bin/
+	install -d /usr/local/lib/ezc/runtime
+	install -d /usr/local/lib/ezc/stdlib
+	install -m 644 src/runtime/ez_runtime.h /usr/local/lib/ezc/runtime/
+	install -m 644 src/runtime/ez_runtime.c /usr/local/lib/ezc/runtime/
+	install -m 644 src/stdlib/ez_std.h /usr/local/lib/ezc/stdlib/
+	install -m 644 src/stdlib/ez_std.c /usr/local/lib/ezc/stdlib/
+
+test: build
+	@echo "Running hello world test..."
+	@echo 'import @std' > /tmp/ezc_test_hello.ez
+	@echo 'using std' >> /tmp/ezc_test_hello.ez
+	@echo '' >> /tmp/ezc_test_hello.ez
+	@echo 'do main() {' >> /tmp/ezc_test_hello.ez
+	@echo '    println("Hello, World!")' >> /tmp/ezc_test_hello.ez
+	@echo '}' >> /tmp/ezc_test_hello.ez
+	cd .. && ./ezc/ezc /tmp/ezc_test_hello.ez -o /tmp/ezc_test_hello
+	@/tmp/ezc_test_hello
+	@rm -f /tmp/ezc_test_hello /tmp/ezc_test_hello.ez
+	@echo "Test passed!"

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -1,0 +1,516 @@
+/*
+ * codegen.c - C code generator for the EZ language
+ *
+ * Walks the AST and emits C source code.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "codegen.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+
+/* Forward declarations */
+static void emit_statement(CodeGen *cg, AstNode *node);
+static void emit_expression(CodeGen *cg, AstNode *node);
+static void emit_call_expression(CodeGen *cg, AstNode *node);
+
+/* --- Helpers --- */
+
+static void emit(CodeGen *cg, const char *s) {
+    buf_append(&cg->output, s);
+}
+
+static void emitf(CodeGen *cg, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+
+    int needed = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+
+    if (needed < 0) return;
+
+    char *tmp = malloc((size_t)needed + 1);
+    va_start(args, fmt);
+    vsnprintf(tmp, (size_t)needed + 1, fmt, args);
+    va_end(args);
+
+    buf_append(&cg->output, tmp);
+    free(tmp);
+}
+
+static void emit_indent(CodeGen *cg) {
+    buf_append_indent(&cg->output, cg->indent);
+}
+
+static void emit_newline(CodeGen *cg) {
+    emit(cg, "\n");
+}
+
+/* Map EZ type name to C type */
+static const char *ez_type_to_c(const char *type_name) {
+    if (!type_name) return "int64_t";
+
+    if (strcmp(type_name, "int") == 0)    return "int64_t";
+    if (strcmp(type_name, "uint") == 0)   return "uint64_t";
+    if (strcmp(type_name, "i8") == 0)     return "int8_t";
+    if (strcmp(type_name, "i16") == 0)    return "int16_t";
+    if (strcmp(type_name, "i32") == 0)    return "int32_t";
+    if (strcmp(type_name, "i64") == 0)    return "int64_t";
+    if (strcmp(type_name, "u8") == 0)     return "uint8_t";
+    if (strcmp(type_name, "u16") == 0)    return "uint16_t";
+    if (strcmp(type_name, "u32") == 0)    return "uint32_t";
+    if (strcmp(type_name, "u64") == 0)    return "uint64_t";
+    if (strcmp(type_name, "i128") == 0)   return "__int128";
+    if (strcmp(type_name, "u128") == 0)   return "unsigned __int128";
+    if (strcmp(type_name, "float") == 0)  return "double";
+    if (strcmp(type_name, "f32") == 0)    return "float";
+    if (strcmp(type_name, "f64") == 0)    return "double";
+    if (strcmp(type_name, "bool") == 0)   return "bool";
+    if (strcmp(type_name, "char") == 0)   return "int32_t";
+    if (strcmp(type_name, "byte") == 0)   return "uint8_t";
+    if (strcmp(type_name, "string") == 0) return "EzString";
+
+    /* Default: assume it's a struct type */
+    return type_name;
+}
+
+static bool is_string_type(const char *type_name) {
+    return type_name && strcmp(type_name, "string") == 0;
+}
+
+/* --- Expression Emission --- */
+
+static void emit_expression(CodeGen *cg, AstNode *node) {
+    if (!node) return;
+
+    switch (node->kind) {
+    case NODE_LABEL:
+        emit(cg, node->data.label.value);
+        break;
+
+    case NODE_INT_VALUE:
+        emitf(cg, "%lld", (long long)node->data.int_value.value);
+        break;
+
+    case NODE_FLOAT_VALUE:
+        emitf(cg, "%g", node->data.float_value.value);
+        break;
+
+    case NODE_STRING_VALUE:
+        emitf(cg, "ez_string_lit(\"%s\")", node->data.string_value.value);
+        break;
+
+    case NODE_BOOL_VALUE:
+        emit(cg, node->data.bool_value.value ? "true" : "false");
+        break;
+
+    case NODE_NIL_VALUE:
+        emit(cg, "NULL");
+        break;
+
+    case NODE_PREFIX_EXPR:
+        emit(cg, "(");
+        emit(cg, node->data.prefix.op);
+        emit_expression(cg, node->data.prefix.right);
+        emit(cg, ")");
+        break;
+
+    case NODE_INFIX_EXPR:
+        emit(cg, "(");
+        emit_expression(cg, node->data.infix.left);
+        emitf(cg, " %s ", node->data.infix.op);
+        emit_expression(cg, node->data.infix.right);
+        emit(cg, ")");
+        break;
+
+    case NODE_POSTFIX_EXPR:
+        emit_expression(cg, node->data.postfix.left);
+        emit(cg, node->data.postfix.op);
+        break;
+
+    case NODE_CALL_EXPR:
+        emit_call_expression(cg, node);
+        break;
+
+    case NODE_MEMBER_EXPR:
+        emit_expression(cg, node->data.member.object);
+        emitf(cg, ".%s", node->data.member.member);
+        break;
+
+    case NODE_INDEX_EXPR:
+        emit_expression(cg, node->data.index_expr.left);
+        emit(cg, "[");
+        emit_expression(cg, node->data.index_expr.index);
+        emit(cg, "]");
+        break;
+
+    default:
+        emitf(cg, "/* TODO: expression kind %d */", node->kind);
+        break;
+    }
+}
+
+/* Check if a call is a stdlib call like std.println or just println (with using) */
+static bool is_stdlib_call(AstNode *node, const char **module, const char **func) {
+    if (node->data.call.function->kind == NODE_MEMBER_EXPR) {
+        AstNode *obj = node->data.call.function->data.member.object;
+        if (obj->kind == NODE_LABEL) {
+            *module = obj->data.label.value;
+            *func = node->data.call.function->data.member.member;
+            return true;
+        }
+    } else if (node->data.call.function->kind == NODE_LABEL) {
+        /* Direct call like println() via using */
+        *module = NULL;
+        *func = node->data.call.function->data.label.value;
+        return true;
+    }
+    return false;
+}
+
+static void emit_call_expression(CodeGen *cg, AstNode *node) {
+    const char *module = NULL;
+    const char *func = NULL;
+
+    if (is_stdlib_call(node, &module, &func)) {
+        /* Handle known stdlib functions */
+        if (strcmp(func, "println") == 0) {
+            if (node->data.call.arg_count == 0) {
+                emit(cg, "putchar('\\n')");
+            } else {
+                AstNode *arg = node->data.call.args[0];
+                /* For now, assume string argument for println */
+                if (arg->kind == NODE_STRING_VALUE) {
+                    emit(cg, "ez_std_println_str(");
+                    emit_expression(cg, arg);
+                    emit(cg, ")");
+                } else if (arg->kind == NODE_INT_VALUE) {
+                    emit(cg, "ez_std_println_int(");
+                    emit_expression(cg, arg);
+                    emit(cg, ")");
+                } else if (arg->kind == NODE_FLOAT_VALUE) {
+                    emit(cg, "ez_std_println_float(");
+                    emit_expression(cg, arg);
+                    emit(cg, ")");
+                } else if (arg->kind == NODE_BOOL_VALUE) {
+                    emit(cg, "ez_std_println_bool(");
+                    emit_expression(cg, arg);
+                    emit(cg, ")");
+                } else {
+                    /* Default to string for now */
+                    emit(cg, "ez_std_println_str(");
+                    emit_expression(cg, arg);
+                    emit(cg, ")");
+                }
+            }
+            return;
+        }
+
+        if (strcmp(func, "print") == 0 && node->data.call.arg_count > 0) {
+            AstNode *arg = node->data.call.args[0];
+            if (arg->kind == NODE_STRING_VALUE) {
+                emit(cg, "ez_std_print_str(");
+            } else {
+                emit(cg, "ez_std_print_str(");
+            }
+            emit_expression(cg, arg);
+            emit(cg, ")");
+            return;
+        }
+    }
+
+    /* Generic function call */
+    emit(cg, "ez_fn_");
+    if (node->data.call.function->kind == NODE_LABEL) {
+        emit(cg, node->data.call.function->data.label.value);
+    } else {
+        emit_expression(cg, node->data.call.function);
+    }
+    emit(cg, "(");
+    for (int i = 0; i < node->data.call.arg_count; i++) {
+        if (i > 0) emit(cg, ", ");
+        emit_expression(cg, node->data.call.args[i]);
+    }
+    emit(cg, ")");
+}
+
+/* --- Statement Emission --- */
+
+static void emit_var_declaration(CodeGen *cg, AstNode *node) {
+    emit_indent(cg);
+
+    const char *c_type = ez_type_to_c(node->data.var_decl.type_name);
+
+    if (!node->data.var_decl.mutable) {
+        emit(cg, "const ");
+    }
+
+    emitf(cg, "%s %s", c_type, node->data.var_decl.name);
+
+    if (node->data.var_decl.value) {
+        emit(cg, " = ");
+        emit_expression(cg, node->data.var_decl.value);
+    }
+
+    emit(cg, ";\n");
+}
+
+static void emit_assign_statement(CodeGen *cg, AstNode *node) {
+    emit_indent(cg);
+    emit_expression(cg, node->data.assign.target);
+    emitf(cg, " %s ", node->data.assign.op);
+    emit_expression(cg, node->data.assign.value);
+    emit(cg, ";\n");
+}
+
+static void emit_return_statement(CodeGen *cg, AstNode *node) {
+    emit_indent(cg);
+    emit(cg, "return");
+    if (node->data.return_stmt.count > 0) {
+        emit(cg, " ");
+        emit_expression(cg, node->data.return_stmt.values[0]);
+    }
+    emit(cg, ";\n");
+}
+
+static void emit_block(CodeGen *cg, AstNode *node) {
+    for (int i = 0; i < node->data.block.count; i++) {
+        emit_statement(cg, node->data.block.stmts[i]);
+    }
+}
+
+static void emit_if_statement(CodeGen *cg, AstNode *node) {
+    emit_indent(cg);
+    emit(cg, "if (");
+    emit_expression(cg, node->data.if_stmt.condition);
+    emit(cg, ") {\n");
+
+    cg->indent++;
+    emit_block(cg, node->data.if_stmt.consequence);
+    cg->indent--;
+
+    if (node->data.if_stmt.alternative) {
+        if (node->data.if_stmt.alternative->kind == NODE_IF_STMT) {
+            emit_indent(cg);
+            emit(cg, "} else ");
+            /* Emit the else-if without indent since we already have "} else " */
+            emit(cg, "if (");
+            emit_expression(cg, node->data.if_stmt.alternative->data.if_stmt.condition);
+            emit(cg, ") {\n");
+            cg->indent++;
+            emit_block(cg, node->data.if_stmt.alternative->data.if_stmt.consequence);
+            cg->indent--;
+            if (node->data.if_stmt.alternative->data.if_stmt.alternative) {
+                /* Recursively handle further or/otherwise chains */
+                AstNode *alt = node->data.if_stmt.alternative->data.if_stmt.alternative;
+                if (alt->kind == NODE_IF_STMT) {
+                    emit_indent(cg);
+                    emit(cg, "} else ");
+                    /* Recurse - but we need to handle this differently */
+                    /* For now, handle one level of else-if */
+                    emit(cg, "{\n");
+                    cg->indent++;
+                    emit_block(cg, alt);
+                    cg->indent--;
+                } else {
+                    emit_indent(cg);
+                    emit(cg, "} else {\n");
+                    cg->indent++;
+                    emit_block(cg, alt);
+                    cg->indent--;
+                }
+            }
+            emit_indent(cg);
+            emit(cg, "}\n");
+        } else {
+            emit_indent(cg);
+            emit(cg, "} else {\n");
+            cg->indent++;
+            emit_block(cg, node->data.if_stmt.alternative);
+            cg->indent--;
+            emit_indent(cg);
+            emit(cg, "}\n");
+        }
+    } else {
+        emit_indent(cg);
+        emit(cg, "}\n");
+    }
+}
+
+static void emit_func_declaration(CodeGen *cg, AstNode *node, bool is_main) {
+    /* Return type */
+    if (is_main) {
+        emit(cg, "static void ez_fn_main(void)");
+    } else {
+        if (node->data.func_decl.return_type_count == 0) {
+            emit(cg, "static void ");
+        } else {
+            emitf(cg, "static %s ", ez_type_to_c(node->data.func_decl.return_types[0]));
+        }
+        emitf(cg, "ez_fn_%s(", node->data.func_decl.name);
+
+        /* Parameters */
+        for (int i = 0; i < node->data.func_decl.param_count; i++) {
+            if (i > 0) emit(cg, ", ");
+            Param *param = &node->data.func_decl.params[i];
+            if (param->mutable) {
+                emitf(cg, "%s *%s", ez_type_to_c(param->type_name), param->name);
+            } else {
+                emitf(cg, "%s %s", ez_type_to_c(param->type_name), param->name);
+            }
+        }
+
+        if (node->data.func_decl.param_count == 0) {
+            emit(cg, "void");
+        }
+        emit(cg, ")");
+    }
+
+    emit(cg, " {\n");
+    cg->indent++;
+    if (node->data.func_decl.body) {
+        emit_block(cg, node->data.func_decl.body);
+    }
+    cg->indent--;
+    emit(cg, "}\n\n");
+}
+
+static void emit_expression_statement(CodeGen *cg, AstNode *node) {
+    emit_indent(cg);
+    emit_expression(cg, node->data.expr_stmt.expr);
+    emit(cg, ";\n");
+}
+
+static void emit_statement(CodeGen *cg, AstNode *node) {
+    if (!node) return;
+
+    switch (node->kind) {
+    case NODE_VAR_DECL:
+        emit_var_declaration(cg, node);
+        break;
+    case NODE_ASSIGN_STMT:
+        emit_assign_statement(cg, node);
+        break;
+    case NODE_RETURN_STMT:
+        emit_return_statement(cg, node);
+        break;
+    case NODE_EXPR_STMT:
+        emit_expression_statement(cg, node);
+        break;
+    case NODE_IF_STMT:
+        emit_if_statement(cg, node);
+        break;
+    case NODE_FUNC_DECL:
+        emit_func_declaration(cg, node,
+            strcmp(node->data.func_decl.name, "main") == 0);
+        break;
+    case NODE_IMPORT_STMT:
+        /* Imports are handled during the preamble scan */
+        break;
+    case NODE_USING_STMT:
+        /* Using is handled during the preamble scan */
+        break;
+    default:
+        emit_indent(cg);
+        emitf(cg, "/* TODO: statement kind %d */\n", node->kind);
+        break;
+    }
+}
+
+/* --- Public API --- */
+
+CodeGen codegen_create(const char *file) {
+    CodeGen cg;
+    cg.output = buf_create(4096);
+    cg.indent = 0;
+    cg.has_std = false;
+    cg.file = file;
+    return cg;
+}
+
+void codegen_generate(CodeGen *cg, AstNode *program) {
+    if (program->kind != NODE_PROGRAM) return;
+
+    /* First pass: scan for imports */
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        AstNode *stmt = program->data.program.stmts[i];
+        if (stmt->kind == NODE_IMPORT_STMT) {
+            for (int j = 0; j < stmt->data.import_stmt.count; j++) {
+                ImportItem *item = &stmt->data.import_stmt.items[j];
+                if (item->is_stdlib && item->module &&
+                    strcmp(item->module, "std") == 0) {
+                    cg->has_std = true;
+                }
+            }
+        }
+    }
+
+    /* Emit preamble */
+    emit(cg, "/* Generated by EZC */\n");
+    emit(cg, "#include \"ez_runtime.h\"\n");
+    if (cg->has_std) {
+        emit(cg, "#include \"ez_std.h\"\n");
+    }
+    emit(cg, "\n");
+
+    /* Emit forward declarations for user functions */
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        AstNode *stmt = program->data.program.stmts[i];
+        if (stmt->kind == NODE_FUNC_DECL) {
+            if (strcmp(stmt->data.func_decl.name, "main") == 0) {
+                emit(cg, "static void ez_fn_main(void);\n");
+            } else {
+                emit(cg, "static ");
+                if (stmt->data.func_decl.return_type_count == 0) {
+                    emit(cg, "void ");
+                } else {
+                    emitf(cg, "%s ", ez_type_to_c(stmt->data.func_decl.return_types[0]));
+                }
+                emitf(cg, "ez_fn_%s(", stmt->data.func_decl.name);
+                for (int j = 0; j < stmt->data.func_decl.param_count; j++) {
+                    if (j > 0) emit(cg, ", ");
+                    Param *param = &stmt->data.func_decl.params[j];
+                    if (param->mutable) {
+                        emitf(cg, "%s *", ez_type_to_c(param->type_name));
+                    } else {
+                        emit(cg, ez_type_to_c(param->type_name));
+                    }
+                }
+                if (stmt->data.func_decl.param_count == 0) {
+                    emit(cg, "void");
+                }
+                emit(cg, ");\n");
+            }
+        }
+    }
+    emit(cg, "\n");
+
+    /* Emit function definitions */
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        AstNode *stmt = program->data.program.stmts[i];
+        if (stmt->kind != NODE_IMPORT_STMT && stmt->kind != NODE_USING_STMT) {
+            emit_statement(cg, stmt);
+        }
+    }
+
+    /* Emit C main() */
+    emit(cg, "int main(int argc, char **argv) {\n");
+    emit(cg, "    (void)argc; (void)argv;\n");
+    emit(cg, "    ez_runtime_init();\n");
+    emit(cg, "    ez_fn_main();\n");
+    emit(cg, "    ez_runtime_shutdown();\n");
+    emit(cg, "    return 0;\n");
+    emit(cg, "}\n");
+}
+
+const char *codegen_result(CodeGen *cg) {
+    return buf_cstr(&cg->output);
+}
+
+void codegen_destroy(CodeGen *cg) {
+    buf_destroy(&cg->output);
+}

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -1,0 +1,26 @@
+/*
+ * codegen.h - C code generator for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_CODEGEN_H
+#define EZC_CODEGEN_H
+
+#include "../parser/ast.h"
+#include "../util/buf.h"
+
+typedef struct {
+    Buf output;
+    int indent;
+    bool has_std;       /* Whether @std was imported */
+    const char *file;
+} CodeGen;
+
+CodeGen codegen_create(const char *file);
+void codegen_generate(CodeGen *cg, AstNode *program);
+const char *codegen_result(CodeGen *cg);
+void codegen_destroy(CodeGen *cg);
+
+#endif

--- a/ezc/src/lexer/lexer.c
+++ b/ezc/src/lexer/lexer.c
@@ -1,0 +1,372 @@
+/*
+ * lexer.c - Lexical analysis for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "lexer.h"
+#include <string.h>
+#include <ctype.h>
+#include <stdio.h>
+
+static void read_char(Lexer *l) {
+    if (l->read_position >= l->input_len) {
+        l->ch = 0;
+    } else {
+        l->ch = l->input[l->read_position];
+    }
+    l->position = l->read_position;
+    l->read_position++;
+    l->column++;
+    if (l->ch == '\n') {
+        l->line++;
+        l->column = 0;
+    }
+}
+
+static char peek_char(Lexer *l) {
+    if (l->read_position >= l->input_len) return 0;
+    return l->input[l->read_position];
+}
+
+static void skip_whitespace(Lexer *l) {
+    while (l->ch == ' ' || l->ch == '\t' || l->ch == '\r' || l->ch == '\n') {
+        read_char(l);
+    }
+}
+
+static void skip_line_comment(Lexer *l) {
+    /* Skip until end of line */
+    while (l->ch != '\n' && l->ch != 0) {
+        read_char(l);
+    }
+}
+
+static void skip_block_comment(Lexer *l) {
+    /* Skip past opening slash-star */
+    read_char(l); /* skip * */
+    while (l->ch != 0) {
+        if (l->ch == '*' && peek_char(l) == '/') {
+            read_char(l); /* skip * */
+            read_char(l); /* skip / */
+            return;
+        }
+        read_char(l);
+    }
+}
+
+static void skip_whitespace_and_comments(Lexer *l) {
+    for (;;) {
+        skip_whitespace(l);
+        if (l->ch == '/' && peek_char(l) == '/') {
+            read_char(l); /* skip first / */
+            read_char(l); /* skip second / */
+            skip_line_comment(l);
+        } else if (l->ch == '/' && peek_char(l) == '*') {
+            read_char(l); /* skip / */
+            skip_block_comment(l);
+        } else {
+            break;
+        }
+    }
+}
+
+static const char *read_identifier(Lexer *l) {
+    int start = l->position;
+    while (isalpha(l->ch) || l->ch == '_' || isdigit(l->ch)) {
+        read_char(l);
+    }
+    return arena_strndup(l->arena, l->input + start, l->position - start);
+}
+
+static const char *read_number(Lexer *l, TokenType *type) {
+    int start = l->position;
+    *type = TOK_INT;
+
+    while (isdigit(l->ch) || l->ch == '_') {
+        read_char(l);
+    }
+
+    if (l->ch == '.' && isdigit(peek_char(l))) {
+        *type = TOK_FLOAT;
+        read_char(l); /* skip . */
+        while (isdigit(l->ch) || l->ch == '_') {
+            read_char(l);
+        }
+    }
+
+    return arena_strndup(l->arena, l->input + start, l->position - start);
+}
+
+static const char *read_string(Lexer *l) {
+    read_char(l); /* skip opening " */
+    int start = l->position;
+
+    while (l->ch != '"' && l->ch != 0) {
+        if (l->ch == '\\') {
+            read_char(l); /* skip escape char */
+        }
+        read_char(l);
+    }
+
+    const char *str = arena_strndup(l->arena, l->input + start, l->position - start);
+    if (l->ch == '"') {
+        read_char(l); /* skip closing " */
+    }
+    return str;
+}
+
+static const char *read_raw_string(Lexer *l) {
+    read_char(l); /* skip opening ` */
+    int start = l->position;
+
+    while (l->ch != '`' && l->ch != 0) {
+        read_char(l);
+    }
+
+    const char *str = arena_strndup(l->arena, l->input + start, l->position - start);
+    if (l->ch == '`') {
+        read_char(l); /* skip closing ` */
+    }
+    return str;
+}
+
+static const char *read_char_literal(Lexer *l) {
+    read_char(l); /* skip opening ' */
+    int start = l->position;
+
+    if (l->ch == '\\') {
+        read_char(l); /* skip backslash */
+        read_char(l); /* skip escaped char */
+    } else {
+        read_char(l); /* skip the char */
+    }
+
+    const char *str = arena_strndup(l->arena, l->input + start, l->position - start);
+    if (l->ch == '\'') {
+        read_char(l); /* skip closing ' */
+    }
+    return str;
+}
+
+static Token make_token(TokenType type, const char *literal, int line, int col) {
+    Token t;
+    t.type = type;
+    t.literal = literal;
+    t.line = line;
+    t.column = col;
+    return t;
+}
+
+static int match_ahead(Lexer *l, const char *s, int len) {
+    if (l->position + len > l->input_len) return 0;
+    return strncmp(l->input + l->position, s, len) == 0;
+}
+
+Lexer *lexer_create(Arena *arena, const char *input, const char *file) {
+    Lexer *l = arena_alloc(arena, sizeof(Lexer));
+    l->input = input;
+    l->input_len = (int)strlen(input);
+    l->position = 0;
+    l->read_position = 0;
+    l->ch = 0;
+    l->line = 1;
+    l->column = 0;
+    l->file = file;
+    l->arena = arena;
+    read_char(l);
+    return l;
+}
+
+Token lexer_next_token(Lexer *l) {
+    Token tok;
+    skip_whitespace_and_comments(l);
+
+    tok.line = l->line;
+    tok.column = l->column;
+
+    switch (l->ch) {
+    case 0:
+        tok = make_token(TOK_EOF, "", l->line, l->column);
+        return tok;
+
+    case '=':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_EQ, "==", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_ASSIGN, "=", tok.line, tok.column);
+        }
+        break;
+
+    case '+':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_PLUS_ASSIGN, "+=", tok.line, tok.column);
+        } else if (peek_char(l) == '+') {
+            read_char(l);
+            tok = make_token(TOK_INCREMENT, "++", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_PLUS, "+", tok.line, tok.column);
+        }
+        break;
+
+    case '-':
+        if (peek_char(l) == '>') {
+            read_char(l);
+            tok = make_token(TOK_ARROW, "->", tok.line, tok.column);
+        } else if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_MINUS_ASSIGN, "-=", tok.line, tok.column);
+        } else if (peek_char(l) == '-') {
+            read_char(l);
+            tok = make_token(TOK_DECREMENT, "--", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_MINUS, "-", tok.line, tok.column);
+        }
+        break;
+
+    case '!':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_NOT_EQ, "!=", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_BANG, "!", tok.line, tok.column);
+        }
+        break;
+
+    case '*':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_ASTERISK_ASSIGN, "*=", tok.line, tok.column);
+        } else if (peek_char(l) == '*') {
+            read_char(l);
+            tok = make_token(TOK_POWER, "**", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_ASTERISK, "*", tok.line, tok.column);
+        }
+        break;
+
+    case '/':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_SLASH_ASSIGN, "/=", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_SLASH, "/", tok.line, tok.column);
+        }
+        break;
+
+    case '%':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_PERCENT_ASSIGN, "%=", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_PERCENT, "%", tok.line, tok.column);
+        }
+        break;
+
+    case '<':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_LT_EQ, "<=", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_LT, "<", tok.line, tok.column);
+        }
+        break;
+
+    case '>':
+        if (peek_char(l) == '=') {
+            read_char(l);
+            tok = make_token(TOK_GT_EQ, ">=", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_GT, ">", tok.line, tok.column);
+        }
+        break;
+
+    case '&':
+        if (peek_char(l) == '&') {
+            read_char(l);
+            tok = make_token(TOK_AND, "&&", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_AMPERSAND, "&", tok.line, tok.column);
+        }
+        break;
+
+    case '|':
+        if (peek_char(l) == '|') {
+            read_char(l);
+            tok = make_token(TOK_OR, "||", tok.line, tok.column);
+        } else {
+            tok = make_token(TOK_ILLEGAL, "|", tok.line, tok.column);
+        }
+        break;
+
+    case ',': tok = make_token(TOK_COMMA, ",", tok.line, tok.column); break;
+    case ':': tok = make_token(TOK_COLON, ":", tok.line, tok.column); break;
+    case ';': tok = make_token(TOK_SEMICOLON, ";", tok.line, tok.column); break;
+    case '(': tok = make_token(TOK_LPAREN, "(", tok.line, tok.column); break;
+    case ')': tok = make_token(TOK_RPAREN, ")", tok.line, tok.column); break;
+    case '{': tok = make_token(TOK_LBRACE, "{", tok.line, tok.column); break;
+    case '}': tok = make_token(TOK_RBRACE, "}", tok.line, tok.column); break;
+    case '[': tok = make_token(TOK_LBRACKET, "[", tok.line, tok.column); break;
+    case ']': tok = make_token(TOK_RBRACKET, "]", tok.line, tok.column); break;
+    case '.': tok = make_token(TOK_DOT, ".", tok.line, tok.column); break;
+    case '@': tok = make_token(TOK_AT, "@", tok.line, tok.column); break;
+
+    case '#':
+        if (match_ahead(l, "#suppress", 9)) {
+            tok = make_token(TOK_SUPPRESS, "#suppress", tok.line, tok.column);
+            for (int i = 0; i < 8; i++) read_char(l);
+        } else if (match_ahead(l, "#strict", 7)) {
+            tok = make_token(TOK_STRICT, "#strict", tok.line, tok.column);
+            for (int i = 0; i < 6; i++) read_char(l);
+        } else if (match_ahead(l, "#flags", 6)) {
+            tok = make_token(TOK_FLAGS, "#flags", tok.line, tok.column);
+            for (int i = 0; i < 5; i++) read_char(l);
+        } else if (match_ahead(l, "#enum", 5)) {
+            tok = make_token(TOK_ENUM_ATTR, "#enum", tok.line, tok.column);
+            for (int i = 0; i < 4; i++) read_char(l);
+        } else if (match_ahead(l, "#doc", 4)) {
+            tok = make_token(TOK_DOC, "#doc", tok.line, tok.column);
+            for (int i = 0; i < 3; i++) read_char(l);
+        } else {
+            tok = make_token(TOK_ILLEGAL, "#", tok.line, tok.column);
+        }
+        break;
+
+    case '"':
+        tok.literal = read_string(l);
+        tok.type = TOK_STRING;
+        return tok;
+
+    case '`':
+        tok.literal = read_raw_string(l);
+        tok.type = TOK_RAW_STRING;
+        return tok;
+
+    case '\'':
+        tok.literal = read_char_literal(l);
+        tok.type = TOK_CHAR;
+        return tok;
+
+    default:
+        if (isalpha(l->ch) || l->ch == '_') {
+            tok.literal = read_identifier(l);
+            tok.type = token_lookup_ident(tok.literal);
+            return tok;
+        } else if (isdigit(l->ch)) {
+            TokenType num_type;
+            tok.literal = read_number(l, &num_type);
+            tok.type = num_type;
+            return tok;
+        } else {
+            char buf[2] = {l->ch, 0};
+            tok = make_token(TOK_ILLEGAL, arena_strdup(l->arena, buf), tok.line, tok.column);
+        }
+        break;
+    }
+
+    read_char(l);
+    return tok;
+}

--- a/ezc/src/lexer/lexer.h
+++ b/ezc/src/lexer/lexer.h
@@ -1,0 +1,29 @@
+/*
+ * lexer.h - Lexical analysis for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_LEXER_H
+#define EZC_LEXER_H
+
+#include "token.h"
+#include "../util/arena.h"
+
+typedef struct {
+    const char *input;
+    int input_len;
+    int position;
+    int read_position;
+    char ch;
+    int line;
+    int column;
+    const char *file;
+    Arena *arena;   /* For allocating token literals */
+} Lexer;
+
+Lexer *lexer_create(Arena *arena, const char *input, const char *file);
+Token lexer_next_token(Lexer *l);
+
+#endif

--- a/ezc/src/lexer/token.c
+++ b/ezc/src/lexer/token.c
@@ -1,0 +1,156 @@
+/*
+ * token.c - Token type definitions and keyword lookup
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "token.h"
+#include <string.h>
+
+typedef struct {
+    const char *keyword;
+    TokenType type;
+} KeywordEntry;
+
+/* Sorted by keyword for binary search */
+static const KeywordEntry keywords[] = {
+    {"_",           TOK_BLANK},
+    {"as_long_as",  TOK_AS_LONG_AS},
+    {"break",       TOK_BREAK},
+    {"cast",        TOK_CAST},
+    {"const",       TOK_CONST},
+    {"continue",    TOK_CONTINUE},
+    {"default",     TOK_DEFAULT},
+    {"do",          TOK_DO},
+    {"ensure",      TOK_ENSURE},
+    {"enum",        TOK_ENUM},
+    {"false",       TOK_FALSE},
+    {"for",         TOK_FOR},
+    {"for_each",    TOK_FOR_EACH},
+    {"if",          TOK_IF},
+    {"import",      TOK_IMPORT},
+    {"in",          TOK_IN},
+    {"is",          TOK_IS},
+    {"loop",        TOK_LOOP},
+    {"module",      TOK_MODULE},
+    {"new",         TOK_NEW},
+    {"nil",         TOK_NIL},
+    {"not_in",      TOK_NOT_IN},
+    {"or",          TOK_OR_KW},
+    {"otherwise",   TOK_OTHERWISE},
+    {"private",     TOK_PRIVATE},
+    {"range",       TOK_RANGE},
+    {"return",      TOK_RETURN},
+    {"struct",      TOK_STRUCT},
+    {"temp",        TOK_TEMP},
+    {"true",        TOK_TRUE},
+    {"use",         TOK_USE},
+    {"using",       TOK_USING},
+    {"when",        TOK_WHEN},
+};
+
+#define KEYWORD_COUNT (sizeof(keywords) / sizeof(keywords[0]))
+
+TokenType token_lookup_ident(const char *ident) {
+    int lo = 0;
+    int hi = KEYWORD_COUNT - 1;
+    while (lo <= hi) {
+        int mid = (lo + hi) / 2;
+        int cmp = strcmp(ident, keywords[mid].keyword);
+        if (cmp == 0) return keywords[mid].type;
+        if (cmp < 0) hi = mid - 1;
+        else lo = mid + 1;
+    }
+    return TOK_IDENT;
+}
+
+const char *token_type_name(TokenType type) {
+    switch (type) {
+    case TOK_ILLEGAL:        return "ILLEGAL";
+    case TOK_EOF:            return "EOF";
+    case TOK_IDENT:          return "IDENT";
+    case TOK_INT:            return "INT";
+    case TOK_FLOAT:          return "FLOAT";
+    case TOK_STRING:         return "STRING";
+    case TOK_RAW_STRING:     return "RAW_STRING";
+    case TOK_CHAR:           return "CHAR";
+    case TOK_ASSIGN:         return "=";
+    case TOK_PLUS:           return "+";
+    case TOK_MINUS:          return "-";
+    case TOK_BANG:           return "!";
+    case TOK_ASTERISK:       return "*";
+    case TOK_SLASH:          return "/";
+    case TOK_PERCENT:        return "%";
+    case TOK_POWER:          return "**";
+    case TOK_LT:             return "<";
+    case TOK_GT:             return ">";
+    case TOK_EQ:             return "==";
+    case TOK_NOT_EQ:         return "!=";
+    case TOK_LT_EQ:          return "<=";
+    case TOK_GT_EQ:          return ">=";
+    case TOK_PLUS_ASSIGN:    return "+=";
+    case TOK_MINUS_ASSIGN:   return "-=";
+    case TOK_ASTERISK_ASSIGN:return "*=";
+    case TOK_SLASH_ASSIGN:   return "/=";
+    case TOK_PERCENT_ASSIGN: return "%=";
+    case TOK_INCREMENT:      return "++";
+    case TOK_DECREMENT:      return "--";
+    case TOK_AND:            return "&&";
+    case TOK_OR:             return "||";
+    case TOK_COMMA:          return ",";
+    case TOK_COLON:          return ":";
+    case TOK_SEMICOLON:      return ";";
+    case TOK_NEWLINE:        return "NEWLINE";
+    case TOK_LPAREN:         return "(";
+    case TOK_RPAREN:         return ")";
+    case TOK_LBRACE:         return "{";
+    case TOK_RBRACE:         return "}";
+    case TOK_LBRACKET:       return "[";
+    case TOK_RBRACKET:       return "]";
+    case TOK_ARROW:          return "->";
+    case TOK_DOT:            return ".";
+    case TOK_AT:             return "@";
+    case TOK_AMPERSAND:      return "&";
+    case TOK_SUPPRESS:       return "#suppress";
+    case TOK_STRICT:         return "#strict";
+    case TOK_FLAGS:          return "#flags";
+    case TOK_ENUM_ATTR:      return "#enum";
+    case TOK_DOC:            return "#doc";
+    case TOK_TEMP:           return "temp";
+    case TOK_CONST:          return "const";
+    case TOK_DO:             return "do";
+    case TOK_RETURN:         return "return";
+    case TOK_IF:             return "if";
+    case TOK_OR_KW:          return "or";
+    case TOK_OTHERWISE:      return "otherwise";
+    case TOK_FOR:            return "for";
+    case TOK_FOR_EACH:       return "for_each";
+    case TOK_AS_LONG_AS:     return "as_long_as";
+    case TOK_LOOP:           return "loop";
+    case TOK_BREAK:          return "break";
+    case TOK_CONTINUE:       return "continue";
+    case TOK_IN:             return "in";
+    case TOK_NOT_IN:         return "not_in";
+    case TOK_RANGE:          return "range";
+    case TOK_IMPORT:         return "import";
+    case TOK_USING:          return "using";
+    case TOK_STRUCT:         return "struct";
+    case TOK_ENUM:           return "enum";
+    case TOK_NIL:            return "nil";
+    case TOK_NEW:            return "new";
+    case TOK_TRUE:           return "true";
+    case TOK_FALSE:          return "false";
+    case TOK_BLANK:          return "_";
+    case TOK_ENSURE:         return "ensure";
+    case TOK_MODULE:         return "module";
+    case TOK_PRIVATE:        return "private";
+    case TOK_USE:            return "use";
+    case TOK_WHEN:           return "when";
+    case TOK_IS:             return "is";
+    case TOK_DEFAULT:        return "default";
+    case TOK_CAST:           return "cast";
+    case TOK_COUNT:          return "COUNT";
+    }
+    return "UNKNOWN";
+}

--- a/ezc/src/lexer/token.h
+++ b/ezc/src/lexer/token.h
@@ -1,0 +1,146 @@
+/*
+ * token.h - Token type definitions for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_TOKEN_H
+#define EZC_TOKEN_H
+
+typedef enum {
+    /* Special tokens */
+    TOK_ILLEGAL,
+    TOK_EOF,
+
+    /* Identifiers and literals */
+    TOK_IDENT,
+    TOK_INT,
+    TOK_FLOAT,
+    TOK_STRING,
+    TOK_RAW_STRING,
+    TOK_CHAR,
+
+    /* Operators */
+    TOK_ASSIGN,         /* = */
+    TOK_PLUS,           /* + */
+    TOK_MINUS,          /* - */
+    TOK_BANG,           /* ! */
+    TOK_ASTERISK,       /* * */
+    TOK_SLASH,          /* / */
+    TOK_PERCENT,        /* % */
+    TOK_POWER,          /* ** */
+
+    /* Comparison */
+    TOK_LT,             /* < */
+    TOK_GT,             /* > */
+    TOK_EQ,             /* == */
+    TOK_NOT_EQ,         /* != */
+    TOK_LT_EQ,          /* <= */
+    TOK_GT_EQ,          /* >= */
+
+    /* Compound assignment */
+    TOK_PLUS_ASSIGN,    /* += */
+    TOK_MINUS_ASSIGN,   /* -= */
+    TOK_ASTERISK_ASSIGN,/* *= */
+    TOK_SLASH_ASSIGN,   /* /= */
+    TOK_PERCENT_ASSIGN, /* %= */
+
+    /* Increment/Decrement */
+    TOK_INCREMENT,      /* ++ */
+    TOK_DECREMENT,      /* -- */
+
+    /* Logical */
+    TOK_AND,            /* && */
+    TOK_OR,             /* || */
+
+    /* Delimiters */
+    TOK_COMMA,          /* , */
+    TOK_COLON,          /* : */
+    TOK_SEMICOLON,      /* ; */
+    TOK_NEWLINE,
+
+    TOK_LPAREN,         /* ( */
+    TOK_RPAREN,         /* ) */
+    TOK_LBRACE,         /* { */
+    TOK_RBRACE,         /* } */
+    TOK_LBRACKET,       /* [ */
+    TOK_RBRACKET,       /* ] */
+
+    /* Arrow */
+    TOK_ARROW,          /* -> */
+
+    /* Dot */
+    TOK_DOT,            /* . */
+
+    /* At sign */
+    TOK_AT,             /* @ */
+
+    /* Ampersand */
+    TOK_AMPERSAND,      /* & */
+
+    /* Hash attributes */
+    TOK_SUPPRESS,       /* #suppress */
+    TOK_STRICT,         /* #strict */
+    TOK_FLAGS,          /* #flags */
+    TOK_ENUM_ATTR,      /* #enum */
+    TOK_DOC,            /* #doc */
+
+    /* Keywords */
+    TOK_TEMP,
+    TOK_CONST,
+    TOK_DO,
+    TOK_RETURN,
+    TOK_IF,
+    TOK_OR_KW,
+    TOK_OTHERWISE,
+    TOK_FOR,
+    TOK_FOR_EACH,
+    TOK_AS_LONG_AS,
+    TOK_LOOP,
+    TOK_BREAK,
+    TOK_CONTINUE,
+    TOK_IN,
+    TOK_NOT_IN,
+    TOK_RANGE,
+    TOK_IMPORT,
+    TOK_USING,
+    TOK_STRUCT,
+    TOK_ENUM,
+    TOK_NIL,
+    TOK_NEW,
+    TOK_TRUE,
+    TOK_FALSE,
+    TOK_BLANK,
+    TOK_ENSURE,
+
+    /* Module system keywords */
+    TOK_MODULE,
+    TOK_PRIVATE,
+    TOK_USE,
+
+    /* When/Is keywords */
+    TOK_WHEN,
+    TOK_IS,
+    TOK_DEFAULT,
+
+    /* Type conversion */
+    TOK_CAST,
+
+    TOK_COUNT /* sentinel */
+} TokenType;
+
+typedef struct {
+    TokenType type;
+    const char *literal;    /* Points into arena or static string */
+    int line;
+    int column;
+} Token;
+
+/* Look up an identifier - returns keyword token type or TOK_IDENT */
+TokenType token_lookup_ident(const char *ident);
+
+/* Return human-readable name for a token type */
+const char *token_type_name(TokenType type);
+
+#endif

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -1,0 +1,256 @@
+/*
+ * main.c - EZC compiler entry point
+ *
+ * Usage: ezc <file.ez> [-o output]
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "util/arena.h"
+#include "lexer/lexer.h"
+#include "parser/parser.h"
+#include "codegen/codegen.h"
+
+#define EZC_VERSION "0.1.0"
+
+static void print_usage(void) {
+    fprintf(stderr, "EZC - EZ Language Compiler v%s\n", EZC_VERSION);
+    fprintf(stderr, "Usage: ezc <file.ez> [-o output]\n");
+    fprintf(stderr, "\nOptions:\n");
+    fprintf(stderr, "  -o <file>    Output binary name (default: based on input filename)\n");
+    fprintf(stderr, "  -c           Emit C source only (don't compile)\n");
+    fprintf(stderr, "  --version    Show version\n");
+    fprintf(stderr, "  --help       Show this help\n");
+}
+
+static char *read_file(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        fprintf(stderr, "ezc: cannot open '%s': ", path);
+        perror("");
+        return NULL;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char *buf = malloc((size_t)size + 1);
+    if (!buf) {
+        fprintf(stderr, "ezc: out of memory\n");
+        fclose(f);
+        return NULL;
+    }
+
+    size_t read = fread(buf, 1, (size_t)size, f);
+    buf[read] = '\0';
+    fclose(f);
+    return buf;
+}
+
+static bool write_file(const char *path, const char *content) {
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        fprintf(stderr, "ezc: cannot write '%s': ", path);
+        perror("");
+        return false;
+    }
+    fputs(content, f);
+    fclose(f);
+    return true;
+}
+
+/* Get the directory where the ezc binary lives (for finding runtime headers) */
+static const char *get_runtime_dir(const char *argv0) {
+    (void)argv0;
+    /* For now, look relative to CWD or use a known path */
+    /* TODO: resolve relative to binary location */
+    return NULL;
+}
+
+/* Strip .ez extension and return base name */
+static char *output_name_from_input(const char *input) {
+    const char *slash = strrchr(input, '/');
+    const char *base = slash ? slash + 1 : input;
+
+    size_t len = strlen(base);
+    if (len > 3 && strcmp(base + len - 3, ".ez") == 0) {
+        len -= 3;
+    }
+
+    char *out = malloc(len + 1);
+    memcpy(out, base, len);
+    out[len] = '\0';
+    return out;
+}
+
+/* Find the runtime source directory */
+static const char *find_runtime_dir(const char *argv0) {
+    /* Try relative to binary */
+    static char path[1024];
+
+    /* Try the source tree layout first (for development) */
+    /* Check if ezc/src/runtime/ez_runtime.h exists relative to CWD */
+    if (access("ezc/src/runtime/ez_runtime.h", R_OK) == 0) {
+        return "ezc/src";
+    }
+
+    /* Check relative to binary location */
+    const char *dir = get_runtime_dir(argv0);
+    if (dir) {
+        snprintf(path, sizeof(path), "%s/../src", dir);
+        return path;
+    }
+
+    /* Fallback: try common install locations */
+    if (access("/usr/local/lib/ezc/runtime/ez_runtime.h", R_OK) == 0) {
+        return "/usr/local/lib/ezc";
+    }
+
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        print_usage();
+        return 1;
+    }
+
+    const char *input_file = NULL;
+    const char *output_file = NULL;
+    bool emit_c_only = false;
+
+    /* Parse arguments */
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--version") == 0) {
+            printf("ezc %s\n", EZC_VERSION);
+            return 0;
+        }
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            print_usage();
+            return 0;
+        }
+        if (strcmp(argv[i], "-o") == 0 && i + 1 < argc) {
+            output_file = argv[++i];
+            continue;
+        }
+        if (strcmp(argv[i], "-c") == 0) {
+            emit_c_only = true;
+            continue;
+        }
+        if (argv[i][0] == '-') {
+            fprintf(stderr, "ezc: unknown option '%s'\n", argv[i]);
+            return 1;
+        }
+        input_file = argv[i];
+    }
+
+    if (!input_file) {
+        fprintf(stderr, "ezc: no input file\n");
+        return 1;
+    }
+
+    /* Read source file */
+    char *source = read_file(input_file);
+    if (!source) return 1;
+
+    /* Create compiler arena */
+    Arena *arena = arena_create(1024 * 1024);
+
+    /* Lex */
+    Lexer *lexer = lexer_create(arena, source, input_file);
+
+    /* Parse */
+    Parser *parser = parser_create(arena, lexer, input_file);
+    AstNode *program = parser_parse_program(parser);
+
+    if (parser_has_errors(parser)) {
+        parser_print_errors(parser);
+        arena_destroy(arena);
+        free(source);
+        return 1;
+    }
+
+    /* Generate C code */
+    CodeGen cg = codegen_create(input_file);
+    codegen_generate(&cg, program);
+    const char *c_code = codegen_result(&cg);
+
+    /* Determine output name */
+    char *default_output = NULL;
+    if (!output_file) {
+        default_output = output_name_from_input(input_file);
+        output_file = default_output;
+    }
+
+    /* Write generated C to temp file */
+    const char *out_base = strrchr(output_file, '/');
+    out_base = out_base ? out_base + 1 : output_file;
+    char c_file[1024];
+    snprintf(c_file, sizeof(c_file), "/tmp/ezc_%s.c", out_base);
+
+    if (!write_file(c_file, c_code)) {
+        codegen_destroy(&cg);
+        arena_destroy(arena);
+        free(source);
+        free(default_output);
+        return 1;
+    }
+
+    if (emit_c_only) {
+        /* Just print the C source */
+        printf("%s", c_code);
+        codegen_destroy(&cg);
+        arena_destroy(arena);
+        free(source);
+        free(default_output);
+        return 0;
+    }
+
+    /* Find runtime directory */
+    const char *runtime_dir = find_runtime_dir(argv[0]);
+    if (!runtime_dir) {
+        fprintf(stderr, "ezc: cannot find runtime headers. "
+            "Run from the project root or install the runtime.\n");
+        codegen_destroy(&cg);
+        arena_destroy(arena);
+        free(source);
+        free(default_output);
+        return 1;
+    }
+
+    /* Compile the generated C code */
+    char cmd[4096];
+    snprintf(cmd, sizeof(cmd),
+        "cc -std=c11 -O2 -Wall -Wno-unused-function "
+        "-I%s/runtime -I%s/stdlib "
+        "-o %s %s %s/runtime/ez_runtime.c %s/stdlib/ez_std.c "
+        "-lm 2>&1",
+        runtime_dir, runtime_dir,
+        output_file, c_file,
+        runtime_dir, runtime_dir);
+
+    int ret = system(cmd);
+    if (ret != 0) {
+        fprintf(stderr, "ezc: C compilation failed\n");
+        /* Keep the generated .c file for debugging */
+        fprintf(stderr, "ezc: generated C source at %s\n", c_file);
+    } else {
+        /* Clean up temp file on success */
+        unlink(c_file);
+    }
+
+    codegen_destroy(&cg);
+    arena_destroy(arena);
+    free(source);
+    free(default_output);
+
+    return ret != 0 ? 1 : 0;
+}

--- a/ezc/src/parser/ast.c
+++ b/ezc/src/parser/ast.c
@@ -1,0 +1,18 @@
+/*
+ * ast.c - AST node construction helpers
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "ast.h"
+#include "../util/arena.h"
+#include <string.h>
+
+AstNode *ast_alloc(Arena *a, NodeKind kind, Token tok) {
+    AstNode *node = arena_alloc(a, sizeof(AstNode));
+    memset(node, 0, sizeof(AstNode));
+    node->kind = kind;
+    node->token = tok;
+    return node;
+}

--- a/ezc/src/parser/ast.h
+++ b/ezc/src/parser/ast.h
@@ -1,0 +1,305 @@
+/*
+ * ast.h - Abstract Syntax Tree node definitions for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_AST_H
+#define EZC_AST_H
+
+#include "../lexer/token.h"
+#include "../util/arena.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+    /* Expressions */
+    NODE_LABEL,
+    NODE_INT_VALUE,
+    NODE_FLOAT_VALUE,
+    NODE_STRING_VALUE,
+    NODE_INTERPOLATED_STRING,
+    NODE_CHAR_VALUE,
+    NODE_BOOL_VALUE,
+    NODE_NIL_VALUE,
+    NODE_ARRAY_VALUE,
+    NODE_MAP_VALUE,
+    NODE_STRUCT_VALUE,
+    NODE_PREFIX_EXPR,
+    NODE_INFIX_EXPR,
+    NODE_POSTFIX_EXPR,
+    NODE_CALL_EXPR,
+    NODE_INDEX_EXPR,
+    NODE_MEMBER_EXPR,
+    NODE_NEW_EXPR,
+    NODE_RANGE_EXPR,
+    NODE_CAST_EXPR,
+    NODE_BLANK_IDENT,
+
+    /* Statements */
+    NODE_VAR_DECL,
+    NODE_ASSIGN_STMT,
+    NODE_RETURN_STMT,
+    NODE_ENSURE_STMT,
+    NODE_EXPR_STMT,
+    NODE_BLOCK_STMT,
+    NODE_IF_STMT,
+    NODE_WHEN_STMT,
+    NODE_FOR_STMT,
+    NODE_FOR_EACH_STMT,
+    NODE_WHILE_STMT,
+    NODE_LOOP_STMT,
+    NODE_BREAK_STMT,
+    NODE_CONTINUE_STMT,
+    NODE_FUNC_DECL,
+    NODE_IMPORT_STMT,
+    NODE_USING_STMT,
+    NODE_STRUCT_DECL,
+    NODE_ENUM_DECL,
+    NODE_MODULE_DECL,
+    NODE_PROGRAM,
+} NodeKind;
+
+/* Forward declaration */
+typedef struct AstNode AstNode;
+
+/* Parameter for function declarations */
+typedef struct {
+    const char *name;
+    const char *type_name;
+    bool mutable;
+    AstNode *default_value;
+} Param;
+
+/* Field in struct declaration */
+typedef struct {
+    const char *name;
+    const char *type_name;
+} StructField;
+
+/* Enum value */
+typedef struct {
+    const char *name;
+    AstNode *value; /* optional explicit value */
+} EnumVal;
+
+/* Import item */
+typedef struct {
+    const char *alias;
+    const char *module;
+    const char *path;
+    bool is_stdlib;
+} ImportItem;
+
+/* When case */
+typedef struct {
+    AstNode **values;
+    int value_count;
+    AstNode *body;
+    bool is_range;
+} WhenCase;
+
+/* AST Node - tagged union */
+struct AstNode {
+    NodeKind kind;
+    Token token;
+
+    union {
+        /* NODE_LABEL */
+        struct { const char *value; } label;
+
+        /* NODE_INT_VALUE */
+        struct { int64_t value; const char *literal; } int_value;
+
+        /* NODE_FLOAT_VALUE */
+        struct { double value; } float_value;
+
+        /* NODE_STRING_VALUE */
+        struct { const char *value; } string_value;
+
+        /* NODE_INTERPOLATED_STRING */
+        struct { AstNode **parts; int part_count; } interpolated_string;
+
+        /* NODE_CHAR_VALUE */
+        struct { char value; } char_value;
+
+        /* NODE_BOOL_VALUE */
+        struct { bool value; } bool_value;
+
+        /* NODE_ARRAY_VALUE */
+        struct { AstNode **elements; int count; } array_value;
+
+        /* NODE_MAP_VALUE */
+        struct {
+            AstNode **keys;
+            AstNode **values;
+            int count;
+        } map_value;
+
+        /* NODE_STRUCT_VALUE */
+        struct {
+            const char *name;
+            const char **field_names;
+            AstNode **field_values;
+            int count;
+        } struct_value;
+
+        /* NODE_PREFIX_EXPR */
+        struct { const char *op; AstNode *right; } prefix;
+
+        /* NODE_INFIX_EXPR */
+        struct { AstNode *left; const char *op; AstNode *right; } infix;
+
+        /* NODE_POSTFIX_EXPR */
+        struct { AstNode *left; const char *op; } postfix;
+
+        /* NODE_CALL_EXPR */
+        struct { AstNode *function; AstNode **args; int arg_count; } call;
+
+        /* NODE_INDEX_EXPR */
+        struct { AstNode *left; AstNode *index; } index_expr;
+
+        /* NODE_MEMBER_EXPR */
+        struct { AstNode *object; const char *member; } member;
+
+        /* NODE_NEW_EXPR */
+        struct { const char *type_name; } new_expr;
+
+        /* NODE_RANGE_EXPR */
+        struct { AstNode *start; AstNode *end; AstNode *step; } range_expr;
+
+        /* NODE_CAST_EXPR */
+        struct {
+            AstNode *value;
+            const char *target_type;
+            bool is_array;
+            const char *element_type;
+        } cast;
+
+        /* NODE_VAR_DECL */
+        struct {
+            const char *name;
+            const char *type_name;
+            AstNode *value;
+            bool mutable;
+        } var_decl;
+
+        /* NODE_ASSIGN_STMT */
+        struct {
+            AstNode *target;
+            const char *op;
+            AstNode *value;
+        } assign;
+
+        /* NODE_RETURN_STMT */
+        struct { AstNode **values; int count; } return_stmt;
+
+        /* NODE_ENSURE_STMT */
+        struct { AstNode *expr; } ensure_stmt;
+
+        /* NODE_EXPR_STMT */
+        struct { AstNode *expr; } expr_stmt;
+
+        /* NODE_BLOCK_STMT */
+        struct { AstNode **stmts; int count; int cap; } block;
+
+        /* NODE_IF_STMT */
+        struct {
+            AstNode *condition;
+            AstNode *consequence;
+            AstNode *alternative; /* can be another if_stmt or block */
+        } if_stmt;
+
+        /* NODE_WHEN_STMT */
+        struct {
+            AstNode *value;
+            WhenCase *cases;
+            int case_count;
+            AstNode *default_body;
+            bool is_strict;
+        } when_stmt;
+
+        /* NODE_FOR_STMT */
+        struct {
+            const char *var_name;
+            const char *var_type;
+            AstNode *iterable;
+            AstNode *body;
+        } for_stmt;
+
+        /* NODE_FOR_EACH_STMT */
+        struct {
+            const char *index_name;
+            const char *var_name;
+            AstNode *collection;
+            AstNode *body;
+        } for_each;
+
+        /* NODE_WHILE_STMT */
+        struct { AstNode *condition; AstNode *body; } while_stmt;
+
+        /* NODE_LOOP_STMT */
+        struct { AstNode *body; } loop_stmt;
+
+        /* NODE_FUNC_DECL */
+        struct {
+            const char *name;
+            Param *params;
+            int param_count;
+            const char **return_types;
+            int return_type_count;
+            AstNode *body;
+            int visibility; /* 0 = public, 1 = private */
+        } func_decl;
+
+        /* NODE_IMPORT_STMT */
+        struct {
+            ImportItem *items;
+            int count;
+            bool auto_use;
+        } import_stmt;
+
+        /* NODE_USING_STMT */
+        struct {
+            const char **modules;
+            int count;
+        } using_stmt;
+
+        /* NODE_STRUCT_DECL */
+        struct {
+            const char *name;
+            StructField *fields;
+            int field_count;
+            int visibility;
+        } struct_decl;
+
+        /* NODE_ENUM_DECL */
+        struct {
+            const char *name;
+            EnumVal *values;
+            int value_count;
+            const char *base_type; /* "int", "string", etc. */
+            bool is_flags;
+            int visibility;
+        } enum_decl;
+
+        /* NODE_MODULE_DECL */
+        struct { const char *name; } module_decl;
+
+        /* NODE_PROGRAM */
+        struct {
+            AstNode *module_decl;
+            AstNode **using_stmts;
+            int using_count;
+            AstNode **stmts;
+            int stmt_count;
+            int stmt_cap;
+        } program;
+    } data;
+};
+
+/* Node constructor helpers */
+AstNode *ast_alloc(Arena *a, NodeKind kind, Token tok);
+
+#endif

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -1,0 +1,655 @@
+/*
+ * parser.c - Recursive descent parser for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "parser.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+/* Operator precedence levels */
+typedef enum {
+    PREC_LOWEST,
+    PREC_OR,            /* || */
+    PREC_AND,           /* && */
+    PREC_EQUALS,        /* == != */
+    PREC_LESSGREATER,   /* > < >= <= */
+    PREC_MEMBERSHIP,    /* in, not_in */
+    PREC_SUM,           /* + - */
+    PREC_PRODUCT,       /* * / % */
+    PREC_POWER,         /* ** */
+    PREC_PREFIX,        /* -x !x &x */
+    PREC_CALL,          /* f(x) */
+    PREC_INDEX,         /* a[i] a.b */
+    PREC_POSTFIX,       /* x++ x-- */
+} Precedence;
+
+/* Forward declarations */
+static AstNode *parse_statement(Parser *p);
+static AstNode *parse_expression(Parser *p, Precedence prec);
+static AstNode *parse_block_statement(Parser *p);
+
+/* --- Helpers --- */
+
+static void parser_error(Parser *p, const char *fmt, ...) {
+    char buf[512];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    if (p->error_count >= p->error_cap) {
+        p->error_cap = p->error_cap ? p->error_cap * 2 : 16;
+        p->errors = realloc(p->errors, sizeof(char *) * p->error_cap);
+    }
+    p->errors[p->error_count++] = arena_strdup(p->arena, buf);
+}
+
+static void next_token(Parser *p) {
+    p->cur_token = p->peek_token;
+    p->peek_token = lexer_next_token(p->lexer);
+}
+
+static bool cur_token_is(Parser *p, TokenType t) {
+    return p->cur_token.type == t;
+}
+
+static bool peek_token_is(Parser *p, TokenType t) {
+    return p->peek_token.type == t;
+}
+
+static bool expect_peek(Parser *p, TokenType t) {
+    if (peek_token_is(p, t)) {
+        next_token(p);
+        return true;
+    }
+    parser_error(p, "%s:%d:%d: expected '%s', got '%s'",
+        p->file, p->peek_token.line, p->peek_token.column,
+        token_type_name(t), token_type_name(p->peek_token.type));
+    return false;
+}
+
+static Precedence token_precedence(TokenType t) {
+    switch (t) {
+    case TOK_OR:             return PREC_OR;
+    case TOK_AND:            return PREC_AND;
+    case TOK_EQ:
+    case TOK_NOT_EQ:         return PREC_EQUALS;
+    case TOK_LT:
+    case TOK_GT:
+    case TOK_LT_EQ:
+    case TOK_GT_EQ:          return PREC_LESSGREATER;
+    case TOK_IN:
+    case TOK_NOT_IN:         return PREC_MEMBERSHIP;
+    case TOK_PLUS:
+    case TOK_MINUS:          return PREC_SUM;
+    case TOK_ASTERISK:
+    case TOK_SLASH:
+    case TOK_PERCENT:        return PREC_PRODUCT;
+    case TOK_POWER:          return PREC_POWER;
+    case TOK_LPAREN:         return PREC_CALL;
+    case TOK_LBRACKET:       return PREC_INDEX;
+    case TOK_DOT:            return PREC_INDEX;
+    case TOK_INCREMENT:
+    case TOK_DECREMENT:      return PREC_POSTFIX;
+    default:                 return PREC_LOWEST;
+    }
+}
+
+/* --- Expression Parsing --- */
+
+static AstNode *parse_identifier(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    node->data.label.value = p->cur_token.literal;
+    return node;
+}
+
+static AstNode *parse_int_literal(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_INT_VALUE, p->cur_token);
+    /* Parse integer, ignoring underscores */
+    int64_t val = 0;
+    const char *s = p->cur_token.literal;
+    while (*s) {
+        if (*s != '_') {
+            val = val * 10 + (*s - '0');
+        }
+        s++;
+    }
+    node->data.int_value.value = val;
+    node->data.int_value.literal = p->cur_token.literal;
+    return node;
+}
+
+static AstNode *parse_float_literal(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_FLOAT_VALUE, p->cur_token);
+    node->data.float_value.value = atof(p->cur_token.literal);
+    return node;
+}
+
+static AstNode *parse_string_literal(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_STRING_VALUE, p->cur_token);
+    node->data.string_value.value = p->cur_token.literal;
+    return node;
+}
+
+static AstNode *parse_bool_literal(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_BOOL_VALUE, p->cur_token);
+    node->data.bool_value.value = (p->cur_token.type == TOK_TRUE);
+    return node;
+}
+
+static AstNode *parse_nil_literal(Parser *p) {
+    return ast_alloc(p->arena, NODE_NIL_VALUE, p->cur_token);
+}
+
+static AstNode *parse_prefix_expression(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_PREFIX_EXPR, p->cur_token);
+    node->data.prefix.op = p->cur_token.literal;
+    next_token(p);
+    node->data.prefix.right = parse_expression(p, PREC_PREFIX);
+    return node;
+}
+
+static AstNode *parse_grouped_expression(Parser *p) {
+    next_token(p);
+    AstNode *expr = parse_expression(p, PREC_LOWEST);
+    if (!expect_peek(p, TOK_RPAREN)) return NULL;
+    return expr;
+}
+
+/* Parse prefix expression (the "nud" in Pratt parsing) */
+static AstNode *parse_prefix(Parser *p) {
+    switch (p->cur_token.type) {
+    case TOK_IDENT:     return parse_identifier(p);
+    case TOK_INT:       return parse_int_literal(p);
+    case TOK_FLOAT:     return parse_float_literal(p);
+    case TOK_STRING:    return parse_string_literal(p);
+    case TOK_TRUE:
+    case TOK_FALSE:     return parse_bool_literal(p);
+    case TOK_NIL:       return parse_nil_literal(p);
+    case TOK_MINUS:
+    case TOK_BANG:
+    case TOK_AMPERSAND: return parse_prefix_expression(p);
+    case TOK_LPAREN:    return parse_grouped_expression(p);
+    default:
+        parser_error(p, "%s:%d:%d: unexpected token '%s'",
+            p->file, p->cur_token.line, p->cur_token.column,
+            token_type_name(p->cur_token.type));
+        return NULL;
+    }
+}
+
+static AstNode *parse_infix_expression(Parser *p, AstNode *left) {
+    AstNode *node = ast_alloc(p->arena, NODE_INFIX_EXPR, p->cur_token);
+    node->data.infix.left = left;
+    node->data.infix.op = p->cur_token.literal;
+    Precedence prec = token_precedence(p->cur_token.type);
+    next_token(p);
+    node->data.infix.right = parse_expression(p, prec);
+    return node;
+}
+
+static AstNode **parse_expression_list(Parser *p, TokenType end, int *count) {
+    *count = 0;
+    int cap = 4;
+    AstNode **list = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+
+    if (peek_token_is(p, end)) {
+        next_token(p);
+        return list;
+    }
+
+    next_token(p);
+    list[(*count)++] = parse_expression(p, PREC_LOWEST);
+
+    while (peek_token_is(p, TOK_COMMA)) {
+        next_token(p); /* skip comma */
+        next_token(p);
+        if (*count >= cap) {
+            cap *= 2;
+            AstNode **new_list = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+            memcpy(new_list, list, sizeof(AstNode *) * (*count));
+            list = new_list;
+        }
+        list[(*count)++] = parse_expression(p, PREC_LOWEST);
+    }
+
+    if (!expect_peek(p, end)) return NULL;
+    return list;
+}
+
+static AstNode *parse_call_expression(Parser *p, AstNode *function) {
+    AstNode *node = ast_alloc(p->arena, NODE_CALL_EXPR, p->cur_token);
+    node->data.call.function = function;
+    node->data.call.args = parse_expression_list(p, TOK_RPAREN, &node->data.call.arg_count);
+    return node;
+}
+
+static AstNode *parse_member_expression(Parser *p, AstNode *object) {
+    next_token(p); /* skip the identifier after dot */
+    AstNode *node = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    node->data.member.object = object;
+    node->data.member.member = p->cur_token.literal;
+    return node;
+}
+
+static AstNode *parse_index_expression(Parser *p, AstNode *left) {
+    AstNode *node = ast_alloc(p->arena, NODE_INDEX_EXPR, p->cur_token);
+    node->data.index_expr.left = left;
+    next_token(p);
+    node->data.index_expr.index = parse_expression(p, PREC_LOWEST);
+    if (!expect_peek(p, TOK_RBRACKET)) return NULL;
+    return node;
+}
+
+static AstNode *parse_postfix_expression(Parser *p, AstNode *left) {
+    AstNode *node = ast_alloc(p->arena, NODE_POSTFIX_EXPR, p->cur_token);
+    node->data.postfix.left = left;
+    node->data.postfix.op = p->cur_token.literal;
+    return node;
+}
+
+/* Parse infix expression (the "led" in Pratt parsing) */
+static AstNode *parse_infix(Parser *p, AstNode *left) {
+    switch (p->cur_token.type) {
+    case TOK_PLUS: case TOK_MINUS: case TOK_ASTERISK: case TOK_SLASH:
+    case TOK_PERCENT: case TOK_POWER:
+    case TOK_EQ: case TOK_NOT_EQ: case TOK_LT: case TOK_GT:
+    case TOK_LT_EQ: case TOK_GT_EQ:
+    case TOK_AND: case TOK_OR:
+    case TOK_IN: case TOK_NOT_IN:
+        return parse_infix_expression(p, left);
+    case TOK_LPAREN:
+        return parse_call_expression(p, left);
+    case TOK_DOT:
+        return parse_member_expression(p, left);
+    case TOK_LBRACKET:
+        return parse_index_expression(p, left);
+    case TOK_INCREMENT:
+    case TOK_DECREMENT:
+        return parse_postfix_expression(p, left);
+    default:
+        return left;
+    }
+}
+
+static AstNode *parse_expression(Parser *p, Precedence prec) {
+    AstNode *left = parse_prefix(p);
+    if (!left) return NULL;
+
+    while (!peek_token_is(p, TOK_EOF) && prec < token_precedence(p->peek_token.type)) {
+        next_token(p);
+        left = parse_infix(p, left);
+        if (!left) return NULL;
+    }
+
+    return left;
+}
+
+/* --- Statement Parsing --- */
+
+static AstNode *parse_expression_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_EXPR_STMT, p->cur_token);
+    node->data.expr_stmt.expr = parse_expression(p, PREC_LOWEST);
+    return node;
+}
+
+static AstNode *parse_var_declaration(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    node->data.var_decl.mutable = (p->cur_token.type == TOK_TEMP);
+
+    if (!expect_peek(p, TOK_IDENT)) return NULL;
+    node->data.var_decl.name = p->cur_token.literal;
+
+    /* Optional type annotation */
+    node->data.var_decl.type_name = NULL;
+    if (peek_token_is(p, TOK_IDENT) || peek_token_is(p, TOK_LBRACKET)) {
+        next_token(p);
+        node->data.var_decl.type_name = p->cur_token.literal;
+    }
+
+    /* = value */
+    if (peek_token_is(p, TOK_ASSIGN)) {
+        next_token(p); /* skip = */
+        next_token(p);
+        node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
+    }
+
+    return node;
+}
+
+static AstNode *parse_return_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_RETURN_STMT, p->cur_token);
+    next_token(p);
+
+    int cap = 4;
+    int count = 0;
+    AstNode **values = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+
+    if (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+        values[count++] = parse_expression(p, PREC_LOWEST);
+
+        while (peek_token_is(p, TOK_COMMA)) {
+            next_token(p); /* skip comma */
+            next_token(p);
+            if (count >= cap) {
+                cap *= 2;
+                AstNode **new_vals = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+                memcpy(new_vals, values, sizeof(AstNode *) * count);
+                values = new_vals;
+            }
+            values[count++] = parse_expression(p, PREC_LOWEST);
+        }
+    }
+
+    node->data.return_stmt.values = values;
+    node->data.return_stmt.count = count;
+    return node;
+}
+
+static AstNode *parse_block_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
+    node->data.block.count = 0;
+    node->data.block.cap = 8;
+    node->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *) * node->data.block.cap);
+
+    next_token(p); /* skip { */
+
+    while (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+        AstNode *stmt = parse_statement(p);
+        if (stmt) {
+            if (node->data.block.count >= node->data.block.cap) {
+                node->data.block.cap *= 2;
+                AstNode **new_stmts = arena_alloc(p->arena, sizeof(AstNode *) * node->data.block.cap);
+                memcpy(new_stmts, node->data.block.stmts, sizeof(AstNode *) * node->data.block.count);
+                node->data.block.stmts = new_stmts;
+            }
+            node->data.block.stmts[node->data.block.count++] = stmt;
+        }
+        next_token(p);
+    }
+
+    return node;
+}
+
+static AstNode *parse_func_declaration(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_FUNC_DECL, p->cur_token);
+
+    if (!expect_peek(p, TOK_IDENT)) return NULL;
+    node->data.func_decl.name = p->cur_token.literal;
+
+    /* Parameters */
+    if (!expect_peek(p, TOK_LPAREN)) return NULL;
+
+    int param_cap = 4;
+    node->data.func_decl.param_count = 0;
+    node->data.func_decl.params = arena_alloc(p->arena, sizeof(Param) * param_cap);
+
+    if (!peek_token_is(p, TOK_RPAREN)) {
+        next_token(p);
+        do {
+            if (node->data.func_decl.param_count >= param_cap) {
+                param_cap *= 2;
+                Param *new_params = arena_alloc(p->arena, sizeof(Param) * param_cap);
+                memcpy(new_params, node->data.func_decl.params,
+                    sizeof(Param) * node->data.func_decl.param_count);
+                node->data.func_decl.params = new_params;
+            }
+
+            Param *param = &node->data.func_decl.params[node->data.func_decl.param_count];
+            memset(param, 0, sizeof(Param));
+
+            /* Check for mutable parameter (&) */
+            if (cur_token_is(p, TOK_AMPERSAND)) {
+                param->mutable = true;
+                next_token(p);
+            }
+
+            param->name = p->cur_token.literal;
+
+            /* Type name follows (unless next param or closing paren) */
+            if (peek_token_is(p, TOK_IDENT)) {
+                next_token(p);
+                param->type_name = p->cur_token.literal;
+            }
+
+            node->data.func_decl.param_count++;
+
+            if (peek_token_is(p, TOK_COMMA)) {
+                next_token(p); /* skip comma */
+                next_token(p);
+            }
+        } while (!cur_token_is(p, TOK_RPAREN) && !peek_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF));
+    }
+
+    if (!expect_peek(p, TOK_RPAREN)) return NULL;
+
+    /* Return type(s) */
+    node->data.func_decl.return_type_count = 0;
+    node->data.func_decl.return_types = NULL;
+
+    if (peek_token_is(p, TOK_ARROW)) {
+        next_token(p); /* skip -> */
+        next_token(p);
+
+        int ret_cap = 4;
+        node->data.func_decl.return_types = arena_alloc(p->arena, sizeof(const char *) * ret_cap);
+
+        if (cur_token_is(p, TOK_LPAREN)) {
+            /* Multiple return types: -> (int, string) */
+            next_token(p);
+            while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
+                node->data.func_decl.return_types[node->data.func_decl.return_type_count++] =
+                    p->cur_token.literal;
+                if (peek_token_is(p, TOK_COMMA)) {
+                    next_token(p);
+                }
+                next_token(p);
+            }
+        } else {
+            /* Single return type */
+            node->data.func_decl.return_types[0] = p->cur_token.literal;
+            node->data.func_decl.return_type_count = 1;
+        }
+    }
+
+    /* Body */
+    if (!expect_peek(p, TOK_LBRACE)) return NULL;
+    node->data.func_decl.body = parse_block_statement(p);
+
+    return node;
+}
+
+static AstNode *parse_import_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_IMPORT_STMT, p->cur_token);
+
+    int cap = 4;
+    node->data.import_stmt.count = 0;
+    node->data.import_stmt.items = arena_alloc(p->arena, sizeof(ImportItem) * cap);
+    node->data.import_stmt.auto_use = false;
+
+    do {
+        next_token(p);
+        ImportItem *item = &node->data.import_stmt.items[node->data.import_stmt.count];
+        memset(item, 0, sizeof(ImportItem));
+
+        if (cur_token_is(p, TOK_AT)) {
+            item->is_stdlib = true;
+            next_token(p);
+            item->module = p->cur_token.literal;
+            item->alias = p->cur_token.literal;
+        } else if (cur_token_is(p, TOK_STRING)) {
+            item->is_stdlib = false;
+            item->path = p->cur_token.literal;
+        } else if (cur_token_is(p, TOK_AMPERSAND)) {
+            /* import & use syntax */
+            node->data.import_stmt.auto_use = true;
+            continue;
+        }
+
+        node->data.import_stmt.count++;
+
+        if (node->data.import_stmt.count >= cap) {
+            cap *= 2;
+            ImportItem *new_items = arena_alloc(p->arena, sizeof(ImportItem) * cap);
+            memcpy(new_items, node->data.import_stmt.items,
+                sizeof(ImportItem) * node->data.import_stmt.count);
+            node->data.import_stmt.items = new_items;
+        }
+    } while (peek_token_is(p, TOK_COMMA));
+
+    return node;
+}
+
+static AstNode *parse_using_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_USING_STMT, p->cur_token);
+
+    int cap = 4;
+    node->data.using_stmt.count = 0;
+    node->data.using_stmt.modules = arena_alloc(p->arena, sizeof(const char *) * cap);
+
+    do {
+        next_token(p);
+        node->data.using_stmt.modules[node->data.using_stmt.count++] = p->cur_token.literal;
+    } while (peek_token_is(p, TOK_COMMA) && (next_token(p), 1));
+
+    return node;
+}
+
+static AstNode *parse_if_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_IF_STMT, p->cur_token);
+
+    next_token(p);
+    node->data.if_stmt.condition = parse_expression(p, PREC_LOWEST);
+
+    if (!expect_peek(p, TOK_LBRACE)) return NULL;
+    node->data.if_stmt.consequence = parse_block_statement(p);
+
+    node->data.if_stmt.alternative = NULL;
+
+    if (peek_token_is(p, TOK_OR_KW)) {
+        next_token(p); /* skip 'or' */
+        /* 'or' acts like 'else if' */
+        node->data.if_stmt.alternative = parse_if_statement(p);
+    } else if (peek_token_is(p, TOK_OTHERWISE)) {
+        next_token(p); /* skip 'otherwise' */
+        if (!expect_peek(p, TOK_LBRACE)) return NULL;
+        node->data.if_stmt.alternative = parse_block_statement(p);
+    }
+
+    return node;
+}
+
+static AstNode *parse_ensure_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_ENSURE_STMT, p->cur_token);
+    next_token(p);
+    node->data.ensure_stmt.expr = parse_expression(p, PREC_LOWEST);
+    return node;
+}
+
+static bool is_assignment_op(TokenType t) {
+    return t == TOK_ASSIGN || t == TOK_PLUS_ASSIGN || t == TOK_MINUS_ASSIGN ||
+           t == TOK_ASTERISK_ASSIGN || t == TOK_SLASH_ASSIGN || t == TOK_PERCENT_ASSIGN;
+}
+
+static AstNode *parse_statement(Parser *p) {
+    switch (p->cur_token.type) {
+    case TOK_TEMP:
+    case TOK_CONST:
+        return parse_var_declaration(p);
+    case TOK_DO:
+        return parse_func_declaration(p);
+    case TOK_RETURN:
+        return parse_return_statement(p);
+    case TOK_IMPORT:
+        return parse_import_statement(p);
+    case TOK_USING:
+        return parse_using_statement(p);
+    case TOK_IF:
+        return parse_if_statement(p);
+    case TOK_ENSURE:
+        return parse_ensure_statement(p);
+    default: {
+        /* Could be assignment or expression statement */
+        AstNode *expr = parse_expression(p, PREC_LOWEST);
+        if (!expr) return NULL;
+
+        /* Check for assignment */
+        if (is_assignment_op(p->peek_token.type)) {
+            next_token(p);
+            AstNode *node = ast_alloc(p->arena, NODE_ASSIGN_STMT, p->cur_token);
+            node->data.assign.target = expr;
+            node->data.assign.op = p->cur_token.literal;
+            next_token(p);
+            node->data.assign.value = parse_expression(p, PREC_LOWEST);
+            return node;
+        }
+
+        AstNode *node = ast_alloc(p->arena, NODE_EXPR_STMT, p->cur_token);
+        node->data.expr_stmt.expr = expr;
+        return node;
+    }
+    }
+}
+
+/* --- Public API --- */
+
+Parser *parser_create(Arena *arena, Lexer *lexer, const char *file) {
+    Parser *p = arena_alloc(arena, sizeof(Parser));
+    p->lexer = lexer;
+    p->arena = arena;
+    p->file = file;
+    p->errors = NULL;
+    p->error_count = 0;
+    p->error_cap = 0;
+
+    /* Read two tokens to fill cur and peek */
+    next_token(p);
+    next_token(p);
+
+    return p;
+}
+
+AstNode *parser_parse_program(Parser *p) {
+    Token tok = {TOK_EOF, "", 0, 0};
+    AstNode *program = ast_alloc(p->arena, NODE_PROGRAM, tok);
+    program->data.program.module_decl = NULL;
+    program->data.program.using_stmts = NULL;
+    program->data.program.using_count = 0;
+    program->data.program.stmt_count = 0;
+    program->data.program.stmt_cap = 16;
+    program->data.program.stmts = arena_alloc(p->arena,
+        sizeof(AstNode *) * program->data.program.stmt_cap);
+
+    while (!cur_token_is(p, TOK_EOF)) {
+        AstNode *stmt = parse_statement(p);
+        if (stmt) {
+            if (program->data.program.stmt_count >= program->data.program.stmt_cap) {
+                program->data.program.stmt_cap *= 2;
+                AstNode **new_stmts = arena_alloc(p->arena,
+                    sizeof(AstNode *) * program->data.program.stmt_cap);
+                memcpy(new_stmts, program->data.program.stmts,
+                    sizeof(AstNode *) * program->data.program.stmt_count);
+                program->data.program.stmts = new_stmts;
+            }
+            program->data.program.stmts[program->data.program.stmt_count++] = stmt;
+        }
+        next_token(p);
+    }
+
+    return program;
+}
+
+bool parser_has_errors(Parser *p) {
+    return p->error_count > 0;
+}
+
+void parser_print_errors(Parser *p) {
+    for (int i = 0; i < p->error_count; i++) {
+        fprintf(stderr, "error: %s\n", p->errors[i]);
+    }
+}

--- a/ezc/src/parser/parser.h
+++ b/ezc/src/parser/parser.h
@@ -1,0 +1,33 @@
+/*
+ * parser.h - Recursive descent parser for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_PARSER_H
+#define EZC_PARSER_H
+
+#include "ast.h"
+#include "../lexer/lexer.h"
+#include "../util/arena.h"
+
+typedef struct {
+    Lexer *lexer;
+    Arena *arena;
+    Token cur_token;
+    Token peek_token;
+    const char *file;
+
+    /* Error tracking */
+    char **errors;
+    int error_count;
+    int error_cap;
+} Parser;
+
+Parser *parser_create(Arena *arena, Lexer *lexer, const char *file);
+AstNode *parser_parse_program(Parser *p);
+bool parser_has_errors(Parser *p);
+void parser_print_errors(Parser *p);
+
+#endif

--- a/ezc/src/runtime/ez_runtime.c
+++ b/ezc/src/runtime/ez_runtime.c
@@ -1,0 +1,123 @@
+/*
+ * ez_runtime.c - EZC runtime implementation
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "ez_runtime.h"
+#include <stdarg.h>
+
+/* --- Global default arena --- */
+
+EzArena *ez_default_arena = NULL;
+
+/* --- Arena Allocator --- */
+
+#define ALIGN_UP(x, a) (((x) + (a) - 1) & ~((a) - 1))
+
+static EzArenaBlock *ez_arena_block_create(size_t size) {
+    EzArenaBlock *block = (EzArenaBlock *)malloc(sizeof(EzArenaBlock) + size);
+    if (!block) {
+        fprintf(stderr, "EZ runtime: out of memory\n");
+        exit(1);
+    }
+    block->next = NULL;
+    block->size = size;
+    block->used = 0;
+    return block;
+}
+
+EzArena *ez_arena_create(size_t initial_size) {
+    EzArena *arena = (EzArena *)malloc(sizeof(EzArena));
+    if (!arena) {
+        fprintf(stderr, "EZ runtime: out of memory\n");
+        exit(1);
+    }
+    arena->default_block_size = initial_size;
+    arena->first = ez_arena_block_create(initial_size);
+    arena->current = arena->first;
+    return arena;
+}
+
+void *ez_arena_alloc(EzArena *arena, size_t size) {
+    size = ALIGN_UP(size, 8);
+    if (arena->current->used + size > arena->current->size) {
+        size_t block_size = arena->default_block_size;
+        if (size > block_size) block_size = size;
+        EzArenaBlock *block = ez_arena_block_create(block_size);
+        arena->current->next = block;
+        arena->current = block;
+    }
+    void *ptr = arena->current->data + arena->current->used;
+    arena->current->used += size;
+    return ptr;
+}
+
+void ez_arena_destroy(EzArena *arena) {
+    EzArenaBlock *block = arena->first;
+    while (block) {
+        EzArenaBlock *next = block->next;
+        free(block);
+        block = next;
+    }
+    free(arena);
+}
+
+/* --- String --- */
+
+EzString ez_string_new(EzArena *arena, const char *s, int32_t len) {
+    char *data = (char *)ez_arena_alloc(arena, (size_t)len + 1);
+    memcpy(data, s, (size_t)len);
+    data[len] = '\0';
+    EzString str;
+    str.data = data;
+    str.len = len;
+    return str;
+}
+
+EzString ez_string_format(EzArena *arena, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    int needed = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+
+    if (needed < 0) {
+        return ez_string_lit("");
+    }
+
+    char *data = (char *)ez_arena_alloc(arena, (size_t)needed + 1);
+    va_start(args, fmt);
+    vsnprintf(data, (size_t)needed + 1, fmt, args);
+    va_end(args);
+
+    EzString str;
+    str.data = data;
+    str.len = (int32_t)needed;
+    return str;
+}
+
+/* --- Runtime Init/Shutdown --- */
+
+void ez_runtime_init(void) {
+    ez_default_arena = ez_arena_create(1024 * 1024); /* 1 MB default */
+}
+
+void ez_runtime_shutdown(void) {
+    if (ez_default_arena) {
+        ez_arena_destroy(ez_default_arena);
+        ez_default_arena = NULL;
+    }
+}
+
+/* --- Panic --- */
+
+void ez_panic(const char *file, int line, const char *fmt, ...) {
+    fprintf(stderr, "panic at %s:%d: ", file, line);
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+    exit(1);
+}

--- a/ezc/src/runtime/ez_runtime.h
+++ b/ezc/src/runtime/ez_runtime.h
@@ -1,0 +1,73 @@
+/*
+ * ez_runtime.h - EZC runtime support
+ *
+ * This header is included in all generated C code.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZ_RUNTIME_H
+#define EZ_RUNTIME_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* --- Arena Allocator --- */
+
+typedef struct EzArenaBlock {
+    struct EzArenaBlock *next;
+    size_t size;
+    size_t used;
+    char data[];
+} EzArenaBlock;
+
+typedef struct {
+    EzArenaBlock *first;
+    EzArenaBlock *current;
+    size_t default_block_size;
+} EzArena;
+
+EzArena *ez_arena_create(size_t initial_size);
+void *ez_arena_alloc(EzArena *arena, size_t size);
+void ez_arena_destroy(EzArena *arena);
+
+/* Global default arena */
+extern EzArena *ez_default_arena;
+
+/* --- String --- */
+
+typedef struct {
+    const char *data;
+    int32_t len;
+} EzString;
+
+/* Create a string from a C string literal (no copy, points to static data) */
+static inline EzString ez_string_lit(const char *s) {
+    EzString str;
+    str.data = s;
+    str.len = (int32_t)strlen(s);
+    return str;
+}
+
+/* Create a string with a copy on the arena */
+EzString ez_string_new(EzArena *arena, const char *s, int32_t len);
+
+/* String formatting (for interpolation) */
+EzString ez_string_format(EzArena *arena, const char *fmt, ...);
+
+/* --- Runtime Init/Shutdown --- */
+
+void ez_runtime_init(void);
+void ez_runtime_shutdown(void);
+
+/* --- Panic --- */
+
+void ez_panic(const char *file, int line, const char *fmt, ...)
+    __attribute__((format(printf, 3, 4), noreturn));
+
+#endif

--- a/ezc/src/stdlib/ez_std.c
+++ b/ezc/src/stdlib/ez_std.c
@@ -1,0 +1,35 @@
+/*
+ * ez_std.c - @std module implementation
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "ez_std.h"
+#include <stdio.h>
+#include <inttypes.h>
+
+void ez_std_println_str(EzString s) {
+    fwrite(s.data, 1, (size_t)s.len, stdout);
+    putchar('\n');
+}
+
+void ez_std_println_int(int64_t v) {
+    printf("%" PRId64 "\n", v);
+}
+
+void ez_std_println_float(double v) {
+    printf("%g\n", v);
+}
+
+void ez_std_println_bool(bool v) {
+    printf("%s\n", v ? "true" : "false");
+}
+
+void ez_std_print_str(EzString s) {
+    fwrite(s.data, 1, (size_t)s.len, stdout);
+}
+
+void ez_std_print_int(int64_t v) {
+    printf("%" PRId64, v);
+}

--- a/ezc/src/stdlib/ez_std.h
+++ b/ezc/src/stdlib/ez_std.h
@@ -1,0 +1,23 @@
+/*
+ * ez_std.h - @std module for EZC
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZ_STD_H
+#define EZ_STD_H
+
+#include "../runtime/ez_runtime.h"
+
+/* println(value) - print a string followed by newline */
+void ez_std_println_str(EzString s);
+void ez_std_println_int(int64_t v);
+void ez_std_println_float(double v);
+void ez_std_println_bool(bool v);
+
+/* print(value) - print without newline */
+void ez_std_print_str(EzString s);
+void ez_std_print_int(int64_t v);
+
+#endif

--- a/ezc/src/util/arena.c
+++ b/ezc/src/util/arena.c
@@ -1,0 +1,76 @@
+/*
+ * arena.c - Compiler-internal arena allocator
+ */
+
+#include "arena.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+
+static ArenaBlock *arena_block_create(size_t size) {
+    ArenaBlock *block = malloc(sizeof(ArenaBlock) + size);
+    if (!block) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    block->next = NULL;
+    block->size = size;
+    block->used = 0;
+    return block;
+}
+
+Arena *arena_create(size_t initial_size) {
+    Arena *a = malloc(sizeof(Arena));
+    if (!a) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    a->default_block_size = initial_size;
+    a->first = arena_block_create(initial_size);
+    a->current = a->first;
+    return a;
+}
+
+void *arena_alloc(Arena *a, size_t size) {
+    size = ALIGN_UP(size, 8);
+
+    if (a->current->used + size > a->current->size) {
+        size_t block_size = a->default_block_size;
+        if (size > block_size) {
+            block_size = size;
+        }
+        ArenaBlock *block = arena_block_create(block_size);
+        a->current->next = block;
+        a->current = block;
+    }
+
+    void *ptr = a->current->data + a->current->used;
+    a->current->used += size;
+    return ptr;
+}
+
+char *arena_strdup(Arena *a, const char *s) {
+    size_t len = strlen(s);
+    char *dup = arena_alloc(a, len + 1);
+    memcpy(dup, s, len + 1);
+    return dup;
+}
+
+char *arena_strndup(Arena *a, const char *s, size_t len) {
+    char *dup = arena_alloc(a, len + 1);
+    memcpy(dup, s, len);
+    dup[len] = '\0';
+    return dup;
+}
+
+void arena_destroy(Arena *a) {
+    ArenaBlock *block = a->first;
+    while (block) {
+        ArenaBlock *next = block->next;
+        free(block);
+        block = next;
+    }
+    free(a);
+}

--- a/ezc/src/util/arena.h
+++ b/ezc/src/util/arena.h
@@ -1,0 +1,32 @@
+/*
+ * arena.h - Compiler-internal arena allocator
+ *
+ * Used for allocating AST nodes, strings, and other compiler data.
+ * All memory is freed in one shot when compilation of a file finishes.
+ */
+
+#ifndef EZC_ARENA_H
+#define EZC_ARENA_H
+
+#include <stddef.h>
+
+typedef struct ArenaBlock {
+    struct ArenaBlock *next;
+    size_t size;
+    size_t used;
+    char data[];
+} ArenaBlock;
+
+typedef struct {
+    ArenaBlock *first;
+    ArenaBlock *current;
+    size_t default_block_size;
+} Arena;
+
+Arena *arena_create(size_t initial_size);
+void *arena_alloc(Arena *a, size_t size);
+char *arena_strdup(Arena *a, const char *s);
+char *arena_strndup(Arena *a, const char *s, size_t len);
+void arena_destroy(Arena *a);
+
+#endif

--- a/ezc/src/util/buf.c
+++ b/ezc/src/util/buf.c
@@ -1,0 +1,89 @@
+/*
+ * buf.c - Growable string buffer for code emission
+ */
+
+#include "buf.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+static void buf_grow(Buf *b, size_t needed) {
+    if (b->len + needed + 1 <= b->cap) return;
+    size_t new_cap = b->cap * 2;
+    if (new_cap < b->len + needed + 1) {
+        new_cap = b->len + needed + 1;
+    }
+    b->data = realloc(b->data, new_cap);
+    if (!b->data) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    b->cap = new_cap;
+}
+
+Buf buf_create(size_t initial_cap) {
+    Buf b;
+    b.data = malloc(initial_cap);
+    if (!b.data) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    b.data[0] = '\0';
+    b.len = 0;
+    b.cap = initial_cap;
+    return b;
+}
+
+void buf_append(Buf *b, const char *s) {
+    size_t len = strlen(s);
+    buf_appendn(b, s, len);
+}
+
+void buf_appendn(Buf *b, const char *s, size_t len) {
+    buf_grow(b, len);
+    memcpy(b->data + b->len, s, len);
+    b->len += len;
+    b->data[b->len] = '\0';
+}
+
+void buf_appendf(Buf *b, const char *fmt, ...) {
+    va_list args;
+
+    va_start(args, fmt);
+    int needed = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+
+    if (needed < 0) return;
+
+    buf_grow(b, (size_t)needed);
+
+    va_start(args, fmt);
+    vsnprintf(b->data + b->len, (size_t)needed + 1, fmt, args);
+    va_end(args);
+
+    b->len += (size_t)needed;
+}
+
+void buf_append_char(Buf *b, char c) {
+    buf_grow(b, 1);
+    b->data[b->len++] = c;
+    b->data[b->len] = '\0';
+}
+
+void buf_append_indent(Buf *b, int depth) {
+    for (int i = 0; i < depth; i++) {
+        buf_append(b, "    ");
+    }
+}
+
+const char *buf_cstr(Buf *b) {
+    return b->data;
+}
+
+void buf_destroy(Buf *b) {
+    free(b->data);
+    b->data = NULL;
+    b->len = 0;
+    b->cap = 0;
+}

--- a/ezc/src/util/buf.h
+++ b/ezc/src/util/buf.h
@@ -1,0 +1,25 @@
+/*
+ * buf.h - Growable string buffer for code emission
+ */
+
+#ifndef EZC_BUF_H
+#define EZC_BUF_H
+
+#include <stddef.h>
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+} Buf;
+
+Buf buf_create(size_t initial_cap);
+void buf_append(Buf *b, const char *s);
+void buf_appendn(Buf *b, const char *s, size_t len);
+void buf_appendf(Buf *b, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+void buf_append_char(Buf *b, char c);
+void buf_append_indent(Buf *b, int depth);
+const char *buf_cstr(Buf *b);
+void buf_destroy(Buf *b);
+
+#endif


### PR DESCRIPTION
## Summary
- Introduces EZC, a C-based compiler tool that compiles `.ez` source files to native binaries via C codegen
- Full pipeline: lexer → parser → AST → code generator → C source → cc → native binary
- Includes runtime (arena allocator, EzString) and `@std` stdlib (`println`, `print`)
- CLI supports `-o` (output name), `-c` (emit C only), `--version`, `--help`

## Files
- `ezc/Makefile` — build system
- `ezc/src/main.c` — CLI entry point, file I/O, cc invocation
- `ezc/src/util/` — compiler-internal arena allocator and growable string buffer
- `ezc/src/lexer/` — token types and lexical scanner (ported from Go)
- `ezc/src/parser/` — AST node definitions and Pratt-style recursive descent parser
- `ezc/src/codegen/` — AST-to-C code emitter with EZ→C type mapping
- `ezc/src/runtime/` — runtime included in generated code (arena, strings, init/shutdown)
- `ezc/src/stdlib/` — `@std` module (println, print)

## Test plan
- [x] `ezc hello.ez -c` emits valid C source
- [x] `ezc hello.ez -o hello && ./hello` prints "Hello, World!"
- [x] Multi-function programs with parameters and return types compile and run
- [x] Output matches `ez` interpreter