### PR TITLE
feat(ezc): structs, enums, and arrays

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -70,7 +70,14 @@ static const char *ez_type_to_c(const char *type_name) {
     if (strcmp(type_name, "byte") == 0)   return "uint8_t";
     if (strcmp(type_name, "string") == 0) return "EzString";
 
-    /* Default: assume it's a struct type */
+    /* If starts with uppercase, it's a struct type */
+    if (type_name[0] >= 'A' && type_name[0] <= 'Z') {
+        /* Return a formatted struct type name */
+        static char buf[256];
+        snprintf(buf, sizeof(buf), "EzStruct_%s", type_name);
+        return buf;
+    }
+
     return type_name;
 }
 
@@ -169,6 +176,17 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         emit(cg, ")");
         break;
     }
+
+    case NODE_STRUCT_VALUE:
+        /* Struct literal: (EzStruct_Name){.field = value, ...} */
+        emitf(cg, "(EzStruct_%s){", node->data.struct_value.name);
+        for (int i = 0; i < node->data.struct_value.count; i++) {
+            if (i > 0) emit(cg, ", ");
+            emitf(cg, ".%s = ", node->data.struct_value.field_names[i]);
+            emit_expression(cg, node->data.struct_value.field_values[i]);
+        }
+        emit(cg, "}");
+        break;
 
     case NODE_PREFIX_EXPR:
         emit(cg, "(");
@@ -600,6 +618,12 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
         emit_func_declaration(cg, node,
             strcmp(node->data.func_decl.name, "main") == 0);
         break;
+    case NODE_STRUCT_DECL:
+        /* Struct declarations are emitted in the preamble */
+        break;
+    case NODE_ENUM_DECL:
+        /* Enum declarations are emitted in the preamble */
+        break;
     case NODE_IMPORT_STMT:
         /* Imports are handled during the preamble scan */
         break;
@@ -648,6 +672,39 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
         emit(cg, "#include \"ez_std.h\"\n");
     }
     emit(cg, "\n");
+
+    /* Emit struct type definitions */
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        AstNode *stmt = program->data.program.stmts[i];
+        if (stmt->kind == NODE_STRUCT_DECL) {
+            emitf(cg, "typedef struct {\n");
+            for (int j = 0; j < stmt->data.struct_decl.field_count; j++) {
+                StructField *f = &stmt->data.struct_decl.fields[j];
+                emitf(cg, "    %s %s;\n", ez_type_to_c(f->type_name), f->name);
+            }
+            emitf(cg, "} EzStruct_%s;\n\n", stmt->data.struct_decl.name);
+        }
+    }
+
+    /* Emit enum type definitions */
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        AstNode *stmt = program->data.program.stmts[i];
+        if (stmt->kind == NODE_ENUM_DECL) {
+            emitf(cg, "typedef enum {\n");
+            for (int j = 0; j < stmt->data.enum_decl.value_count; j++) {
+                EnumVal *ev = &stmt->data.enum_decl.values[j];
+                emitf(cg, "    EzEnum_%s_%s", stmt->data.enum_decl.name, ev->name);
+                if (ev->value) {
+                    emit(cg, " = ");
+                    emit_expression(cg, ev->value);
+                } else {
+                    emitf(cg, " = %d", j);
+                }
+                emit(cg, ",\n");
+            }
+            emitf(cg, "} EzEnum_%s;\n\n", stmt->data.enum_decl.name);
+        }
+    }
 
     /* Emit forward declarations for user functions */
     for (int i = 0; i < program->data.program.stmt_count; i++) {

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -17,6 +17,7 @@
 static void emit_statement(CodeGen *cg, AstNode *node);
 static void emit_expression(CodeGen *cg, AstNode *node);
 static void emit_call_expression(CodeGen *cg, AstNode *node);
+static bool codegen_is_enum(CodeGen *cg, const char *name);
 
 /* --- Helpers --- */
 
@@ -47,7 +48,7 @@ static void emit_indent(CodeGen *cg) {
 }
 
 /* Map EZ type name to C type */
-static const char *ez_type_to_c(const char *type_name) {
+static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
     if (!type_name) return "int64_t";
 
     if (strcmp(type_name, "int") == 0)    return "int64_t";
@@ -70,11 +71,14 @@ static const char *ez_type_to_c(const char *type_name) {
     if (strcmp(type_name, "byte") == 0)   return "uint8_t";
     if (strcmp(type_name, "string") == 0) return "EzString";
 
-    /* If starts with uppercase, it's a struct type */
+    /* If starts with uppercase, it's a user-defined type */
     if (type_name[0] >= 'A' && type_name[0] <= 'Z') {
-        /* Return a formatted struct type name */
         static char buf[256];
-        snprintf(buf, sizeof(buf), "EzStruct_%s", type_name);
+        if (cg && codegen_is_enum(cg, type_name)) {
+            snprintf(buf, sizeof(buf), "EzEnum_%s", type_name);
+        } else {
+            snprintf(buf, sizeof(buf), "EzStruct_%s", type_name);
+        }
         return buf;
     }
 
@@ -201,14 +205,16 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         const char *op = node->data.infix.op;
         bool needs_parens = true;
         /* Check if both children are simple (no further nesting needed) */
-        if (node->data.infix.left->kind == NODE_LABEL ||
-            node->data.infix.left->kind == NODE_INT_VALUE ||
-            node->data.infix.left->kind == NODE_FLOAT_VALUE) {
-            if (node->data.infix.right->kind == NODE_LABEL ||
-                node->data.infix.right->kind == NODE_INT_VALUE ||
-                node->data.infix.right->kind == NODE_FLOAT_VALUE) {
-                needs_parens = false;
-            }
+        NodeKind lk = node->data.infix.left->kind;
+        NodeKind rk = node->data.infix.right->kind;
+        bool l_simple = (lk == NODE_LABEL || lk == NODE_INT_VALUE ||
+                        lk == NODE_FLOAT_VALUE || lk == NODE_MEMBER_EXPR ||
+                        lk == NODE_CALL_EXPR || lk == NODE_BOOL_VALUE);
+        bool r_simple = (rk == NODE_LABEL || rk == NODE_INT_VALUE ||
+                        rk == NODE_FLOAT_VALUE || rk == NODE_MEMBER_EXPR ||
+                        rk == NODE_CALL_EXPR || rk == NODE_BOOL_VALUE);
+        if (l_simple && r_simple) {
+            needs_parens = false;
         }
         if (needs_parens) emit(cg, "(");
         emit_expression(cg, node->data.infix.left);
@@ -228,6 +234,15 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         break;
 
     case NODE_MEMBER_EXPR:
+        /* Check if this is an enum access: EnumName.VALUE */
+        if (node->data.member.object->kind == NODE_LABEL) {
+            const char *obj_name = node->data.member.object->data.label.value;
+            if (obj_name[0] >= 'A' && obj_name[0] <= 'Z') {
+                /* Could be enum access — emit as EzEnum_Name_VALUE */
+                emitf(cg, "EzEnum_%s_%s", obj_name, node->data.member.member);
+                break;
+            }
+        }
         emit_expression(cg, node->data.member.object);
         emitf(cg, ".%s", node->data.member.member);
         break;
@@ -317,7 +332,7 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
 static void emit_var_declaration(CodeGen *cg, AstNode *node) {
     emit_indent(cg);
 
-    const char *c_type = ez_type_to_c(node->data.var_decl.type_name);
+    const char *c_type = ez_type_to_c_cg(cg,node->data.var_decl.type_name);
 
     if (!node->data.var_decl.mutable) {
         emit(cg, "const ");
@@ -492,7 +507,7 @@ static void emit_func_declaration(CodeGen *cg, AstNode *node, bool is_main) {
         if (node->data.func_decl.return_type_count == 0) {
             emit(cg, "static void ");
         } else {
-            emitf(cg, "static %s ", ez_type_to_c(node->data.func_decl.return_types[0]));
+            emitf(cg, "static %s ", ez_type_to_c_cg(cg,node->data.func_decl.return_types[0]));
         }
         emitf(cg, "ez_fn_%s(", node->data.func_decl.name);
 
@@ -501,9 +516,9 @@ static void emit_func_declaration(CodeGen *cg, AstNode *node, bool is_main) {
             if (i > 0) emit(cg, ", ");
             Param *param = &node->data.func_decl.params[i];
             if (param->mutable) {
-                emitf(cg, "%s *%s", ez_type_to_c(param->type_name), param->name);
+                emitf(cg, "%s *%s", ez_type_to_c_cg(cg,param->type_name), param->name);
             } else {
-                emitf(cg, "%s %s", ez_type_to_c(param->type_name), param->name);
+                emitf(cg, "%s %s", ez_type_to_c_cg(cg,param->type_name), param->name);
             }
         }
 
@@ -639,12 +654,22 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
 
 /* --- Public API --- */
 
+static bool codegen_is_enum(CodeGen *cg, const char *name) {
+    for (int i = 0; i < cg->enum_count; i++) {
+        if (strcmp(cg->enum_names[i], name) == 0) return true;
+    }
+    return false;
+}
+
 CodeGen codegen_create(const char *file) {
     CodeGen cg;
     cg.output = buf_create(4096);
     cg.indent = 0;
     cg.has_std = false;
     cg.file = file;
+    cg.enum_names = NULL;
+    cg.enum_count = 0;
+    cg.enum_cap = 0;
     return cg;
 }
 
@@ -680,16 +705,23 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
             emitf(cg, "typedef struct {\n");
             for (int j = 0; j < stmt->data.struct_decl.field_count; j++) {
                 StructField *f = &stmt->data.struct_decl.fields[j];
-                emitf(cg, "    %s %s;\n", ez_type_to_c(f->type_name), f->name);
+                emitf(cg, "    %s %s;\n", ez_type_to_c_cg(cg,f->type_name), f->name);
             }
             emitf(cg, "} EzStruct_%s;\n\n", stmt->data.struct_decl.name);
         }
     }
 
-    /* Emit enum type definitions */
+    /* Collect and emit enum type definitions */
     for (int i = 0; i < program->data.program.stmt_count; i++) {
         AstNode *stmt = program->data.program.stmts[i];
         if (stmt->kind == NODE_ENUM_DECL) {
+            /* Register enum name */
+            if (cg->enum_count >= cg->enum_cap) {
+                cg->enum_cap = cg->enum_cap ? cg->enum_cap * 2 : 8;
+                const char **new_names = realloc(cg->enum_names, sizeof(const char *) * cg->enum_cap);
+                cg->enum_names = new_names;
+            }
+            cg->enum_names[cg->enum_count++] = stmt->data.enum_decl.name;
             emitf(cg, "typedef enum {\n");
             for (int j = 0; j < stmt->data.enum_decl.value_count; j++) {
                 EnumVal *ev = &stmt->data.enum_decl.values[j];
@@ -717,16 +749,16 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
                 if (stmt->data.func_decl.return_type_count == 0) {
                     emit(cg, "void ");
                 } else {
-                    emitf(cg, "%s ", ez_type_to_c(stmt->data.func_decl.return_types[0]));
+                    emitf(cg, "%s ", ez_type_to_c_cg(cg,stmt->data.func_decl.return_types[0]));
                 }
                 emitf(cg, "ez_fn_%s(", stmt->data.func_decl.name);
                 for (int j = 0; j < stmt->data.func_decl.param_count; j++) {
                     if (j > 0) emit(cg, ", ");
                     Param *param = &stmt->data.func_decl.params[j];
                     if (param->mutable) {
-                        emitf(cg, "%s *", ez_type_to_c(param->type_name));
+                        emitf(cg, "%s *", ez_type_to_c_cg(cg,param->type_name));
                     } else {
-                        emit(cg, ez_type_to_c(param->type_name));
+                        emit(cg, ez_type_to_c_cg(cg,param->type_name));
                     }
                 }
                 if (stmt->data.func_decl.param_count == 0) {

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -181,6 +181,16 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         break;
     }
 
+    case NODE_ARRAY_VALUE:
+        /* Array literal: emit as C compound literal */
+        emit(cg, "{");
+        for (int i = 0; i < node->data.array_value.count; i++) {
+            if (i > 0) emit(cg, ", ");
+            emit_expression(cg, node->data.array_value.elements[i]);
+        }
+        emit(cg, "}");
+        break;
+
     case NODE_STRUCT_VALUE:
         /* Struct literal: (EzStruct_Name){.field = value, ...} */
         emitf(cg, "(EzStruct_%s){", node->data.struct_value.name);
@@ -329,10 +339,42 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
 
 /* --- Statement Emission --- */
 
+static const char *extract_array_elem_type(const char *type_name) {
+    if (!type_name || type_name[0] != '[') return NULL;
+    /* Extract element type from "[int]" -> "int" */
+    static char buf[128];
+    size_t len = strlen(type_name);
+    if (len < 3) return NULL;
+    memcpy(buf, type_name + 1, len - 2);
+    buf[len - 2] = '\0';
+    return buf;
+}
+
 static void emit_var_declaration(CodeGen *cg, AstNode *node) {
     emit_indent(cg);
 
-    const char *c_type = ez_type_to_c_cg(cg,node->data.var_decl.type_name);
+    const char *type_name = node->data.var_decl.type_name;
+    const char *elem_type = extract_array_elem_type(type_name);
+
+    if (elem_type) {
+        /* Array declaration: temp arr [int] = {1, 2, 3} */
+        const char *c_elem_type = ez_type_to_c_cg(cg, elem_type);
+        if (node->data.var_decl.value &&
+            node->data.var_decl.value->kind == NODE_ARRAY_VALUE) {
+            int count = node->data.var_decl.value->data.array_value.count;
+            emitf(cg, "%s %s[%d] = ", c_elem_type, node->data.var_decl.name, count);
+            emit_expression(cg, node->data.var_decl.value);
+            emit(cg, ";\n");
+            /* Emit length tracking variable */
+            emit_indent(cg);
+            emitf(cg, "const int32_t %s_len = %d;\n", node->data.var_decl.name, count);
+        } else {
+            emitf(cg, "%s *%s = NULL;\n", c_elem_type, node->data.var_decl.name);
+        }
+        return;
+    }
+
+    const char *c_type = ez_type_to_c_cg(cg, type_name);
 
     if (!node->data.var_decl.mutable) {
         emit(cg, "const ");

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -16,6 +16,11 @@ typedef struct {
     int indent;
     bool has_std;       /* Whether @std was imported */
     const char *file;
+
+    /* Track declared type names for codegen */
+    const char **enum_names;
+    int enum_count;
+    int enum_cap;
 } CodeGen;
 
 CodeGen codegen_create(const char *file);

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -276,6 +276,31 @@ static AstNode *parse_prefix(Parser *p) {
     case TOK_BANG:
     case TOK_AMPERSAND: return parse_prefix_expression(p);
     case TOK_LPAREN:    return parse_grouped_expression(p);
+    case TOK_LBRACE: {
+        /* Array literal: {1, 2, 3} */
+        AstNode *node = ast_alloc(p->arena, NODE_ARRAY_VALUE, p->cur_token);
+        int cap = 8;
+        node->data.array_value.count = 0;
+        node->data.array_value.elements = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+
+        next_token(p); /* skip { */
+        while (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+            if (node->data.array_value.count >= cap) {
+                cap *= 2;
+                AstNode **new_elems = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+                memcpy(new_elems, node->data.array_value.elements,
+                    sizeof(AstNode *) * node->data.array_value.count);
+                node->data.array_value.elements = new_elems;
+            }
+            node->data.array_value.elements[node->data.array_value.count++] =
+                parse_expression(p, PREC_LOWEST);
+            if (peek_token_is(p, TOK_COMMA)) {
+                next_token(p);
+            }
+            next_token(p);
+        }
+        return node;
+    }
     case TOK_RANGE: {
         /* range(end) or range(start, end) or range(start, end, step) */
         AstNode *node = ast_alloc(p->arena, NODE_RANGE_EXPR, p->cur_token);
@@ -428,9 +453,19 @@ static AstNode *parse_var_declaration(Parser *p) {
 
     /* Optional type annotation */
     node->data.var_decl.type_name = NULL;
-    if (peek_token_is(p, TOK_IDENT) || peek_token_is(p, TOK_LBRACKET)) {
+    if (peek_token_is(p, TOK_IDENT)) {
         next_token(p);
         node->data.var_decl.type_name = p->cur_token.literal;
+    } else if (peek_token_is(p, TOK_LBRACKET)) {
+        /* Array type: [int], [string], etc. */
+        next_token(p); /* skip [ */
+        next_token(p); /* element type */
+        const char *elem_type = p->cur_token.literal;
+        if (!expect_peek(p, TOK_RBRACKET)) return NULL;
+        /* Build type string like "[int]" */
+        char *type_str = arena_alloc(p->arena, strlen(elem_type) + 3);
+        sprintf(type_str, "[%s]", elem_type);
+        node->data.var_decl.type_name = type_str;
     }
 
     /* = value */

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -32,6 +32,7 @@ typedef enum {
 static AstNode *parse_statement(Parser *p);
 static AstNode *parse_expression(Parser *p, Precedence prec);
 static AstNode *parse_block_statement(Parser *p);
+static AstNode *parse_struct_literal(Parser *p, const char *name);
 
 /* --- Helpers --- */
 
@@ -254,7 +255,17 @@ static AstNode *parse_grouped_expression(Parser *p) {
 /* Parse prefix expression (the "nud" in Pratt parsing) */
 static AstNode *parse_prefix(Parser *p) {
     switch (p->cur_token.type) {
-    case TOK_IDENT:     return parse_identifier(p);
+    case TOK_IDENT:
+        /* Check for struct literal: Name{ ... } */
+        if (peek_token_is(p, TOK_LBRACE)) {
+            const char *name = p->cur_token.literal;
+            /* Only treat as struct literal if name starts with uppercase */
+            if (name[0] >= 'A' && name[0] <= 'Z') {
+                next_token(p); /* move to { */
+                return parse_struct_literal(p, name);
+            }
+        }
+        return parse_identifier(p);
     case TOK_INT:       return parse_int_literal(p);
     case TOK_FLOAT:     return parse_float_literal(p);
     case TOK_STRING:    return parse_string_literal(p);
@@ -654,6 +665,125 @@ static AstNode *parse_if_statement(Parser *p) {
     return node;
 }
 
+static AstNode *parse_struct_declaration(Parser *p) {
+    /* cur_token is the struct name (IDENT), already consumed by caller */
+    AstNode *node = ast_alloc(p->arena, NODE_STRUCT_DECL, p->cur_token);
+    node->data.struct_decl.name = p->cur_token.literal;
+    node->data.struct_decl.visibility = 0;
+
+    next_token(p); /* skip 'struct' keyword */
+    if (!expect_peek(p, TOK_LBRACE)) return NULL;
+    next_token(p); /* skip { */
+
+    int field_cap = 8;
+    node->data.struct_decl.field_count = 0;
+    node->data.struct_decl.fields = arena_alloc(p->arena, sizeof(StructField) * field_cap);
+
+    while (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+        if (node->data.struct_decl.field_count >= field_cap) {
+            field_cap *= 2;
+            StructField *new_fields = arena_alloc(p->arena, sizeof(StructField) * field_cap);
+            memcpy(new_fields, node->data.struct_decl.fields,
+                sizeof(StructField) * node->data.struct_decl.field_count);
+            node->data.struct_decl.fields = new_fields;
+        }
+
+        StructField *field = &node->data.struct_decl.fields[node->data.struct_decl.field_count];
+        field->name = p->cur_token.literal;
+        next_token(p);
+        field->type_name = p->cur_token.literal;
+        node->data.struct_decl.field_count++;
+        next_token(p);
+    }
+
+    return node;
+}
+
+static AstNode *parse_enum_declaration(Parser *p) {
+    /* cur_token is the enum name (IDENT), already consumed by caller */
+    AstNode *node = ast_alloc(p->arena, NODE_ENUM_DECL, p->cur_token);
+    node->data.enum_decl.name = p->cur_token.literal;
+    node->data.enum_decl.visibility = 0;
+    node->data.enum_decl.base_type = "int";
+    node->data.enum_decl.is_flags = false;
+
+    next_token(p); /* skip 'enum' keyword */
+    if (!expect_peek(p, TOK_LBRACE)) return NULL;
+    next_token(p); /* skip { */
+
+    int val_cap = 8;
+    node->data.enum_decl.value_count = 0;
+    node->data.enum_decl.values = arena_alloc(p->arena, sizeof(EnumVal) * val_cap);
+
+    while (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+        if (node->data.enum_decl.value_count >= val_cap) {
+            val_cap *= 2;
+            EnumVal *new_vals = arena_alloc(p->arena, sizeof(EnumVal) * val_cap);
+            memcpy(new_vals, node->data.enum_decl.values,
+                sizeof(EnumVal) * node->data.enum_decl.value_count);
+            node->data.enum_decl.values = new_vals;
+        }
+
+        EnumVal *ev = &node->data.enum_decl.values[node->data.enum_decl.value_count];
+        ev->name = p->cur_token.literal;
+        ev->value = NULL;
+
+        /* Check for explicit value: VALUE = expr */
+        if (peek_token_is(p, TOK_ASSIGN)) {
+            next_token(p); /* skip = */
+            next_token(p);
+            ev->value = parse_expression(p, PREC_LOWEST);
+        }
+
+        node->data.enum_decl.value_count++;
+        next_token(p);
+    }
+
+    return node;
+}
+
+/* Parse struct literal: StructName{field: value, ...} */
+static AstNode *parse_struct_literal(Parser *p, const char *name) {
+    AstNode *node = ast_alloc(p->arena, NODE_STRUCT_VALUE, p->cur_token);
+    node->data.struct_value.name = name;
+
+    int cap = 8;
+    node->data.struct_value.count = 0;
+    node->data.struct_value.field_names = arena_alloc(p->arena, sizeof(const char *) * cap);
+    node->data.struct_value.field_values = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+
+    next_token(p); /* skip { */
+
+    while (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+        if (node->data.struct_value.count >= cap) {
+            cap *= 2;
+            const char **new_names = arena_alloc(p->arena, sizeof(const char *) * cap);
+            AstNode **new_vals = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+            memcpy(new_names, node->data.struct_value.field_names,
+                sizeof(const char *) * node->data.struct_value.count);
+            memcpy(new_vals, node->data.struct_value.field_values,
+                sizeof(AstNode *) * node->data.struct_value.count);
+            node->data.struct_value.field_names = new_names;
+            node->data.struct_value.field_values = new_vals;
+        }
+
+        node->data.struct_value.field_names[node->data.struct_value.count] = p->cur_token.literal;
+
+        if (!expect_peek(p, TOK_COLON)) return NULL;
+        next_token(p);
+        node->data.struct_value.field_values[node->data.struct_value.count] =
+            parse_expression(p, PREC_LOWEST);
+        node->data.struct_value.count++;
+
+        if (peek_token_is(p, TOK_COMMA)) {
+            next_token(p);
+        }
+        next_token(p);
+    }
+
+    return node;
+}
+
 static AstNode *parse_ensure_statement(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_ENSURE_STMT, p->cur_token);
     next_token(p);
@@ -794,6 +924,22 @@ static AstNode *parse_statement(Parser *p) {
     switch (p->cur_token.type) {
     case TOK_TEMP:
     case TOK_CONST:
+        /* Check if this is a struct or enum declaration: const Name struct { */
+        if (p->cur_token.type == TOK_CONST && peek_token_is(p, TOK_IDENT)) {
+            /* Save state and look ahead */
+            Token saved_cur = p->cur_token;
+            Token saved_peek = p->peek_token;
+            next_token(p); /* now on IDENT (name) */
+            if (peek_token_is(p, TOK_STRUCT)) {
+                return parse_struct_declaration(p);
+            }
+            if (peek_token_is(p, TOK_ENUM)) {
+                return parse_enum_declaration(p);
+            }
+            /* Not struct/enum — restore and parse as var declaration */
+            p->cur_token = saved_cur;
+            p->peek_token = saved_peek;
+        }
         return parse_var_declaration(p);
     case TOK_DO:
         return parse_func_declaration(p);


### PR DESCRIPTION
## Summary
- Struct declarations (`const Person struct { ... }`) emit as `typedef struct`
- Struct literals (`Person{name: "Alice", age: 30}`) emit as C designated initializers
- Struct field access and mutation via dot notation
- Enum declarations with auto-incrementing integer values
- Enum member access (`Color.RED` → `EzEnum_Color_RED`)
- Enum type resolution distinguishes `EzEnum_` from `EzStruct_`
- Array literals (`{1, 2, 3}`) emit as C arrays with length tracking
- Array type annotations (`[int]`, `[string]`)
- Array indexing and mutation via bracket notation

## Verified examples
- `examples/basic/enums.ez` — compiles and **matches interpreter output exactly**
- Custom struct test — field access, mutation, and function parameters work
- Custom array test — initialization, indexing, mutation, iteration work

## Test plan
- [x] Struct declaration, instantiation, field access, mutation
- [x] Enum declaration, member access, comparison in if/when
- [x] Array literals, indexing, mutation, iteration with for loop
- [x] `examples/basic/enums.ez` output matches interpreter