### PR TITLE
feat(ezc): diagnostic system with source context and colored output

### DIFF
--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -18,6 +18,7 @@ endif
 SRC = src/main.c \
       src/util/arena.c \
       src/util/buf.c \
+      src/util/error.c \
       src/lexer/token.c \
       src/lexer/lexer.c \
       src/parser/ast.c \

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 
 #include "util/arena.h"
+#include "util/error.h"
 #include "lexer/lexer.h"
 #include "parser/parser.h"
 #include "codegen/codegen.h"
@@ -145,6 +146,10 @@ int main(int argc, char **argv) {
             emit_c_only = true;
             continue;
         }
+        if (strcmp(argv[i], "--no-color") == 0) {
+            /* Handled after diag_create */
+            continue;
+        }
         if (argv[i][0] == '-') {
             fprintf(stderr, "ezc: unknown option '%s'\n", argv[i]);
             return 1;
@@ -161,18 +166,29 @@ int main(int argc, char **argv) {
     char *source = read_file(input_file);
     if (!source) return 1;
 
-    /* Create compiler arena */
+    /* Create compiler arena and diagnostics */
     Arena *arena = arena_create(1024 * 1024);
+    DiagnosticList *diag = diag_create();
+    diag_set_source(diag, input_file, source);
+
+    /* Check for --no-color flag */
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--no-color") == 0) {
+            diag->use_color = false;
+        }
+    }
 
     /* Lex */
     Lexer *lexer = lexer_create(arena, source, input_file);
 
     /* Parse */
-    Parser *parser = parser_create(arena, lexer, input_file);
+    Parser *parser = parser_create(arena, lexer, input_file, diag);
     AstNode *program = parser_parse_program(parser);
 
-    if (parser_has_errors(parser)) {
-        parser_print_errors(parser);
+    if (diag_has_errors(diag)) {
+        diag_print_all(diag);
+        diag_print_summary(diag);
+        diag_destroy(diag);
         arena_destroy(arena);
         free(source);
         return 1;
@@ -248,6 +264,7 @@ int main(int argc, char **argv) {
     }
 
     codegen_destroy(&cg);
+    diag_destroy(diag);
     arena_destroy(arena);
     free(source);
     free(default_output);

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -36,20 +36,6 @@ static AstNode *parse_struct_literal(Parser *p, const char *name);
 
 /* --- Helpers --- */
 
-static void parser_error(Parser *p, const char *fmt, ...) {
-    char buf[512];
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(buf, sizeof(buf), fmt, args);
-    va_end(args);
-
-    if (p->error_count >= p->error_cap) {
-        p->error_cap = p->error_cap ? p->error_cap * 2 : 16;
-        p->errors = realloc(p->errors, sizeof(char *) * p->error_cap);
-    }
-    p->errors[p->error_count++] = arena_strdup(p->arena, buf);
-}
-
 static void next_token(Parser *p) {
     p->cur_token = p->peek_token;
     p->peek_token = lexer_next_token(p->lexer);
@@ -68,9 +54,11 @@ static bool expect_peek(Parser *p, TokenType t) {
         next_token(p);
         return true;
     }
-    parser_error(p, "%s:%d:%d: expected '%s', got '%s'",
-        p->file, p->peek_token.line, p->peek_token.column,
+    char buf[256];
+    snprintf(buf, sizeof(buf), "expected '%s', got '%s'",
         token_type_name(t), token_type_name(p->peek_token.type));
+    diag_error(p->diag, "E2001", arena_strdup(p->arena, buf),
+        p->file, p->peek_token.line, p->peek_token.column, 0);
     return false;
 }
 
@@ -188,7 +176,7 @@ static AstNode *parse_interpolated_string(Parser *p, const char *raw) {
 
             char *expr_text = arena_strndup(p->arena, expr_start, s - expr_start);
             Lexer *expr_lexer = lexer_create(p->arena, expr_text, p->file);
-            Parser *expr_parser = parser_create(p->arena, expr_lexer, p->file);
+            Parser *expr_parser = parser_create(p->arena, expr_lexer, p->file, p->diag);
             AstNode *expr = parse_expression(expr_parser, PREC_LOWEST);
             if (expr) parts[count++] = expr;
 
@@ -344,9 +332,13 @@ static AstNode *parse_prefix(Parser *p) {
         return node;
     }
     default:
-        parser_error(p, "%s:%d:%d: unexpected token '%s'",
-            p->file, p->cur_token.line, p->cur_token.column,
+    {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "unexpected token '%s'",
             token_type_name(p->cur_token.type));
+        diag_error(p->diag, "E2002", arena_strdup(p->arena, buf),
+            p->file, p->cur_token.line, p->cur_token.column, 0);
+    }
         return NULL;
     }
 }
@@ -1118,14 +1110,12 @@ static AstNode *parse_statement(Parser *p) {
 
 /* --- Public API --- */
 
-Parser *parser_create(Arena *arena, Lexer *lexer, const char *file) {
+Parser *parser_create(Arena *arena, Lexer *lexer, const char *file, DiagnosticList *diag) {
     Parser *p = arena_alloc(arena, sizeof(Parser));
     p->lexer = lexer;
     p->arena = arena;
     p->file = file;
-    p->errors = NULL;
-    p->error_count = 0;
-    p->error_cap = 0;
+    p->diag = diag;
 
     /* Read two tokens to fill cur and peek */
     next_token(p);
@@ -1164,12 +1154,3 @@ AstNode *parser_parse_program(Parser *p) {
     return program;
 }
 
-bool parser_has_errors(Parser *p) {
-    return p->error_count > 0;
-}
-
-void parser_print_errors(Parser *p) {
-    for (int i = 0; i < p->error_count; i++) {
-        fprintf(stderr, "error: %s\n", p->errors[i]);
-    }
-}

--- a/ezc/src/parser/parser.h
+++ b/ezc/src/parser/parser.h
@@ -11,6 +11,7 @@
 #include "ast.h"
 #include "../lexer/lexer.h"
 #include "../util/arena.h"
+#include "../util/error.h"
 
 typedef struct {
     Lexer *lexer;
@@ -18,16 +19,10 @@ typedef struct {
     Token cur_token;
     Token peek_token;
     const char *file;
-
-    /* Error tracking */
-    char **errors;
-    int error_count;
-    int error_cap;
+    DiagnosticList *diag;
 } Parser;
 
-Parser *parser_create(Arena *arena, Lexer *lexer, const char *file);
+Parser *parser_create(Arena *arena, Lexer *lexer, const char *file, DiagnosticList *diag);
 AstNode *parser_parse_program(Parser *p);
-bool parser_has_errors(Parser *p);
-void parser_print_errors(Parser *p);
 
 #endif

--- a/ezc/src/util/error.c
+++ b/ezc/src/util/error.c
@@ -1,0 +1,283 @@
+/*
+ * error.c - Compiler diagnostic system
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "error.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* --- ANSI color codes --- */
+
+#define COL_RESET   "\033[0m"
+#define COL_BOLD    "\033[1m"
+#define COL_RED     "\033[31m"
+#define COL_YELLOW  "\033[33m"
+#define COL_CYAN    "\033[36m"
+#define COL_BLUE    "\033[34m"
+#define COL_WHITE   "\033[37m"
+
+static const char *col(DiagnosticList *dl, const char *code) {
+    return dl->use_color ? code : "";
+}
+
+/* --- Source line reading --- */
+
+static const char *read_source_line(const char *source, int line_num) {
+    if (!source) return NULL;
+
+    int current_line = 1;
+    const char *line_start = source;
+
+    while (*line_start && current_line < line_num) {
+        if (*line_start == '\n') current_line++;
+        line_start++;
+    }
+
+    if (current_line != line_num) return NULL;
+
+    /* Find end of line */
+    const char *line_end = line_start;
+    while (*line_end && *line_end != '\n') line_end++;
+
+    /* Copy line to static buffer */
+    static char buf[1024];
+    int len = (int)(line_end - line_start);
+    if (len >= (int)sizeof(buf)) len = (int)sizeof(buf) - 1;
+    memcpy(buf, line_start, len);
+    buf[len] = '\0';
+    return buf;
+}
+
+static const char *read_file_to_string(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char *buf = malloc((size_t)size + 1);
+    if (!buf) { fclose(f); return NULL; }
+
+    size_t read = fread(buf, 1, (size_t)size, f);
+    buf[read] = '\0';
+    fclose(f);
+    return buf;
+}
+
+/* --- DiagnosticList management --- */
+
+DiagnosticList *diag_create(void) {
+    DiagnosticList *dl = calloc(1, sizeof(DiagnosticList));
+    dl->use_color = isatty(STDERR_FILENO);
+    return dl;
+}
+
+void diag_destroy(DiagnosticList *dl) {
+    free(dl->items);
+    /* cached_source is owned by caller, don't free it */
+    free(dl);
+}
+
+static void diag_add(DiagnosticList *dl, Severity sev, const char *code,
+    const char *message, const char *file, int line, int col_start,
+    int end_col, const char *help) {
+
+    if (dl->count >= dl->cap) {
+        dl->cap = dl->cap ? dl->cap * 2 : 16;
+        dl->items = realloc(dl->items, sizeof(Diagnostic) * dl->cap);
+    }
+
+    Diagnostic *d = &dl->items[dl->count++];
+    d->severity = sev;
+    d->code = code;
+    d->message = message;
+    d->file = file;
+    d->line = line;
+    d->column = col_start;
+    d->end_column = end_col;
+    d->source_line = NULL;
+    d->help = help;
+}
+
+void diag_error(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col_start, int end_col) {
+    diag_add(dl, SEV_ERROR, code, message, file, line, col_start, end_col, NULL);
+}
+
+void diag_error_help(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col_start, int end_col, const char *help) {
+    diag_add(dl, SEV_ERROR, code, message, file, line, col_start, end_col, help);
+}
+
+void diag_warning(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col_start, int end_col) {
+    diag_add(dl, SEV_WARNING, code, message, file, line, col_start, end_col, NULL);
+}
+
+void diag_warning_help(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col_start, int end_col, const char *help) {
+    diag_add(dl, SEV_WARNING, code, message, file, line, col_start, end_col, help);
+}
+
+void diag_note(DiagnosticList *dl, const char *message,
+    const char *file, int line, int col_start, int end_col) {
+    diag_add(dl, SEV_NOTE, NULL, message, file, line, col_start, end_col, NULL);
+}
+
+void diag_set_source(DiagnosticList *dl, const char *file, const char *source) {
+    dl->cached_file = file;
+    /* Don't free — source is owned by caller (main.c's read_file) */
+    dl->cached_source = source;
+}
+
+bool diag_has_errors(DiagnosticList *dl) {
+    for (int i = 0; i < dl->count; i++) {
+        if (dl->items[i].severity == SEV_ERROR) return true;
+    }
+    return false;
+}
+
+int diag_error_count(DiagnosticList *dl) {
+    int n = 0;
+    for (int i = 0; i < dl->count; i++) {
+        if (dl->items[i].severity == SEV_ERROR) n++;
+    }
+    return n;
+}
+
+int diag_warning_count(DiagnosticList *dl) {
+    int n = 0;
+    for (int i = 0; i < dl->count; i++) {
+        if (dl->items[i].severity == SEV_WARNING) n++;
+    }
+    return n;
+}
+
+/* --- Rendering --- */
+
+static void print_diagnostic(DiagnosticList *dl, Diagnostic *d) {
+    const char *sev_str;
+    const char *sev_color;
+
+    switch (d->severity) {
+    case SEV_ERROR:
+        sev_str = "error";
+        sev_color = COL_RED;
+        break;
+    case SEV_WARNING:
+        sev_str = "warning";
+        sev_color = COL_YELLOW;
+        break;
+    case SEV_NOTE:
+        sev_str = "note";
+        sev_color = COL_CYAN;
+        break;
+    }
+
+    /* Line 1: severity[code]: message */
+    fprintf(stderr, "%s%s%s%s", col(dl, COL_BOLD), col(dl, sev_color), sev_str, col(dl, COL_RESET));
+    if (d->code) {
+        fprintf(stderr, "%s%s[%s]%s", col(dl, COL_BOLD), col(dl, sev_color), d->code, col(dl, COL_RESET));
+    }
+    fprintf(stderr, "%s: %s%s\n", col(dl, COL_BOLD), d->message, col(dl, COL_RESET));
+
+    /* Line 2: --> file:line:column */
+    if (d->file && d->line > 0) {
+        fprintf(stderr, "  %s-->%s %s:%d:%d\n",
+            col(dl, COL_BLUE), col(dl, COL_RESET),
+            d->file, d->line, d->column);
+    }
+
+    /* Lines 3-4: source context with underline */
+    const char *src_line = d->source_line;
+    if (!src_line && dl->cached_source && d->file &&
+        dl->cached_file && strcmp(d->file, dl->cached_file) == 0) {
+        src_line = read_source_line(dl->cached_source, d->line);
+    }
+    if (!src_line && d->file) {
+        const char *file_content = read_file_to_string(d->file);
+        if (file_content) {
+            src_line = read_source_line(file_content, d->line);
+            free((void *)file_content);
+        }
+    }
+
+    if (src_line && d->line > 0) {
+        /* Line number gutter */
+        fprintf(stderr, "   %s|%s\n", col(dl, COL_BLUE), col(dl, COL_RESET));
+        fprintf(stderr, "%s%3d%s %s|%s %s\n",
+            col(dl, COL_BLUE), d->line, col(dl, COL_RESET),
+            col(dl, COL_BLUE), col(dl, COL_RESET),
+            src_line);
+
+        /* Underline */
+        int start = d->column > 0 ? d->column : 1;
+        int end = d->end_column > 0 ? d->end_column : start;
+        int span_len = end - start + 1;
+        if (span_len < 1) span_len = 1;
+
+        fprintf(stderr, "   %s|%s ", col(dl, COL_BLUE), col(dl, COL_RESET));
+        for (int i = 1; i < start; i++) {
+            fputc(' ', stderr);
+        }
+        fprintf(stderr, "%s%s", col(dl, COL_BOLD), col(dl, sev_color));
+        for (int i = 0; i < span_len; i++) {
+            fputc('^', stderr);
+        }
+        fprintf(stderr, "%s\n", col(dl, COL_RESET));
+    }
+
+    /* Help text */
+    if (d->help) {
+        fprintf(stderr, "   %s|%s\n", col(dl, COL_BLUE), col(dl, COL_RESET));
+        fprintf(stderr, "   %s=%s %shelp%s: %s\n",
+            col(dl, COL_BLUE), col(dl, COL_RESET),
+            col(dl, COL_CYAN), col(dl, COL_RESET),
+            d->help);
+    }
+
+    fprintf(stderr, "\n");
+}
+
+void diag_print_all(DiagnosticList *dl) {
+    for (int i = 0; i < dl->count; i++) {
+        print_diagnostic(dl, &dl->items[i]);
+    }
+}
+
+void diag_print_summary(DiagnosticList *dl) {
+    int errors = diag_error_count(dl);
+    int warnings = diag_warning_count(dl);
+
+    if (errors == 0 && warnings == 0) return;
+
+    fprintf(stderr, "%sezc:%s ", col(dl, COL_BOLD), col(dl, COL_RESET));
+
+    if (errors > 0) {
+        fprintf(stderr, "%s%s%d error%s%s",
+            col(dl, COL_BOLD), col(dl, COL_RED),
+            errors, errors == 1 ? "" : "s",
+            col(dl, COL_RESET));
+    }
+    if (errors > 0 && warnings > 0) {
+        fprintf(stderr, ", ");
+    }
+    if (warnings > 0) {
+        fprintf(stderr, "%s%s%d warning%s%s",
+            col(dl, COL_BOLD), col(dl, COL_YELLOW),
+            warnings, warnings == 1 ? "" : "s",
+            col(dl, COL_RESET));
+    }
+
+    if (errors > 0) {
+        fprintf(stderr, ". compilation failed.\n");
+    } else {
+        fprintf(stderr, "\n");
+    }
+}

--- a/ezc/src/util/error.h
+++ b/ezc/src/util/error.h
@@ -1,0 +1,81 @@
+/*
+ * error.h - Compiler diagnostic system
+ *
+ * Provides structured error/warning reporting with source context,
+ * span underlines, colored output, and help text.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_ERROR_H
+#define EZC_ERROR_H
+
+#include <stdbool.h>
+
+typedef enum {
+    SEV_ERROR,
+    SEV_WARNING,
+    SEV_NOTE,
+} Severity;
+
+typedef struct {
+    Severity severity;
+    const char *code;       /* "E3018", "W2001", etc. */
+    const char *message;    /* Primary error message */
+    const char *file;
+    int line;               /* 1-indexed */
+    int column;             /* 1-indexed start column */
+    int end_column;         /* 1-indexed end column (0 = same as column) */
+    const char *source_line;/* The actual source line (optional, will be read if NULL) */
+    const char *help;       /* Optional help/suggestion text */
+} Diagnostic;
+
+typedef struct {
+    Diagnostic *items;
+    int count;
+    int cap;
+
+    /* Source file cache for reading lines */
+    const char *cached_file;
+    const char *cached_source;
+
+    /* Options */
+    bool use_color;
+} DiagnosticList;
+
+/* Create/destroy */
+DiagnosticList *diag_create(void);
+void diag_destroy(DiagnosticList *dl);
+
+/* Add diagnostics */
+void diag_error(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col, int end_col);
+
+void diag_error_help(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col, int end_col, const char *help);
+
+void diag_warning(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col, int end_col);
+
+void diag_warning_help(DiagnosticList *dl, const char *code, const char *message,
+    const char *file, int line, int col, int end_col, const char *help);
+
+void diag_note(DiagnosticList *dl, const char *message,
+    const char *file, int line, int col, int end_col);
+
+/* Set the source text for a file (avoids re-reading from disk) */
+void diag_set_source(DiagnosticList *dl, const char *file, const char *source);
+
+/* Query */
+bool diag_has_errors(DiagnosticList *dl);
+int diag_error_count(DiagnosticList *dl);
+int diag_warning_count(DiagnosticList *dl);
+
+/* Render all diagnostics to stderr */
+void diag_print_all(DiagnosticList *dl);
+
+/* Print summary line: "ezc: 2 errors, 1 warning" */
+void diag_print_summary(DiagnosticList *dl);
+
+#endif


### PR DESCRIPTION
## Summary
Replaces the parser's basic string error list with a proper diagnostic system that renders Rust-style compiler messages with source context, span underlines, color, and help text.

### Before
```
error: examples/basic/control_flow.ez:67:5: unexpected token '#strict'
```

### After
```
error[E2002]: unexpected token '#strict'
  --> examples/basic/control_flow.ez:67:5
   |
 67 |     #strict
   |     ^

ezc: 1 error. compilation failed.
```

### Features
- Source line display with line number gutter
- Span underline with `^` carets (supports multi-char spans)
- Colored output: red (errors), yellow (warnings), cyan (help/notes)
- `--no-color` flag for CI and piped output
- Error/warning/note severity levels
- Error codes (`Exxxx`) on each diagnostic
- Optional help text field for suggestions
- Summary line: `ezc: 2 errors, 1 warning. compilation failed.`
- Source file caching (avoids re-reading files)
- DiagnosticList passed through parser (and future type checker)

## Test plan
- [x] Parse errors show source context with underline
- [x] `--no-color` strips ANSI codes
- [x] Multiple errors collected and displayed
- [x] Summary line shows correct counts
- [x] All 6 passing examples still compile and run
- [x] No double-free crash (source ownership fixed)