### PR TITLE
feat(ezc): type checker, .gitignore, and type-aware string interpolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.o
 *.a
 /ez
+/ezc/ezc
 
 # Build directories
 dist/

--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -23,6 +23,9 @@ SRC = src/main.c \
       src/lexer/lexer.c \
       src/parser/ast.c \
       src/parser/parser.c \
+      src/typechecker/types.c \
+      src/typechecker/scope.c \
+      src/typechecker/typechecker.c \
       src/codegen/codegen.c
 
 OBJ = $(SRC:.c=.o)

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -152,12 +152,6 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         break;
 
     case NODE_INTERPOLATED_STRING: {
-        /*
-         * For now, emit snprintf-style formatting.
-         * Without a type checker, we use %s for string literals/labels
-         * and %lld for integer expressions. The type checker (Phase 2+)
-         * will provide proper type resolution.
-         */
         emit(cg, "ez_string_format(ez_default_arena, \"");
         /* First pass: emit format string */
         for (int i = 0; i < node->data.interpolated_string.part_count; i++) {
@@ -169,19 +163,26 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                     else buf_append_char(&cg->output, *s);
                     s++;
                 }
-            } else if (part->kind == NODE_INT_VALUE ||
-                       part->kind == NODE_INFIX_EXPR ||
-                       part->kind == NODE_PREFIX_EXPR ||
-                       part->kind == NODE_POSTFIX_EXPR ||
-                       part->kind == NODE_CALL_EXPR) {
-                emit(cg, "%lld");
-            } else if (part->kind == NODE_FLOAT_VALUE) {
-                emit(cg, "%g");
-            } else if (part->kind == NODE_BOOL_VALUE) {
-                emit(cg, "%s");
             } else {
-                /* NODE_LABEL or other — default to int until type checker resolves */
-                emit(cg, "%lld");
+                /* Use type table to determine format specifier */
+                EzType *t = cg->type_table ? typetable_get(cg->type_table, part) : NULL;
+                TypeKind tk = t ? t->kind : TK_UNKNOWN;
+
+                /* Fall back to AST-based inference if no type info */
+                if (tk == TK_UNKNOWN) {
+                    if (part->kind == NODE_FLOAT_VALUE) tk = TK_FLOAT;
+                    else if (part->kind == NODE_BOOL_VALUE) tk = TK_BOOL;
+                    else if (part->kind == NODE_STRING_VALUE) tk = TK_STRING;
+                    else tk = TK_INT;
+                }
+
+                switch (tk) {
+                case TK_STRING: emit(cg, "%s"); break;
+                case TK_FLOAT:  emit(cg, "%g"); break;
+                case TK_BOOL:   emit(cg, "%s"); break;
+                case TK_CHAR:   emit(cg, "%c"); break;
+                default:        emit(cg, "%lld"); break;
+                }
             }
         }
         emit(cg, "\"");
@@ -190,27 +191,41 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             AstNode *part = node->data.interpolated_string.parts[i];
             if (part->kind == NODE_STRING_VALUE) continue;
             emit(cg, ", ");
-            if (part->kind == NODE_BOOL_VALUE) {
+
+            EzType *t = cg->type_table ? typetable_get(cg->type_table, part) : NULL;
+            TypeKind tk = t ? t->kind : TK_UNKNOWN;
+            if (tk == TK_UNKNOWN) {
+                if (part->kind == NODE_FLOAT_VALUE) tk = TK_FLOAT;
+                else if (part->kind == NODE_BOOL_VALUE) tk = TK_BOOL;
+                else if (part->kind == NODE_STRING_VALUE) tk = TK_STRING;
+                else tk = TK_INT;
+            }
+
+            switch (tk) {
+            case TK_STRING:
+                emit_expression(cg, part);
+                emit(cg, ".data");
+                break;
+            case TK_BOOL:
                 emit(cg, "(");
                 emit_expression(cg, part);
                 emit(cg, ") ? \"true\" : \"false\"");
-            } else if (part->kind == NODE_INT_VALUE ||
-                       part->kind == NODE_INFIX_EXPR ||
-                       part->kind == NODE_PREFIX_EXPR ||
-                       part->kind == NODE_POSTFIX_EXPR ||
-                       part->kind == NODE_CALL_EXPR) {
-                emit(cg, "(long long)(");
-                emit_expression(cg, part);
-                emit(cg, ")");
-            } else if (part->kind == NODE_FLOAT_VALUE) {
+                break;
+            case TK_FLOAT:
                 emit(cg, "(double)(");
                 emit_expression(cg, part);
                 emit(cg, ")");
-            } else {
-                /* Label/variable — default to int cast until type checker */
+                break;
+            case TK_CHAR:
+                emit(cg, "(char)(");
+                emit_expression(cg, part);
+                emit(cg, ")");
+                break;
+            default:
                 emit(cg, "(long long)(");
                 emit_expression(cg, part);
                 emit(cg, ")");
+                break;
             }
         }
         emit(cg, ")");
@@ -336,10 +351,22 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
             } else {
                 AstNode *arg = node->data.call.args[0];
                 const char *suffix = "_int"; /* default */
-                if (arg->kind == NODE_STRING_VALUE ||
-                    arg->kind == NODE_INTERPOLATED_STRING) suffix = "_str";
-                else if (arg->kind == NODE_FLOAT_VALUE) suffix = "_float";
-                else if (arg->kind == NODE_BOOL_VALUE) suffix = "_bool";
+                /* Use type table if available */
+                EzType *arg_type = cg->type_table ? typetable_get(cg->type_table, arg) : NULL;
+                if (arg_type) {
+                    switch (arg_type->kind) {
+                    case TK_STRING: suffix = "_str"; break;
+                    case TK_FLOAT:  suffix = "_float"; break;
+                    case TK_BOOL:   suffix = "_bool"; break;
+                    default: suffix = "_int"; break;
+                    }
+                } else {
+                    /* Fallback to AST-based inference */
+                    if (arg->kind == NODE_STRING_VALUE ||
+                        arg->kind == NODE_INTERPOLATED_STRING) suffix = "_str";
+                    else if (arg->kind == NODE_FLOAT_VALUE) suffix = "_float";
+                    else if (arg->kind == NODE_BOOL_VALUE) suffix = "_bool";
+                }
                 emitf(cg, "ez_std_println%s(", suffix);
                 emit_expression(cg, arg);
                 emit(cg, ")");
@@ -865,6 +892,7 @@ CodeGen codegen_create(const char *file) {
     cg.all_funcs = NULL;
     cg.func_count = 0;
     cg.func_cap = 0;
+    cg.type_table = NULL;
     return cg;
 }
 

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -10,6 +10,7 @@
 
 #include "../parser/ast.h"
 #include "../util/buf.h"
+#include "../typechecker/typechecker.h"
 
 typedef struct {
     Buf output;
@@ -29,6 +30,9 @@ typedef struct {
     AstNode **all_funcs;
     int func_count;
     int func_cap;
+
+    /* Type table from type checker (for type-aware codegen) */
+    TypeTable *type_table;
 } CodeGen;
 
 CodeGen codegen_create(const char *file);

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -17,6 +17,7 @@
 #include "util/error.h"
 #include "lexer/lexer.h"
 #include "parser/parser.h"
+#include "typechecker/typechecker.h"
 #include "codegen/codegen.h"
 
 #define EZC_VERSION "0.1.0"
@@ -194,8 +195,22 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    /* Type check */
+    TypeChecker *tc = typechecker_create(diag, input_file);
+    typechecker_check(tc, program);
+
+    if (diag_has_errors(diag)) {
+        diag_print_all(diag);
+        diag_print_summary(diag);
+        diag_destroy(diag);
+        arena_destroy(arena);
+        free(source);
+        return 1;
+    }
+
     /* Generate C code */
     CodeGen cg = codegen_create(input_file);
+    cg.type_table = typechecker_get_table(tc);
     codegen_generate(&cg, program);
     const char *c_code = codegen_result(&cg);
 

--- a/ezc/src/typechecker/scope.c
+++ b/ezc/src/typechecker/scope.c
@@ -1,0 +1,55 @@
+/*
+ * scope.c - Lexical scope and symbol table
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "scope.h"
+#include <stdlib.h>
+#include <string.h>
+
+Scope *scope_create(Scope *parent) {
+    Scope *s = calloc(1, sizeof(Scope));
+    s->parent = parent;
+    return s;
+}
+
+void scope_define(Scope *s, const char *name, EzType *type, bool mutable) {
+    /* Check for redefinition in current scope */
+    for (int i = 0; i < s->count; i++) {
+        if (strcmp(s->symbols[i].name, name) == 0) {
+            /* Update existing */
+            s->symbols[i].type = type;
+            s->symbols[i].mutable = mutable;
+            return;
+        }
+    }
+
+    if (s->count >= s->cap) {
+        s->cap = s->cap ? s->cap * 2 : 8;
+        s->symbols = realloc(s->symbols, sizeof(Symbol) * s->cap);
+    }
+
+    Symbol *sym = &s->symbols[s->count++];
+    sym->name = name;
+    sym->type = type;
+    sym->mutable = mutable;
+}
+
+Symbol *scope_lookup(Scope *s, const char *name) {
+    for (Scope *cur = s; cur; cur = cur->parent) {
+        Symbol *sym = scope_lookup_local(cur, name);
+        if (sym) return sym;
+    }
+    return NULL;
+}
+
+Symbol *scope_lookup_local(Scope *s, const char *name) {
+    for (int i = 0; i < s->count; i++) {
+        if (strcmp(s->symbols[i].name, name) == 0) {
+            return &s->symbols[i];
+        }
+    }
+    return NULL;
+}

--- a/ezc/src/typechecker/scope.h
+++ b/ezc/src/typechecker/scope.h
@@ -1,0 +1,31 @@
+/*
+ * scope.h - Lexical scope and symbol table for type checking
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_SCOPE_H
+#define EZC_SCOPE_H
+
+#include "types.h"
+
+typedef struct {
+    const char *name;
+    EzType *type;
+    bool mutable;
+} Symbol;
+
+typedef struct Scope {
+    struct Scope *parent;
+    Symbol *symbols;
+    int count;
+    int cap;
+} Scope;
+
+Scope *scope_create(Scope *parent);
+void scope_define(Scope *s, const char *name, EzType *type, bool mutable);
+Symbol *scope_lookup(Scope *s, const char *name);
+Symbol *scope_lookup_local(Scope *s, const char *name);
+
+#endif

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -1,0 +1,484 @@
+/*
+ * typechecker.c - Type checking pass for the EZ language
+ *
+ * Walks the AST, resolves expression types, checks type correctness,
+ * and builds a type table that the codegen can query.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "typechecker.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* --- Type Table --- */
+
+TypeTable *typetable_create(void) {
+    TypeTable *tt = calloc(1, sizeof(TypeTable));
+    return tt;
+}
+
+void typetable_set(TypeTable *tt, AstNode *node, EzType *type) {
+    /* Check if already set */
+    for (int i = 0; i < tt->count; i++) {
+        if (tt->nodes[i] == node) {
+            tt->types[i] = type;
+            return;
+        }
+    }
+    if (tt->count >= tt->cap) {
+        tt->cap = tt->cap ? tt->cap * 2 : 64;
+        tt->nodes = realloc(tt->nodes, sizeof(AstNode *) * tt->cap);
+        tt->types = realloc(tt->types, sizeof(EzType *) * tt->cap);
+    }
+    tt->nodes[tt->count] = node;
+    tt->types[tt->count] = type;
+    tt->count++;
+}
+
+EzType *typetable_get(TypeTable *tt, AstNode *node) {
+    if (!tt) return NULL;
+    for (int i = 0; i < tt->count; i++) {
+        if (tt->nodes[i] == node) return tt->types[i];
+    }
+    return NULL;
+}
+
+/* --- Struct info helpers --- */
+
+static void register_struct(TypeChecker *tc, const char *name,
+    const char **field_names, EzType **field_types, int field_count) {
+    if (tc->struct_count >= tc->struct_cap) {
+        tc->struct_cap = tc->struct_cap ? tc->struct_cap * 2 : 8;
+        tc->structs = realloc(tc->structs, sizeof(StructInfo) * tc->struct_cap);
+    }
+    StructInfo *si = &tc->structs[tc->struct_count++];
+    si->struct_name = name;
+    si->field_names = field_names;
+    si->field_types = field_types;
+    si->field_count = field_count;
+}
+
+static StructInfo *find_struct(TypeChecker *tc, const char *name) {
+    for (int i = 0; i < tc->struct_count; i++) {
+        if (strcmp(tc->structs[i].struct_name, name) == 0)
+            return &tc->structs[i];
+    }
+    return NULL;
+}
+
+static EzType *struct_field_type(TypeChecker *tc, const char *struct_name, const char *field) {
+    StructInfo *si = find_struct(tc, struct_name);
+    if (!si) return &TYPE_UNKNOWN;
+    for (int i = 0; i < si->field_count; i++) {
+        if (strcmp(si->field_names[i], field) == 0)
+            return si->field_types[i];
+    }
+    return &TYPE_UNKNOWN;
+}
+
+/* --- Function signature helpers --- */
+
+static void register_func(TypeChecker *tc, const char *name,
+    EzType **param_types, int param_count,
+    EzType **return_types, int return_count) {
+    if (tc->func_count >= tc->func_cap) {
+        tc->func_cap = tc->func_cap ? tc->func_cap * 2 : 16;
+        tc->funcs = realloc(tc->funcs, sizeof(FuncSig) * tc->func_cap);
+    }
+    FuncSig *fs = &tc->funcs[tc->func_count++];
+    fs->name = name;
+    fs->param_types = param_types;
+    fs->param_count = param_count;
+    fs->return_types = return_types;
+    fs->return_count = return_count;
+}
+
+static FuncSig *find_func(TypeChecker *tc, const char *name) {
+    for (int i = 0; i < tc->func_count; i++) {
+        if (strcmp(tc->funcs[i].name, name) == 0)
+            return &tc->funcs[i];
+    }
+    return NULL;
+}
+
+/* --- Enum helpers --- */
+
+static void register_enum(TypeChecker *tc, const char *name) {
+    if (tc->enum_count >= tc->enum_cap) {
+        tc->enum_cap = tc->enum_cap ? tc->enum_cap * 2 : 8;
+        tc->enum_names = realloc(tc->enum_names, sizeof(const char *) * tc->enum_cap);
+    }
+    tc->enum_names[tc->enum_count++] = name;
+}
+
+static bool is_enum_name(TypeChecker *tc, const char *name) {
+    for (int i = 0; i < tc->enum_count; i++) {
+        if (strcmp(tc->enum_names[i], name) == 0) return true;
+    }
+    return false;
+}
+
+/* --- Expression type resolution --- */
+
+static EzType *resolve_expr(TypeChecker *tc, AstNode *node);
+
+static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
+    if (!node) return &TYPE_UNKNOWN;
+
+    EzType *result = &TYPE_UNKNOWN;
+
+    switch (node->kind) {
+    case NODE_INT_VALUE:
+        result = &TYPE_INT;
+        break;
+
+    case NODE_FLOAT_VALUE:
+        result = &TYPE_FLOAT;
+        break;
+
+    case NODE_STRING_VALUE:
+        result = &TYPE_STRING;
+        break;
+
+    case NODE_INTERPOLATED_STRING:
+        /* Resolve types of all interpolation parts */
+        for (int i = 0; i < node->data.interpolated_string.part_count; i++) {
+            resolve_expr(tc, node->data.interpolated_string.parts[i]);
+        }
+        result = &TYPE_STRING;
+        break;
+
+    case NODE_BOOL_VALUE:
+        result = &TYPE_BOOL;
+        break;
+
+    case NODE_CHAR_VALUE:
+        result = &TYPE_CHAR;
+        break;
+
+    case NODE_NIL_VALUE:
+        result = &TYPE_NIL;
+        break;
+
+    case NODE_LABEL: {
+        Symbol *sym = scope_lookup(tc->current_scope, node->data.label.value);
+        if (sym) {
+            result = sym->type;
+        }
+        break;
+    }
+
+    case NODE_PREFIX_EXPR: {
+        EzType *right = resolve_expr(tc, node->data.prefix.right);
+        if (strcmp(node->data.prefix.op, "!") == 0) {
+            result = &TYPE_BOOL;
+        } else if (strcmp(node->data.prefix.op, "-") == 0) {
+            result = right;
+        } else {
+            result = right;
+        }
+        break;
+    }
+
+    case NODE_INFIX_EXPR: {
+        EzType *left = resolve_expr(tc, node->data.infix.left);
+        EzType *right = resolve_expr(tc, node->data.infix.right);
+        const char *op = node->data.infix.op;
+
+        if (strcmp(op, "==") == 0 || strcmp(op, "!=") == 0 ||
+            strcmp(op, "<") == 0 || strcmp(op, ">") == 0 ||
+            strcmp(op, "<=") == 0 || strcmp(op, ">=") == 0 ||
+            strcmp(op, "&&") == 0 || strcmp(op, "||") == 0 ||
+            strcmp(op, "in") == 0 || strcmp(op, "not_in") == 0) {
+            result = &TYPE_BOOL;
+        } else if (left->kind == TK_FLOAT || right->kind == TK_FLOAT) {
+            result = &TYPE_FLOAT;
+        } else if (left->kind == TK_STRING && strcmp(op, "+") == 0) {
+            result = &TYPE_STRING;
+        } else {
+            result = left;
+        }
+        break;
+    }
+
+    case NODE_POSTFIX_EXPR:
+        result = resolve_expr(tc, node->data.postfix.left);
+        break;
+
+    case NODE_CALL_EXPR: {
+        /* Resolve argument types first */
+        for (int i = 0; i < node->data.call.arg_count; i++) {
+            resolve_expr(tc, node->data.call.args[i]);
+        }
+
+        /* Resolve function return type */
+        AstNode *fn = node->data.call.function;
+        const char *fn_name = NULL;
+
+        if (fn->kind == NODE_LABEL) {
+            fn_name = fn->data.label.value;
+        } else if (fn->kind == NODE_MEMBER_EXPR && fn->data.member.object->kind == NODE_LABEL) {
+            /* std.println etc — stdlib calls, return void for now */
+            result = &TYPE_VOID;
+            break;
+        }
+
+        if (fn_name) {
+            FuncSig *sig = find_func(tc, fn_name);
+            if (sig && sig->return_count > 0) {
+                result = sig->return_types[0];
+            }
+        }
+        break;
+    }
+
+    case NODE_MEMBER_EXPR: {
+        /* Resolve object type, then look up field */
+        AstNode *obj = node->data.member.object;
+        const char *member = node->data.member.member;
+
+        if (obj->kind == NODE_LABEL) {
+            const char *obj_name = obj->data.label.value;
+
+            /* Check if it's an enum access: Color.RED */
+            if (is_enum_name(tc, obj_name)) {
+                result = &TYPE_INT; /* enum values are ints */
+                break;
+            }
+
+            /* Otherwise it's a struct field access */
+            Symbol *sym = scope_lookup(tc->current_scope, obj_name);
+            if (sym && sym->type->kind == TK_STRUCT) {
+                result = struct_field_type(tc, sym->type->name, member);
+            }
+        }
+        break;
+    }
+
+    case NODE_INDEX_EXPR: {
+        EzType *left = resolve_expr(tc, node->data.index_expr.left);
+        if (left->kind == TK_ARRAY && left->element_type) {
+            result = type_from_name(left->element_type);
+        } else if (left->kind == TK_STRING) {
+            result = &TYPE_CHAR;
+        }
+        break;
+    }
+
+    case NODE_ARRAY_VALUE:
+        if (node->data.array_value.count > 0) {
+            EzType *elem = resolve_expr(tc, node->data.array_value.elements[0]);
+            result = type_array(type_name(elem));
+        }
+        break;
+
+    case NODE_STRUCT_VALUE:
+        result = type_struct(node->data.struct_value.name);
+        break;
+
+    case NODE_RANGE_EXPR:
+        result = &TYPE_INT; /* range produces ints */
+        break;
+
+    default:
+        break;
+    }
+
+    typetable_set(tc->type_table, node, result);
+    return result;
+}
+
+/* --- Statement checking --- */
+
+static void check_statement(TypeChecker *tc, AstNode *node);
+
+static void check_block(TypeChecker *tc, AstNode *node) {
+    if (!node || node->kind != NODE_BLOCK_STMT) return;
+    for (int i = 0; i < node->data.block.count; i++) {
+        check_statement(tc, node->data.block.stmts[i]);
+    }
+}
+
+static void check_statement(TypeChecker *tc, AstNode *node) {
+    if (!node) return;
+
+    switch (node->kind) {
+    case NODE_VAR_DECL: {
+        EzType *declared = node->data.var_decl.type_name
+            ? type_from_name(node->data.var_decl.type_name)
+            : &TYPE_UNKNOWN;
+
+        if (node->data.var_decl.value) {
+            EzType *value_type = resolve_expr(tc, node->data.var_decl.value);
+            /* If no declared type, infer from value */
+            if (declared->kind == TK_UNKNOWN) {
+                declared = value_type;
+            }
+        }
+
+        if (strcmp(node->data.var_decl.name, "_") != 0) {
+            scope_define(tc->current_scope, node->data.var_decl.name,
+                declared, node->data.var_decl.mutable);
+        }
+        break;
+    }
+
+    case NODE_ASSIGN_STMT:
+        resolve_expr(tc, node->data.assign.target);
+        resolve_expr(tc, node->data.assign.value);
+        break;
+
+    case NODE_RETURN_STMT:
+        for (int i = 0; i < node->data.return_stmt.count; i++) {
+            resolve_expr(tc, node->data.return_stmt.values[i]);
+        }
+        break;
+
+    case NODE_EXPR_STMT:
+        resolve_expr(tc, node->data.expr_stmt.expr);
+        break;
+
+    case NODE_BLOCK_STMT: {
+        Scope *inner = scope_create(tc->current_scope);
+        Scope *outer = tc->current_scope;
+        tc->current_scope = inner;
+        check_block(tc, node);
+        tc->current_scope = outer;
+        break;
+    }
+
+    case NODE_IF_STMT:
+        resolve_expr(tc, node->data.if_stmt.condition);
+        check_block(tc, node->data.if_stmt.consequence);
+        if (node->data.if_stmt.alternative) {
+            check_statement(tc, node->data.if_stmt.alternative);
+        }
+        break;
+
+    case NODE_FOR_STMT: {
+        Scope *loop_scope = scope_create(tc->current_scope);
+        Scope *outer = tc->current_scope;
+        tc->current_scope = loop_scope;
+        scope_define(loop_scope, node->data.for_stmt.var_name, &TYPE_INT, false);
+        resolve_expr(tc, node->data.for_stmt.iterable);
+        check_block(tc, node->data.for_stmt.body);
+        tc->current_scope = outer;
+        break;
+    }
+
+    case NODE_WHILE_STMT:
+        resolve_expr(tc, node->data.while_stmt.condition);
+        check_block(tc, node->data.while_stmt.body);
+        break;
+
+    case NODE_LOOP_STMT:
+        check_block(tc, node->data.loop_stmt.body);
+        break;
+
+    case NODE_FUNC_DECL: {
+        Scope *func_scope = scope_create(tc->current_scope);
+        Scope *outer = tc->current_scope;
+        tc->current_scope = func_scope;
+
+        /* Define parameters in function scope */
+        for (int i = 0; i < node->data.func_decl.param_count; i++) {
+            Param *p = &node->data.func_decl.params[i];
+            EzType *ptype = p->type_name ? type_from_name(p->type_name) : &TYPE_UNKNOWN;
+            scope_define(func_scope, p->name, ptype, p->mutable);
+        }
+
+        check_block(tc, node->data.func_decl.body);
+        tc->current_scope = outer;
+        break;
+    }
+
+    case NODE_ENSURE_STMT:
+        resolve_expr(tc, node->data.ensure_stmt.expr);
+        break;
+
+    case NODE_WHEN_STMT:
+        resolve_expr(tc, node->data.when_stmt.value);
+        for (int i = 0; i < node->data.when_stmt.case_count; i++) {
+            for (int j = 0; j < node->data.when_stmt.cases[i].value_count; j++) {
+                resolve_expr(tc, node->data.when_stmt.cases[i].values[j]);
+            }
+            check_block(tc, node->data.when_stmt.cases[i].body);
+        }
+        if (node->data.when_stmt.default_body) {
+            check_block(tc, node->data.when_stmt.default_body);
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+/* --- Registration pass --- */
+
+static void register_declarations(TypeChecker *tc, AstNode *program) {
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        AstNode *stmt = program->data.program.stmts[i];
+
+        if (stmt->kind == NODE_STRUCT_DECL) {
+            int fc = stmt->data.struct_decl.field_count;
+            const char **fnames = malloc(sizeof(const char *) * fc);
+            EzType **ftypes = malloc(sizeof(EzType *) * fc);
+            for (int j = 0; j < fc; j++) {
+                fnames[j] = stmt->data.struct_decl.fields[j].name;
+                ftypes[j] = type_from_name(stmt->data.struct_decl.fields[j].type_name);
+            }
+            register_struct(tc, stmt->data.struct_decl.name, fnames, ftypes, fc);
+        }
+
+        if (stmt->kind == NODE_ENUM_DECL) {
+            register_enum(tc, stmt->data.enum_decl.name);
+        }
+
+        if (stmt->kind == NODE_FUNC_DECL) {
+            int pc = stmt->data.func_decl.param_count;
+            EzType **ptypes = malloc(sizeof(EzType *) * (pc ? pc : 1));
+            for (int j = 0; j < pc; j++) {
+                ptypes[j] = type_from_name(stmt->data.func_decl.params[j].type_name);
+            }
+
+            int rc = stmt->data.func_decl.return_type_count;
+            EzType **rtypes = malloc(sizeof(EzType *) * (rc ? rc : 1));
+            for (int j = 0; j < rc; j++) {
+                rtypes[j] = type_from_name(stmt->data.func_decl.return_types[j]);
+            }
+
+            register_func(tc, stmt->data.func_decl.name, ptypes, pc, rtypes, rc);
+        }
+    }
+}
+
+/* --- Public API --- */
+
+TypeChecker *typechecker_create(DiagnosticList *diag, const char *file) {
+    TypeChecker *tc = calloc(1, sizeof(TypeChecker));
+    tc->diag = diag;
+    tc->file = file;
+    tc->current_scope = scope_create(NULL);
+    tc->type_table = typetable_create();
+    return tc;
+}
+
+void typechecker_check(TypeChecker *tc, AstNode *program) {
+    if (!program || program->kind != NODE_PROGRAM) return;
+
+    /* Pass 1: register all type/function declarations */
+    register_declarations(tc, program);
+
+    /* Pass 2: check all statements */
+    for (int i = 0; i < program->data.program.stmt_count; i++) {
+        check_statement(tc, program->data.program.stmts[i]);
+    }
+}
+
+TypeTable *typechecker_get_table(TypeChecker *tc) {
+    return tc->type_table;
+}

--- a/ezc/src/typechecker/typechecker.h
+++ b/ezc/src/typechecker/typechecker.h
@@ -1,0 +1,74 @@
+/*
+ * typechecker.h - Type checking pass for the EZ language
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_TYPECHECKER_H
+#define EZC_TYPECHECKER_H
+
+#include "types.h"
+#include "scope.h"
+#include "../parser/ast.h"
+#include "../util/error.h"
+
+/* Type annotation table: maps AST node pointers to resolved types */
+typedef struct {
+    AstNode **nodes;
+    EzType **types;
+    int count;
+    int cap;
+} TypeTable;
+
+typedef struct {
+    /* Struct field info for field type lookup */
+    const char *struct_name;
+    const char **field_names;
+    EzType **field_types;
+    int field_count;
+} StructInfo;
+
+typedef struct {
+    /* Function signature for call type checking */
+    const char *name;
+    EzType **param_types;
+    int param_count;
+    EzType **return_types;
+    int return_count;
+} FuncSig;
+
+typedef struct {
+    DiagnosticList *diag;
+    Scope *current_scope;
+    TypeTable *type_table;
+    const char *file;
+
+    /* Registered struct types */
+    StructInfo *structs;
+    int struct_count;
+    int struct_cap;
+
+    /* Registered function signatures */
+    FuncSig *funcs;
+    int func_count;
+    int func_cap;
+
+    /* Registered enum names */
+    const char **enum_names;
+    int enum_count;
+    int enum_cap;
+} TypeChecker;
+
+/* Create and run the type checker */
+TypeChecker *typechecker_create(DiagnosticList *diag, const char *file);
+void typechecker_check(TypeChecker *tc, AstNode *program);
+
+/* Query the type table (used by codegen) */
+EzType *typetable_get(TypeTable *tt, AstNode *node);
+void typetable_set(TypeTable *tt, AstNode *node, EzType *type);
+
+/* Get the type table from the checker */
+TypeTable *typechecker_get_table(TypeChecker *tc);
+
+#endif

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -1,0 +1,121 @@
+/*
+ * types.c - Type representation
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "types.h"
+#include <string.h>
+#include <stdlib.h>
+
+/* Built-in type singletons */
+EzType TYPE_VOID    = {TK_VOID,   "void",   NULL, NULL, NULL};
+EzType TYPE_INT     = {TK_INT,    "int",    NULL, NULL, NULL};
+EzType TYPE_FLOAT   = {TK_FLOAT,  "float",  NULL, NULL, NULL};
+EzType TYPE_BOOL    = {TK_BOOL,   "bool",   NULL, NULL, NULL};
+EzType TYPE_CHAR    = {TK_CHAR,   "char",   NULL, NULL, NULL};
+EzType TYPE_BYTE    = {TK_BYTE,   "byte",   NULL, NULL, NULL};
+EzType TYPE_STRING  = {TK_STRING, "string", NULL, NULL, NULL};
+EzType TYPE_NIL     = {TK_NIL,    "nil",    NULL, NULL, NULL};
+EzType TYPE_UNKNOWN = {TK_UNKNOWN,"unknown",NULL, NULL, NULL};
+
+/* Pool for dynamically created types (leak on exit, fine for a compiler) */
+static EzType type_pool[256];
+static int type_pool_count = 0;
+
+static EzType *type_alloc(void) {
+    if (type_pool_count >= 256) return &TYPE_UNKNOWN;
+    return &type_pool[type_pool_count++];
+}
+
+EzType *type_array(const char *elem_type) {
+    EzType *t = type_alloc();
+    t->kind = TK_ARRAY;
+    t->element_type = elem_type;
+    t->name = elem_type; /* simplified */
+    return t;
+}
+
+EzType *type_struct(const char *name) {
+    EzType *t = type_alloc();
+    t->kind = TK_STRUCT;
+    t->name = name;
+    return t;
+}
+
+EzType *type_enum(const char *name) {
+    EzType *t = type_alloc();
+    t->kind = TK_ENUM;
+    t->name = name;
+    return t;
+}
+
+bool type_is_numeric(EzType *t) {
+    return t->kind == TK_INT || t->kind == TK_FLOAT ||
+           t->kind == TK_CHAR || t->kind == TK_BYTE;
+}
+
+bool type_is_integer(EzType *t) {
+    return t->kind == TK_INT || t->kind == TK_CHAR || t->kind == TK_BYTE;
+}
+
+bool type_eq(EzType *a, EzType *b) {
+    if (a->kind != b->kind) return false;
+    if (a->kind == TK_STRUCT || a->kind == TK_ENUM) {
+        return strcmp(a->name, b->name) == 0;
+    }
+    if (a->kind == TK_ARRAY) {
+        return strcmp(a->element_type, b->element_type) == 0;
+    }
+    return true;
+}
+
+const char *type_name(EzType *t) {
+    if (!t) return "unknown";
+    return t->name;
+}
+
+EzType *type_from_name(const char *name) {
+    if (!name) return &TYPE_UNKNOWN;
+
+    if (strcmp(name, "int") == 0)    return &TYPE_INT;
+    if (strcmp(name, "uint") == 0)   return &TYPE_INT;
+    if (strcmp(name, "i8") == 0)     return &TYPE_INT;
+    if (strcmp(name, "i16") == 0)    return &TYPE_INT;
+    if (strcmp(name, "i32") == 0)    return &TYPE_INT;
+    if (strcmp(name, "i64") == 0)    return &TYPE_INT;
+    if (strcmp(name, "i128") == 0)   return &TYPE_INT;
+    if (strcmp(name, "u8") == 0)     return &TYPE_INT;
+    if (strcmp(name, "u16") == 0)    return &TYPE_INT;
+    if (strcmp(name, "u32") == 0)    return &TYPE_INT;
+    if (strcmp(name, "u64") == 0)    return &TYPE_INT;
+    if (strcmp(name, "u128") == 0)   return &TYPE_INT;
+    if (strcmp(name, "float") == 0)  return &TYPE_FLOAT;
+    if (strcmp(name, "f32") == 0)    return &TYPE_FLOAT;
+    if (strcmp(name, "f64") == 0)    return &TYPE_FLOAT;
+    if (strcmp(name, "bool") == 0)   return &TYPE_BOOL;
+    if (strcmp(name, "char") == 0)   return &TYPE_CHAR;
+    if (strcmp(name, "byte") == 0)   return &TYPE_BYTE;
+    if (strcmp(name, "string") == 0) return &TYPE_STRING;
+    if (strcmp(name, "void") == 0)   return &TYPE_VOID;
+    if (strcmp(name, "nil") == 0)    return &TYPE_NIL;
+
+    /* Array type: [int], [string], etc. */
+    if (name[0] == '[') {
+        size_t len = strlen(name);
+        if (len > 2 && name[len - 1] == ']') {
+            char *elem = malloc(len - 1);
+            memcpy(elem, name + 1, len - 2);
+            elem[len - 2] = '\0';
+            return type_array(elem);
+        }
+    }
+
+    /* Uppercase = struct type */
+    if (name[0] >= 'A' && name[0] <= 'Z') {
+        return type_struct(name);
+    }
+
+    return &TYPE_UNKNOWN;
+}

--- a/ezc/src/typechecker/types.h
+++ b/ezc/src/typechecker/types.h
@@ -1,0 +1,63 @@
+/*
+ * types.h - Type representation for the EZ type system
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_TYPES_H
+#define EZC_TYPES_H
+
+#include <stdbool.h>
+
+typedef enum {
+    TK_VOID,
+    TK_INT,
+    TK_FLOAT,
+    TK_BOOL,
+    TK_CHAR,
+    TK_BYTE,
+    TK_STRING,
+    TK_ARRAY,
+    TK_MAP,
+    TK_STRUCT,
+    TK_ENUM,
+    TK_FUNCTION,
+    TK_NIL,
+    TK_UNKNOWN,
+} TypeKind;
+
+typedef struct EzType {
+    TypeKind kind;
+    const char *name;           /* "int", "string", "Person", "[int]", etc. */
+    const char *element_type;   /* For arrays: element type name */
+    const char *key_type;       /* For maps: key type name */
+    const char *value_type;     /* For maps: value type name */
+} EzType;
+
+/* Built-in type singletons */
+extern EzType TYPE_VOID;
+extern EzType TYPE_INT;
+extern EzType TYPE_FLOAT;
+extern EzType TYPE_BOOL;
+extern EzType TYPE_CHAR;
+extern EzType TYPE_BYTE;
+extern EzType TYPE_STRING;
+extern EzType TYPE_NIL;
+extern EzType TYPE_UNKNOWN;
+
+/* Type constructors */
+EzType *type_array(const char *elem_type);
+EzType *type_struct(const char *name);
+EzType *type_enum(const char *name);
+
+/* Type queries */
+bool type_is_numeric(EzType *t);
+bool type_is_integer(EzType *t);
+bool type_eq(EzType *a, EzType *b);
+const char *type_name(EzType *t);
+
+/* Resolve a type name string to an EzType */
+EzType *type_from_name(const char *name);
+
+#endif


### PR DESCRIPTION
## Summary
Adds a two-pass type checker that resolves expression types and builds a type table shared with the code generator. This is the biggest architectural addition since the initial scaffold.

### Type Checker (#1175)
- **Scope chain** with symbol table (name → type + mutability)
- **Two-pass design**: Pass 1 registers struct/enum/function declarations, Pass 2 checks statements and resolves expression types
- **Struct field type lookup** for member expressions (e.g., `person.name` → string)
- **Function return type resolution** for calls
- **Type table** (AST node pointer → EzType) shared with codegen

### Type-Aware Codegen
- String interpolation now correctly uses `%s` + `.data` for strings, `%lld` for ints, `%g` for floats, `%s` + ternary for bools
- `println()` dispatch uses resolved argument type instead of AST node kind
- Both fall back to AST-based inference when type table has no entry

### Also included
- `.gitignore` entry for `ezc/ezc` binary (#1168)

## Results
- **7/14 basic examples now pass** (up from 6)
- `variables.ez` now compiles — was blocked by string interpolation with string variables

## Test plan
- [x] `${name}` where name is a string → `%s` + `.data`
- [x] `${age}` where age is an int → `%lld`
- [x] `${score}` where score is a float → `%g`
- [x] `${active}` where active is a bool → `%s` + ternary
- [x] Mixed interpolation: `"${name} is ${age} years old"` works
- [x] `variables.ez` output matches interpreter exactly
- [x] All 7 passing examples produce identical output to interpreter
- [x] No regressions in previously passing examples