### PR TITLE
feat(ezc): builtins, multi-var fixes, named returns, struct field arrays

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -374,6 +374,46 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
             return;
         }
 
+        if (strcmp(func, "len") == 0 && node->data.call.arg_count == 1) {
+            AstNode *arg = node->data.call.args[0];
+            EzType *t = cg->type_table ? typetable_get(cg->type_table, arg) : NULL;
+            if (t && t->kind == TK_STRING) {
+                emit(cg, "(int64_t)(");
+                emit_expression(cg, arg);
+                emit(cg, ").len");
+            } else if (t && t->kind == TK_ARRAY) {
+                emit_expression(cg, arg);
+                emit(cg, "_len");
+            } else {
+                /* Default: try _len suffix for arrays */
+                emit_expression(cg, arg);
+                emit(cg, "_len");
+            }
+            return;
+        }
+
+        if (strcmp(func, "typeof") == 0 && node->data.call.arg_count == 1) {
+            AstNode *arg = node->data.call.args[0];
+            EzType *t = cg->type_table ? typetable_get(cg->type_table, arg) : NULL;
+            const char *tn = t ? type_name(t) : "unknown";
+            emitf(cg, "ez_string_lit(\"%s\")", tn);
+            return;
+        }
+
+        if (strcmp(func, "to_int") == 0 && node->data.call.arg_count == 1) {
+            emit(cg, "(int64_t)(");
+            emit_expression(cg, node->data.call.args[0]);
+            emit(cg, ")");
+            return;
+        }
+
+        if (strcmp(func, "to_float") == 0 && node->data.call.arg_count == 1) {
+            emit(cg, "(double)(");
+            emit_expression(cg, node->data.call.args[0]);
+            emit(cg, ")");
+            return;
+        }
+
         if (strcmp(func, "print") == 0 && node->data.call.arg_count > 0) {
             AstNode *arg = node->data.call.args[0];
             const char *suffix = "_int";

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -71,6 +71,13 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
     if (strcmp(type_name, "byte") == 0)   return "uint8_t";
     if (strcmp(type_name, "string") == 0) return "EzString";
 
+    /* Array type: [T] — for struct fields, use pointer representation */
+    if (type_name[0] == '[') {
+        /* For now, array fields in structs are unsupported in C codegen */
+        /* TODO: Use EzArray or pointer type */
+        return "void *";
+    }
+
     /* If starts with uppercase, it's a user-defined type */
     if (type_name[0] >= 'A' && type_name[0] <= 'Z') {
         static char buf[256];

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -819,7 +819,17 @@ static AstNode *parse_struct_declaration(Parser *p) {
         StructField *field = &node->data.struct_decl.fields[node->data.struct_decl.field_count];
         field->name = p->cur_token.literal;
         next_token(p);
-        field->type_name = p->cur_token.literal;
+        if (cur_token_is(p, TOK_LBRACKET)) {
+            /* Array type: [type] */
+            next_token(p); /* element type */
+            const char *elem = p->cur_token.literal;
+            next_token(p); /* skip ] */
+            char *type_str = arena_alloc(p->arena, strlen(elem) + 3);
+            sprintf(type_str, "[%s]", elem);
+            field->type_name = type_str;
+        } else {
+            field->type_name = p->cur_token.literal;
+        }
         node->data.struct_decl.field_count++;
         next_token(p);
     }

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -679,9 +679,19 @@ static AstNode *parse_func_declaration(Parser *p) {
         node->data.func_decl.return_types = arena_alloc(p->arena, sizeof(const char *) * ret_cap);
 
         if (cur_token_is(p, TOK_LPAREN)) {
-            /* Multiple return types: -> (int, string) */
+            /* Multiple/named return types: -> (int, string) or -> (x int, y int) */
             next_token(p);
             while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
+                if (cur_token_is(p, TOK_IDENT) && peek_token_is(p, TOK_IDENT)) {
+                    /* Named return: name type — skip name, use type */
+                    next_token(p);
+                } else if (cur_token_is(p, TOK_IDENT) && peek_token_is(p, TOK_COMMA)) {
+                    /* Could be shared type: -> (x, y int) — just a name, type comes later */
+                    /* For now, skip the name */
+                    next_token(p); /* skip comma */
+                    next_token(p); /* next name or type */
+                    continue;
+                }
                 node->data.func_decl.return_types[node->data.func_decl.return_type_count++] =
                     p->cur_token.literal;
                 if (peek_token_is(p, TOK_COMMA)) {

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -469,9 +469,10 @@ static AstNode *parse_var_declaration(Parser *p) {
     if (peek_token_is(p, TOK_IDENT)) {
         next_token(p);
         node->data.var_decl.type_name = p->cur_token.literal;
+    }
 
-        /* Check for multi-var declaration: temp x int, y int = expr */
-        if (peek_token_is(p, TOK_COMMA)) {
+    /* Check for multi-var declaration: temp x int, y int = expr OR temp _, _ = expr */
+    if (peek_token_is(p, TOK_COMMA)) {
             /* Collect all variable names and types */
             const char *names[16];
             const char *types[16];
@@ -538,7 +539,6 @@ static AstNode *parse_var_declaration(Parser *p) {
             }
 
             return block;
-        }
     } else if (peek_token_is(p, TOK_LBRACKET)) {
         /* Array type: [int], [string], etc. */
         next_token(p); /* skip [ */

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -227,9 +227,20 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
         }
 
         if (fn_name) {
-            FuncSig *sig = find_func(tc, fn_name);
-            if (sig && sig->return_count > 0) {
-                result = sig->return_types[0];
+            /* Check built-in functions first */
+            if (strcmp(fn_name, "len") == 0 || strcmp(fn_name, "to_int") == 0) {
+                result = &TYPE_INT;
+            } else if (strcmp(fn_name, "to_float") == 0) {
+                result = &TYPE_FLOAT;
+            } else if (strcmp(fn_name, "to_string") == 0 || strcmp(fn_name, "typeof") == 0) {
+                result = &TYPE_STRING;
+            } else if (strcmp(fn_name, "to_bool") == 0) {
+                result = &TYPE_BOOL;
+            } else {
+                FuncSig *sig = find_func(tc, fn_name);
+                if (sig && sig->return_count > 0) {
+                    result = sig->return_types[0];
+                }
             }
         }
         break;


### PR DESCRIPTION
## Summary
Targeted fixes to unblock more examples and add essential builtins.

### Builtins
- `len()` — returns `.len` for strings, `_len` for arrays
- `typeof()` — returns compile-time type name as string literal
- `to_int()`, `to_float()` — C casts with correct type resolution in type checker

### Parser fixes
- `temp _, _ = expr` — multi-var declarations without type annotations
- `-> (area int)` — named return params (skip name, use type)
- `-> (x, y int)` — shared type syntax
- `[string]` as struct field type — parsed correctly (codegen placeholder)

## Results
**8/14 basic examples now pass** (up from 7)
- `arrays.ez` — newly passing (len() builtin)

## Test plan
- [x] `len(string)` returns string length
- [x] `len(array)` returns array length
- [x] `typeof()` returns correct type name
- [x] `to_float(42)` produces double
- [x] `temp _, b = func()` discards first value
- [x] Named returns parse without generating invalid types
- [x] All 8 passing examples still compile and run