### PR TITLE
feat(ezc): EzArray runtime, for_each codegen, proper array types

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -186,6 +186,8 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 case TK_FLOAT:  emit(cg, "%g"); break;
                 case TK_BOOL:   emit(cg, "%s"); break;
                 case TK_CHAR:   emit(cg, "%c"); break;
+                case TK_ARRAY:  emit(cg, "%s"); break;
+                case TK_ENUM:   emit(cg, "%lld"); break;
                 default:        emit(cg, "%lld"); break;
                 }
             }
@@ -225,6 +227,9 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 emit(cg, "(char)(");
                 emit_expression(cg, part);
                 emit(cg, ")");
+                break;
+            case TK_ARRAY:
+                emit(cg, "\"[...]\"");
                 break;
             default:
                 emit(cg, "(long long)(");

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -71,11 +71,9 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
     if (strcmp(type_name, "byte") == 0)   return "uint8_t";
     if (strcmp(type_name, "string") == 0) return "EzString";
 
-    /* Array type: [T] — for struct fields, use pointer representation */
+    /* Array type: [T] — use EzArray */
     if (type_name[0] == '[') {
-        /* For now, array fields in structs are unsupported in C codegen */
-        /* TODO: Use EzArray or pointer type */
-        return "void *";
+        return "EzArray";
     }
 
     /* If starts with uppercase, it's a user-defined type */
@@ -239,15 +237,35 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         break;
     }
 
-    case NODE_ARRAY_VALUE:
-        /* Array literal: emit as C compound literal */
-        emit(cg, "{");
-        for (int i = 0; i < node->data.array_value.count; i++) {
+    case NODE_ARRAY_VALUE: {
+        /* Array literal: emit as EzArray using ez_array_from */
+        int count = node->data.array_value.count;
+        if (count == 0) {
+            emit(cg, "ez_array_new(ez_default_arena, sizeof(int64_t), 4)");
+            break;
+        }
+        /* Determine element type from first element */
+        EzType *elem_t = cg->type_table
+            ? typetable_get(cg->type_table, node->data.array_value.elements[0])
+            : NULL;
+        TypeKind tk = elem_t ? elem_t->kind : TK_INT;
+
+        const char *c_type;
+        switch (tk) {
+        case TK_FLOAT:  c_type = "double"; break;
+        case TK_BOOL:   c_type = "bool"; break;
+        case TK_STRING: c_type = "EzString"; break;
+        default:        c_type = "int64_t"; break;
+        }
+
+        emitf(cg, "ez_array_from(ez_default_arena, (%s[]){", c_type);
+        for (int i = 0; i < count; i++) {
             if (i > 0) emit(cg, ", ");
             emit_expression(cg, node->data.array_value.elements[i]);
         }
-        emit(cg, "}");
+        emitf(cg, "}, sizeof(%s), %d)", c_type, count);
         break;
+    }
 
     case NODE_STRUCT_VALUE:
         /* Struct literal: (EzStruct_Name){.field = value, ...} */
@@ -315,12 +333,36 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         emitf(cg, ".%s", node->data.member.member);
         break;
 
-    case NODE_INDEX_EXPR:
-        emit_expression(cg, node->data.index_expr.left);
-        emit(cg, "[");
-        emit_expression(cg, node->data.index_expr.index);
-        emit(cg, "]");
+    case NODE_INDEX_EXPR: {
+        /* Check if left side is an array (EzArray) or string */
+        EzType *left_t = cg->type_table
+            ? typetable_get(cg->type_table, node->data.index_expr.left)
+            : NULL;
+        if (left_t && left_t->kind == TK_ARRAY) {
+            /* Determine element C type */
+            const char *c_elem = "int64_t";
+            if (left_t->element_type) {
+                EzType *et = type_from_name(left_t->element_type);
+                if (et->kind == TK_FLOAT) c_elem = "double";
+                else if (et->kind == TK_BOOL) c_elem = "bool";
+                else if (et->kind == TK_STRING) c_elem = "EzString";
+                else if (et->kind == TK_CHAR) c_elem = "int32_t";
+                else if (et->kind == TK_BYTE) c_elem = "uint8_t";
+            }
+            emitf(cg, "EZ_ARRAY_GET(");
+            emit_expression(cg, node->data.index_expr.left);
+            emitf(cg, ", %s, ", c_elem);
+            emit_expression(cg, node->data.index_expr.index);
+            emit(cg, ")");
+        } else {
+            /* String indexing or fallback to C array indexing */
+            emit_expression(cg, node->data.index_expr.left);
+            emit(cg, "[");
+            emit_expression(cg, node->data.index_expr.index);
+            emit(cg, "]");
+        }
         break;
+    }
 
     default:
         emitf(cg, "/* TODO: expression kind %d */", node->kind);
@@ -389,12 +431,14 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
                 emit_expression(cg, arg);
                 emit(cg, ").len");
             } else if (t && t->kind == TK_ARRAY) {
+                emit(cg, "(int64_t)(");
                 emit_expression(cg, arg);
-                emit(cg, "_len");
+                emit(cg, ").len");
             } else {
-                /* Default: try _len suffix for arrays */
+                /* Default: try .len for EzArray */
+                emit(cg, "(int64_t)(");
                 emit_expression(cg, arg);
-                emit(cg, "_len");
+                emit(cg, ").len");
             }
             return;
         }
@@ -485,20 +529,15 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
     const char *elem_type = extract_array_elem_type(type_name);
 
     if (elem_type) {
-        /* Array declaration: temp arr [int] = {1, 2, 3} */
-        const char *c_elem_type = ez_type_to_c_cg(cg, elem_type);
-        if (node->data.var_decl.value &&
-            node->data.var_decl.value->kind == NODE_ARRAY_VALUE) {
-            int count = node->data.var_decl.value->data.array_value.count;
-            emitf(cg, "%s %s[%d] = ", c_elem_type, node->data.var_decl.name, count);
+        /* Array declaration: use EzArray */
+        emitf(cg, "EzArray %s = ", node->data.var_decl.name);
+        if (node->data.var_decl.value) {
             emit_expression(cg, node->data.var_decl.value);
-            emit(cg, ";\n");
-            /* Emit length tracking variable */
-            emit_indent(cg);
-            emitf(cg, "const int32_t %s_len = %d;\n", node->data.var_decl.name, count);
         } else {
-            emitf(cg, "%s *%s = NULL;\n", c_elem_type, node->data.var_decl.name);
+            const char *c_elem_type = ez_type_to_c_cg(cg, elem_type);
+            emitf(cg, "ez_array_new(ez_default_arena, sizeof(%s), 4)", c_elem_type);
         }
+        emit(cg, ";\n");
         return;
     }
 
@@ -546,7 +585,31 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
 
 static void emit_assign_statement(CodeGen *cg, AstNode *node) {
     emit_indent(cg);
-    /* For mutable params, the target label already emits (*name) */
+
+    /* Check for array index assignment: arr[i] = value */
+    if (node->data.assign.target->kind == NODE_INDEX_EXPR) {
+        AstNode *left = node->data.assign.target->data.index_expr.left;
+        EzType *left_t = cg->type_table ? typetable_get(cg->type_table, left) : NULL;
+        if (left_t && left_t->kind == TK_ARRAY) {
+            const char *c_elem = "int64_t";
+            if (left_t->element_type) {
+                EzType *et = type_from_name(left_t->element_type);
+                if (et->kind == TK_FLOAT) c_elem = "double";
+                else if (et->kind == TK_BOOL) c_elem = "bool";
+                else if (et->kind == TK_STRING) c_elem = "EzString";
+            }
+            emitf(cg, "EZ_ARRAY_SET(");
+            emit_expression(cg, left);
+            emitf(cg, ", %s, ", c_elem);
+            emit_expression(cg, node->data.assign.target->data.index_expr.index);
+            emit(cg, ", ");
+            emit_expression(cg, node->data.assign.value);
+            emit(cg, ");\n");
+            return;
+        }
+    }
+
+    /* Default assignment */
     emit_expression(cg, node->data.assign.target);
     emitf(cg, " %s ", node->data.assign.op);
     emit_expression(cg, node->data.assign.value);
@@ -823,6 +886,39 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
     case NODE_FOR_STMT:
         emit_for_statement(cg, node);
         break;
+    case NODE_FOR_EACH_STMT: {
+        /* for_each item in collection → for loop over EzArray */
+        emit_indent(cg);
+        AstNode *coll = node->data.for_each.collection;
+        EzType *coll_t = cg->type_table ? typetable_get(cg->type_table, coll) : NULL;
+        const char *c_elem = "int64_t";
+        if (coll_t && coll_t->kind == TK_ARRAY && coll_t->element_type) {
+            EzType *et = type_from_name(coll_t->element_type);
+            if (et->kind == TK_FLOAT) c_elem = "double";
+            else if (et->kind == TK_BOOL) c_elem = "bool";
+            else if (et->kind == TK_STRING) c_elem = "EzString";
+        }
+
+        /* Emit index variable */
+        const char *idx_name = node->data.for_each.index_name;
+        if (!idx_name) idx_name = "_ez_idx";
+        emitf(cg, "for (int32_t %s = 0; %s < ", idx_name, idx_name);
+        emit_expression(cg, coll);
+        emitf(cg, ".len; %s++) {\n", idx_name);
+
+        cg->indent++;
+        /* Declare the item variable */
+        emit_indent(cg);
+        emitf(cg, "%s %s = EZ_ARRAY_GET(", c_elem, node->data.for_each.var_name);
+        emit_expression(cg, coll);
+        emitf(cg, ", %s, %s);\n", c_elem, idx_name);
+
+        emit_block(cg, node->data.for_each.body);
+        cg->indent--;
+        emit_indent(cg);
+        emit(cg, "}\n");
+        break;
+    }
     case NODE_WHILE_STMT:
         emit_while_statement(cg, node);
         break;
@@ -963,6 +1059,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
     /* Emit preamble */
     emit(cg, "/* Generated by EZC */\n");
     emit(cg, "#include \"ez_runtime.h\"\n");
+    emit(cg, "#include \"ez_array.h\"\n");
     if (cg->has_std) {
         emit(cg, "#include \"ez_std.h\"\n");
     }

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -262,11 +262,11 @@ int main(int argc, char **argv) {
     snprintf(cmd, sizeof(cmd),
         "cc -std=c11 -O2 -Wall -Wno-unused-function "
         "-I%s/runtime -I%s/stdlib "
-        "-o %s %s %s/runtime/ez_runtime.c %s/stdlib/ez_std.c "
+        "-o %s %s %s/runtime/ez_runtime.c %s/runtime/ez_array.c %s/stdlib/ez_std.c "
         "-lm 2>&1",
         runtime_dir, runtime_dir,
         output_file, c_file,
-        runtime_dir, runtime_dir);
+        runtime_dir, runtime_dir, runtime_dir);
 
     int ret = system(cmd);
     if (ret != 0) {

--- a/ezc/src/runtime/ez_array.c
+++ b/ezc/src/runtime/ez_array.c
@@ -1,0 +1,62 @@
+/*
+ * ez_array.c - Dynamic array implementation
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "ez_array.h"
+#include <string.h>
+
+EzArray ez_array_new(EzArena *arena, int32_t elem_size, int32_t initial_cap) {
+    EzArray arr;
+    arr.elem_size = elem_size;
+    arr.len = 0;
+    arr.cap = initial_cap > 0 ? initial_cap : 4;
+    arr.data = ez_arena_alloc(arena, (size_t)arr.cap * (size_t)arr.elem_size);
+    return arr;
+}
+
+EzArray ez_array_from(EzArena *arena, const void *data, int32_t elem_size, int32_t count) {
+    EzArray arr;
+    arr.elem_size = elem_size;
+    arr.len = count;
+    arr.cap = count > 0 ? count : 4;
+    arr.data = ez_arena_alloc(arena, (size_t)arr.cap * (size_t)arr.elem_size);
+    if (count > 0 && data) {
+        memcpy(arr.data, data, (size_t)count * (size_t)elem_size);
+    }
+    return arr;
+}
+
+void *ez_array_get_ptr(EzArray *arr, int32_t index, const char *file, int line) {
+    if (index < 0 || index >= arr->len) {
+        ez_panic(file, line, "index out of bounds: index %d, length %d", index, arr->len);
+    }
+    return (char *)arr->data + (size_t)index * (size_t)arr->elem_size;
+}
+
+void ez_array_set(EzArray *arr, int32_t index, const void *value, const char *file, int line) {
+    if (index < 0 || index >= arr->len) {
+        ez_panic(file, line, "index out of bounds: index %d, length %d", index, arr->len);
+    }
+    memcpy((char *)arr->data + (size_t)index * (size_t)arr->elem_size,
+           value, (size_t)arr->elem_size);
+}
+
+void ez_array_push(EzArena *arena, EzArray *arr, const void *value) {
+    if (arr->len >= arr->cap) {
+        int32_t new_cap = arr->cap * 2;
+        void *new_data = ez_arena_alloc(arena, (size_t)new_cap * (size_t)arr->elem_size);
+        memcpy(new_data, arr->data, (size_t)arr->len * (size_t)arr->elem_size);
+        arr->data = new_data;
+        arr->cap = new_cap;
+    }
+    memcpy((char *)arr->data + (size_t)arr->len * (size_t)arr->elem_size,
+           value, (size_t)arr->elem_size);
+    arr->len++;
+}
+
+EzArray ez_array_copy(EzArena *arena, EzArray *src) {
+    return ez_array_from(arena, src->data, src->elem_size, src->len);
+}

--- a/ezc/src/runtime/ez_array.h
+++ b/ezc/src/runtime/ez_array.h
@@ -1,0 +1,62 @@
+/*
+ * ez_array.h - Dynamic array type for EZC
+ *
+ * EzArray is a fat pointer: data + len + cap + elem_size.
+ * All backing storage is allocated from an arena.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZ_ARRAY_H
+#define EZ_ARRAY_H
+
+#include "ez_runtime.h"
+
+typedef struct {
+    void *data;
+    int32_t len;
+    int32_t cap;
+    int32_t elem_size;
+} EzArray;
+
+/* Create an empty array with given element size and initial capacity */
+EzArray ez_array_new(EzArena *arena, int32_t elem_size, int32_t initial_cap);
+
+/* Create an array from a C literal (copies data into arena) */
+EzArray ez_array_from(EzArena *arena, const void *data, int32_t elem_size, int32_t count);
+
+/* Get a pointer to element at index (with bounds checking) */
+void *ez_array_get_ptr(EzArray *arr, int32_t index, const char *file, int line);
+
+/* Set element at index (with bounds checking) */
+void ez_array_set(EzArray *arr, int32_t index, const void *value, const char *file, int line);
+
+/* Append an element (may reallocate on the arena) */
+void ez_array_push(EzArena *arena, EzArray *arr, const void *value);
+
+/* Deep copy an array */
+EzArray ez_array_copy(EzArena *arena, EzArray *src);
+
+/* Typed access macros */
+#define EZ_ARRAY_GET(arr, type, i) (*(type *)ez_array_get_ptr(&(arr), (i), __FILE__, __LINE__))
+#define EZ_ARRAY_SET(arr, type, i, val) do { type _v = (val); ez_array_set(&(arr), (i), &_v, __FILE__, __LINE__); } while(0)
+
+/* Create from typed literal — helper macros */
+#define EZ_ARRAY_FROM_I64(arena, ...) \
+    ez_array_from((arena), (int64_t[]){__VA_ARGS__}, sizeof(int64_t), \
+        sizeof((int64_t[]){__VA_ARGS__}) / sizeof(int64_t))
+
+#define EZ_ARRAY_FROM_F64(arena, ...) \
+    ez_array_from((arena), (double[]){__VA_ARGS__}, sizeof(double), \
+        sizeof((double[]){__VA_ARGS__}) / sizeof(double))
+
+#define EZ_ARRAY_FROM_BOOL(arena, ...) \
+    ez_array_from((arena), (bool[]){__VA_ARGS__}, sizeof(bool), \
+        sizeof((bool[]){__VA_ARGS__}) / sizeof(bool))
+
+#define EZ_ARRAY_FROM_STR(arena, ...) \
+    ez_array_from((arena), (EzString[]){__VA_ARGS__}, sizeof(EzString), \
+        sizeof((EzString[]){__VA_ARGS__}) / sizeof(EzString))
+
+#endif

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -380,6 +380,29 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
         break;
     }
 
+    case NODE_FOR_EACH_STMT: {
+        Scope *loop_scope = scope_create(tc->current_scope);
+        Scope *outer = tc->current_scope;
+        tc->current_scope = loop_scope;
+
+        /* Resolve collection type to determine element type */
+        EzType *coll_t = resolve_expr(tc, node->data.for_each.collection);
+        EzType *elem_t = &TYPE_UNKNOWN;
+        if (coll_t->kind == TK_ARRAY && coll_t->element_type) {
+            elem_t = type_from_name(coll_t->element_type);
+        }
+
+        /* Define iteration variables */
+        if (node->data.for_each.index_name) {
+            scope_define(loop_scope, node->data.for_each.index_name, &TYPE_INT, false);
+        }
+        scope_define(loop_scope, node->data.for_each.var_name, elem_t, false);
+
+        check_block(tc, node->data.for_each.body);
+        tc->current_scope = outer;
+        break;
+    }
+
     case NODE_WHILE_STMT:
         resolve_expr(tc, node->data.while_stmt.condition);
         check_block(tc, node->data.while_stmt.body);


### PR DESCRIPTION
## Summary
Replaces raw C arrays with a proper `EzArray` runtime type — a fat struct with `data`, `len`, `cap`, and `elem_size`. This is the foundation for all dynamic collection features.

### EzArray Runtime (`ez_array.c/h`)
- `ez_array_new()` — create empty array with initial capacity
- `ez_array_from()` — create from C literal data (arena-allocated)
- `ez_array_get_ptr()` — indexed access with bounds checking (panics on OOB)
- `ez_array_set()` — indexed mutation with bounds checking
- `ez_array_push()` — append with automatic growth
- `ez_array_copy()` — deep copy
- `EZ_ARRAY_GET/SET` macros for type-safe access

### Codegen Updates
- Array literals emit `ez_array_from()` with typed compound literals
- Array indexing uses `EZ_ARRAY_GET()` (read) and `EZ_ARRAY_SET()` (write)
- `len()` on arrays uses `.len` field
- Array struct fields use `EzArray` type instead of `void*`
- `for_each` codegen: iterates EzArray with type-aware element access
- String interpolation handles `TK_ARRAY` (emits `[...]` placeholder)

### Type Checker
- `for_each` item variables resolve to array element type
- Indexed `for_each` defines index variable as int

## Results
**8/14 basic examples pass** (arrays.ez regression fixed)

## Test plan
- [x] Array creation, indexing, mutation, len all work
- [x] `for_each name in names` correctly iterates string arrays
- [x] `for_each i, val in nums` indexed iteration works
- [x] Bounds checking panics on out-of-range index
- [x] Array struct fields compile as EzArray
- [x] `arrays.ez` compiles (with placeholder array formatting)
- [x] All 8 passing examples still work