### PR TITLE
feat(ezc): unit tests and parity test infrastructure

### DIFF
--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -47,7 +47,7 @@ $(BIN): $(OBJ)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 clean:
-	rm -f $(OBJ) $(BIN)
+	rm -f $(OBJ) $(BIN) tests/test_lexer tests/test_parser
 
 install: build
 	install -d /usr/local/bin
@@ -59,15 +59,26 @@ install: build
 	install -m 644 src/stdlib/ez_std.h /usr/local/lib/ezc/stdlib/
 	install -m 644 src/stdlib/ez_std.c /usr/local/lib/ezc/stdlib/
 
-test: build
-	@echo "Running hello world test..."
-	@echo 'import @std' > /tmp/ezc_test_hello.ez
-	@echo 'using std' >> /tmp/ezc_test_hello.ez
-	@echo '' >> /tmp/ezc_test_hello.ez
-	@echo 'do main() {' >> /tmp/ezc_test_hello.ez
-	@echo '    println("Hello, World!")' >> /tmp/ezc_test_hello.ez
-	@echo '}' >> /tmp/ezc_test_hello.ez
-	cd .. && ./ezc/ezc /tmp/ezc_test_hello.ez -o /tmp/ezc_test_hello
-	@/tmp/ezc_test_hello
-	@rm -f /tmp/ezc_test_hello /tmp/ezc_test_hello.ez
-	@echo "Test passed!"
+# Shared objects needed by test binaries (everything except main.o)
+TEST_DEPS = src/util/arena.o src/util/buf.o src/util/error.o \
+            src/lexer/token.o src/lexer/lexer.o \
+            src/parser/ast.o src/parser/parser.o \
+            src/typechecker/types.o src/typechecker/scope.o src/typechecker/typechecker.o
+
+tests/test_lexer: tests/test_lexer.c $(TEST_DEPS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+tests/test_parser: tests/test_parser.c $(TEST_DEPS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+test-unit: $(TEST_DEPS) tests/test_lexer tests/test_parser
+	@echo ""
+	@echo "=== Lexer Tests ==="
+	@./tests/test_lexer
+	@echo "=== Parser Tests ==="
+	@./tests/test_parser
+
+test-parity: build
+	@./tests/run_parity.sh
+
+test: test-unit test-parity

--- a/ezc/tests/run_parity.sh
+++ b/ezc/tests/run_parity.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# run_parity.sh - Compare ezc (compiler) output against ez (interpreter)
+#
+# Usage: ./ezc/tests/run_parity.sh [file.ez ...]
+#   No args: runs all examples/basic/*.ez
+#   With args: runs only the specified files
+#
+# Copyright (c) 2025-Present Marshall A Burns
+# Licensed under the MIT License. See LICENSE for details.
+
+# No set -e: we handle errors ourselves
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+EZC="$ROOT_DIR/ezc/ezc"
+EZ="go run $ROOT_DIR/cmd/ez/..."
+TMP_DIR="/tmp/ezc_parity_$$"
+
+mkdir -p "$TMP_DIR"
+trap "rm -rf $TMP_DIR" EXIT
+
+# Counters
+PASS=0
+FAIL=0
+SKIP=0
+COMPILE_FAIL=0
+TOTAL=0
+
+# Examples that use features not yet implemented in EZC
+SKIP_LIST=(
+    "control_flow"   # #strict attribute
+    "ensure"         # @io stdlib
+    "functions"      # named return var initialization
+    "maps"           # map type
+    "references"     # ref() builtin
+    "structs"        # array-typed struct fields
+)
+
+should_skip() {
+    local name="$1"
+    for skip in "${SKIP_LIST[@]}"; do
+        if [ "$name" = "$skip" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+run_test() {
+    local file="$1"
+    local name
+    name=$(basename "$file" .ez)
+    TOTAL=$((TOTAL + 1))
+
+    if should_skip "$name"; then
+        printf "  ${YELLOW}SKIP${RESET}  %s (unimplemented features)\n" "$name"
+        SKIP=$((SKIP + 1))
+        return
+    fi
+
+    # Compile with ezc
+    local bin="$TMP_DIR/$name"
+    local compile_out
+    compile_out=$("$EZC" "$file" -o "$bin" 2>&1)
+    if [ $? -ne 0 ]; then
+        printf "  ${RED}FAIL${RESET}  %s (compile error)\n" "$name"
+        echo "$compile_out" | head -3 | sed 's/^/        /'
+        COMPILE_FAIL=$((COMPILE_FAIL + 1))
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    # Run compiled binary
+    local ezc_out
+    ezc_out=$("$bin" 2>&1) || true
+
+    # Run with interpreter
+    local ez_out
+    ez_out=$(cd "$ROOT_DIR" && $EZ "$file" 2>&1 | sed '/^Note:/d' | sed '/^$/{ N; /^\n$/d; }' | sed '1{ /^$/d; }') || true
+
+    # Compare
+    if [ "$ezc_out" = "$ez_out" ]; then
+        printf "  ${GREEN}PASS${RESET}  %s\n" "$name"
+        PASS=$((PASS + 1))
+    else
+        printf "  ${RED}FAIL${RESET}  %s (output mismatch)\n" "$name"
+        # Show first diff
+        diff <(echo "$ezc_out") <(echo "$ez_out") | head -10 | sed 's/^/        /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Header
+echo ""
+printf "${BOLD}EZC Parity Tests${RESET}\n"
+echo "Comparing ezc (compiler) output against ez (interpreter)"
+echo ""
+
+# Build ezc if needed
+if [ ! -f "$EZC" ]; then
+    echo "Building ezc..."
+    (cd "$ROOT_DIR/ezc" && make build) || { echo "Build failed"; exit 1; }
+fi
+
+# Run tests
+if [ $# -gt 0 ]; then
+    # Run specified files
+    for file in "$@"; do
+        run_test "$file"
+    done
+else
+    # Run all basic examples
+    for file in "$ROOT_DIR"/examples/basic/*.ez; do
+        run_test "$file"
+    done
+fi
+
+# Summary
+echo ""
+printf "${BOLD}Results:${RESET} "
+if [ $FAIL -eq 0 ]; then
+    printf "${GREEN}%d passed${RESET}" "$PASS"
+else
+    printf "${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}" "$PASS" "$FAIL"
+fi
+if [ $SKIP -gt 0 ]; then
+    printf ", ${YELLOW}%d skipped${RESET}" "$SKIP"
+fi
+printf " (${TOTAL} total)\n"
+
+if [ $COMPILE_FAIL -gt 0 ]; then
+    printf "${RED}%d compilation failures${RESET}\n" "$COMPILE_FAIL"
+fi
+
+echo ""
+
+# Exit code
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/ezc/tests/test.h
+++ b/ezc/tests/test.h
@@ -1,0 +1,71 @@
+/*
+ * test.h - Minimal C test framework
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_TEST_H
+#define EZC_TEST_H
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+static int _test_pass = 0;
+static int _test_fail = 0;
+static int _test_total = 0;
+static int _test_failed_this = 0;
+
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        _test_failed_this = 1; \
+        return; \
+    } \
+} while(0)
+
+#define ASSERT_EQ(a, b) do { \
+    if ((a) != (b)) { \
+        fprintf(stderr, "  FAIL %s:%d: %s != %s (%lld != %lld)\n", \
+            __FILE__, __LINE__, #a, #b, (long long)(a), (long long)(b)); \
+        _test_failed_this = 1; \
+        return; \
+    } \
+} while(0)
+
+#define ASSERT_STR_EQ(a, b) do { \
+    if (strcmp((a), (b)) != 0) { \
+        fprintf(stderr, "  FAIL %s:%d: \"%s\" != \"%s\"\n", \
+            __FILE__, __LINE__, (a), (b)); \
+        _test_failed_this = 1; \
+        return; \
+    } \
+} while(0)
+
+#define ASSERT_NOT_NULL(ptr) do { \
+    if ((ptr) == NULL) { \
+        fprintf(stderr, "  FAIL %s:%d: %s is NULL\n", __FILE__, __LINE__, #ptr); \
+        _test_failed_this = 1; \
+        return; \
+    } \
+} while(0)
+
+#define RUN_TEST(func) do { \
+    _test_total++; \
+    _test_failed_this = 0; \
+    func(); \
+    if (_test_failed_this) { \
+        _test_fail++; \
+    } else { \
+        printf("  PASS %s\n", #func); \
+        _test_pass++; \
+    } \
+} while(0)
+
+#define PRINT_RESULTS() do { \
+    printf("\n%d passed, %d failed (%d total)\n\n", \
+        _test_pass, _test_fail, _test_total); \
+} while(0)
+
+#endif

--- a/ezc/tests/test_lexer.c
+++ b/ezc/tests/test_lexer.c
@@ -1,0 +1,237 @@
+/*
+ * test_lexer.c - Unit tests for the EZC lexer
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "test.h"
+#include "../src/util/arena.h"
+#include "../src/lexer/lexer.h"
+
+static Arena *arena;
+
+static Lexer *lex(const char *input) {
+    return lexer_create(arena, input, "test.ez");
+}
+
+static Token next(Lexer *l) {
+    return lexer_next_token(l);
+}
+
+static void test_empty_input(void) {
+    Lexer *l = lex("");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_EOF);
+}
+
+static void test_single_char_tokens(void) {
+    Lexer *l = lex("(){}[],.:@");
+    ASSERT_EQ(next(l).type, TOK_LPAREN);
+    ASSERT_EQ(next(l).type, TOK_RPAREN);
+    ASSERT_EQ(next(l).type, TOK_LBRACE);
+    ASSERT_EQ(next(l).type, TOK_RBRACE);
+    ASSERT_EQ(next(l).type, TOK_LBRACKET);
+    ASSERT_EQ(next(l).type, TOK_RBRACKET);
+    ASSERT_EQ(next(l).type, TOK_COMMA);
+    ASSERT_EQ(next(l).type, TOK_DOT);
+    ASSERT_EQ(next(l).type, TOK_COLON);
+    ASSERT_EQ(next(l).type, TOK_AT);
+    ASSERT_EQ(next(l).type, TOK_EOF);
+}
+
+static void test_two_char_tokens(void) {
+    Lexer *l = lex("== != <= >= += -= *= /= ++ -- -> && ||");
+    ASSERT_EQ(next(l).type, TOK_EQ);
+    ASSERT_EQ(next(l).type, TOK_NOT_EQ);
+    ASSERT_EQ(next(l).type, TOK_LT_EQ);
+    ASSERT_EQ(next(l).type, TOK_GT_EQ);
+    ASSERT_EQ(next(l).type, TOK_PLUS_ASSIGN);
+    ASSERT_EQ(next(l).type, TOK_MINUS_ASSIGN);
+    ASSERT_EQ(next(l).type, TOK_ASTERISK_ASSIGN);
+    ASSERT_EQ(next(l).type, TOK_SLASH_ASSIGN);
+    ASSERT_EQ(next(l).type, TOK_INCREMENT);
+    ASSERT_EQ(next(l).type, TOK_DECREMENT);
+    ASSERT_EQ(next(l).type, TOK_ARROW);
+    ASSERT_EQ(next(l).type, TOK_AND);
+    ASSERT_EQ(next(l).type, TOK_OR);
+}
+
+static void test_integer_literal(void) {
+    Lexer *l = lex("42");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_INT);
+    ASSERT_STR_EQ(t.literal, "42");
+}
+
+static void test_integer_with_separators(void) {
+    Lexer *l = lex("1_000_000");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_INT);
+    ASSERT_STR_EQ(t.literal, "1_000_000");
+}
+
+static void test_float_literal(void) {
+    Lexer *l = lex("3.14");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_FLOAT);
+    ASSERT_STR_EQ(t.literal, "3.14");
+}
+
+static void test_string_literal(void) {
+    Lexer *l = lex("\"hello world\"");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_STRING);
+    ASSERT_STR_EQ(t.literal, "hello world");
+}
+
+static void test_string_with_escapes(void) {
+    Lexer *l = lex("\"hello\\nworld\"");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_STRING);
+    ASSERT_STR_EQ(t.literal, "hello\\nworld");
+}
+
+static void test_char_literal(void) {
+    Lexer *l = lex("'A'");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_CHAR);
+    ASSERT_STR_EQ(t.literal, "A");
+}
+
+static void test_raw_string(void) {
+    Lexer *l = lex("`raw string`");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_RAW_STRING);
+    ASSERT_STR_EQ(t.literal, "raw string");
+}
+
+static void test_keywords(void) {
+    Lexer *l = lex("temp const do return if or otherwise for for_each as_long_as loop break continue");
+    ASSERT_EQ(next(l).type, TOK_TEMP);
+    ASSERT_EQ(next(l).type, TOK_CONST);
+    ASSERT_EQ(next(l).type, TOK_DO);
+    ASSERT_EQ(next(l).type, TOK_RETURN);
+    ASSERT_EQ(next(l).type, TOK_IF);
+    ASSERT_EQ(next(l).type, TOK_OR_KW);
+    ASSERT_EQ(next(l).type, TOK_OTHERWISE);
+    ASSERT_EQ(next(l).type, TOK_FOR);
+    ASSERT_EQ(next(l).type, TOK_FOR_EACH);
+    ASSERT_EQ(next(l).type, TOK_AS_LONG_AS);
+    ASSERT_EQ(next(l).type, TOK_LOOP);
+    ASSERT_EQ(next(l).type, TOK_BREAK);
+    ASSERT_EQ(next(l).type, TOK_CONTINUE);
+}
+
+static void test_more_keywords(void) {
+    Lexer *l = lex("import using struct enum nil new true false when is default cast ensure module private");
+    ASSERT_EQ(next(l).type, TOK_IMPORT);
+    ASSERT_EQ(next(l).type, TOK_USING);
+    ASSERT_EQ(next(l).type, TOK_STRUCT);
+    ASSERT_EQ(next(l).type, TOK_ENUM);
+    ASSERT_EQ(next(l).type, TOK_NIL);
+    ASSERT_EQ(next(l).type, TOK_NEW);
+    ASSERT_EQ(next(l).type, TOK_TRUE);
+    ASSERT_EQ(next(l).type, TOK_FALSE);
+    ASSERT_EQ(next(l).type, TOK_WHEN);
+    ASSERT_EQ(next(l).type, TOK_IS);
+    ASSERT_EQ(next(l).type, TOK_DEFAULT);
+    ASSERT_EQ(next(l).type, TOK_CAST);
+    ASSERT_EQ(next(l).type, TOK_ENSURE);
+    ASSERT_EQ(next(l).type, TOK_MODULE);
+    ASSERT_EQ(next(l).type, TOK_PRIVATE);
+}
+
+static void test_identifiers(void) {
+    Lexer *l = lex("foo bar_baz count123");
+    Token t1 = next(l);
+    ASSERT_EQ(t1.type, TOK_IDENT);
+    ASSERT_STR_EQ(t1.literal, "foo");
+    Token t2 = next(l);
+    ASSERT_EQ(t2.type, TOK_IDENT);
+    ASSERT_STR_EQ(t2.literal, "bar_baz");
+    Token t3 = next(l);
+    ASSERT_EQ(t3.type, TOK_IDENT);
+    ASSERT_STR_EQ(t3.literal, "count123");
+}
+
+static void test_skip_comments(void) {
+    Lexer *l = lex("a // line comment\nb");
+    Token t1 = next(l);
+    ASSERT_EQ(t1.type, TOK_IDENT);
+    ASSERT_STR_EQ(t1.literal, "a");
+    Token t2 = next(l);
+    ASSERT_EQ(t2.type, TOK_IDENT);
+    ASSERT_STR_EQ(t2.literal, "b");
+}
+
+static void test_skip_block_comments(void) {
+    Lexer *l = lex("a /* block */ b");
+    Token t1 = next(l);
+    ASSERT_STR_EQ(t1.literal, "a");
+    Token t2 = next(l);
+    ASSERT_STR_EQ(t2.literal, "b");
+}
+
+static void test_line_tracking(void) {
+    Lexer *l = lex("a\nb\nc");
+    Token t1 = next(l);
+    ASSERT_EQ(t1.line, 1);
+    Token t2 = next(l);
+    ASSERT_EQ(t2.line, 2);
+    Token t3 = next(l);
+    ASSERT_EQ(t3.line, 3);
+}
+
+static void test_hash_attributes(void) {
+    Lexer *l = lex("#suppress #strict #flags #doc");
+    ASSERT_EQ(next(l).type, TOK_SUPPRESS);
+    ASSERT_EQ(next(l).type, TOK_STRICT);
+    ASSERT_EQ(next(l).type, TOK_FLAGS);
+    ASSERT_EQ(next(l).type, TOK_DOC);
+}
+
+static void test_hello_world_tokens(void) {
+    Lexer *l = lex("import @std\nusing std\n\ndo main() {\n    println(\"Hello\")\n}");
+    ASSERT_EQ(next(l).type, TOK_IMPORT);
+    ASSERT_EQ(next(l).type, TOK_AT);
+    ASSERT_EQ(next(l).type, TOK_IDENT);  /* std */
+    ASSERT_EQ(next(l).type, TOK_USING);
+    ASSERT_EQ(next(l).type, TOK_IDENT);  /* std */
+    ASSERT_EQ(next(l).type, TOK_DO);
+    ASSERT_EQ(next(l).type, TOK_IDENT);  /* main */
+    ASSERT_EQ(next(l).type, TOK_LPAREN);
+    ASSERT_EQ(next(l).type, TOK_RPAREN);
+    ASSERT_EQ(next(l).type, TOK_LBRACE);
+    ASSERT_EQ(next(l).type, TOK_IDENT);  /* println */
+    ASSERT_EQ(next(l).type, TOK_LPAREN);
+    ASSERT_EQ(next(l).type, TOK_STRING); /* "Hello" */
+    ASSERT_EQ(next(l).type, TOK_RPAREN);
+    ASSERT_EQ(next(l).type, TOK_RBRACE);
+    ASSERT_EQ(next(l).type, TOK_EOF);
+}
+
+int main(void) {
+    arena = arena_create(64 * 1024);
+    printf("\n");
+    RUN_TEST(test_empty_input);
+    RUN_TEST(test_single_char_tokens);
+    RUN_TEST(test_two_char_tokens);
+    RUN_TEST(test_integer_literal);
+    RUN_TEST(test_integer_with_separators);
+    RUN_TEST(test_float_literal);
+    RUN_TEST(test_string_literal);
+    RUN_TEST(test_string_with_escapes);
+    RUN_TEST(test_char_literal);
+    RUN_TEST(test_raw_string);
+    RUN_TEST(test_keywords);
+    RUN_TEST(test_more_keywords);
+    RUN_TEST(test_identifiers);
+    RUN_TEST(test_skip_comments);
+    RUN_TEST(test_skip_block_comments);
+    RUN_TEST(test_line_tracking);
+    RUN_TEST(test_hash_attributes);
+    RUN_TEST(test_hello_world_tokens);
+    PRINT_RESULTS();
+    return _test_fail > 0 ? 1 : 0;
+}

--- a/ezc/tests/test_parser.c
+++ b/ezc/tests/test_parser.c
@@ -1,0 +1,210 @@
+/*
+ * test_parser.c - Unit tests for the EZC parser
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "test.h"
+#include "../src/util/arena.h"
+#include "../src/util/error.h"
+#include "../src/lexer/lexer.h"
+#include "../src/parser/parser.h"
+
+static Arena *arena;
+static DiagnosticList *diag;
+
+static AstNode *parse(const char *input) {
+    diag = diag_create();
+    diag->use_color = false;
+    Lexer *l = lexer_create(arena, input, "test.ez");
+    Parser *p = parser_create(arena, l, "test.ez", diag);
+    return parser_parse_program(p);
+}
+
+static AstNode *first_stmt(AstNode *prog) {
+    if (!prog || prog->kind != NODE_PROGRAM) return NULL;
+    if (prog->data.program.stmt_count == 0) return NULL;
+    return prog->data.program.stmts[0];
+}
+
+static void test_parse_var_decl(void) {
+    AstNode *prog = parse("temp x int = 42");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_VAR_DECL);
+    ASSERT_STR_EQ(stmt->data.var_decl.name, "x");
+    ASSERT_STR_EQ(stmt->data.var_decl.type_name, "int");
+    ASSERT(stmt->data.var_decl.mutable);
+    ASSERT_NOT_NULL(stmt->data.var_decl.value);
+    ASSERT_EQ(stmt->data.var_decl.value->kind, NODE_INT_VALUE);
+}
+
+static void test_parse_const_decl(void) {
+    AstNode *prog = parse("const PI float = 3.14");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_VAR_DECL);
+    ASSERT(!stmt->data.var_decl.mutable);
+    ASSERT_STR_EQ(stmt->data.var_decl.name, "PI");
+}
+
+static void test_parse_func_decl(void) {
+    AstNode *prog = parse("do add(a int, b int) -> int { return a + b }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_FUNC_DECL);
+    ASSERT_STR_EQ(stmt->data.func_decl.name, "add");
+    ASSERT_EQ(stmt->data.func_decl.param_count, 2);
+    ASSERT_EQ(stmt->data.func_decl.return_type_count, 1);
+    ASSERT_STR_EQ(stmt->data.func_decl.return_types[0], "int");
+}
+
+static void test_parse_func_no_return(void) {
+    AstNode *prog = parse("do greet() { }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_FUNC_DECL);
+    ASSERT_STR_EQ(stmt->data.func_decl.name, "greet");
+    ASSERT_EQ(stmt->data.func_decl.param_count, 0);
+    ASSERT_EQ(stmt->data.func_decl.return_type_count, 0);
+}
+
+static void test_parse_import_single(void) {
+    AstNode *prog = parse("import @std");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_IMPORT_STMT);
+    ASSERT_EQ(stmt->data.import_stmt.count, 1);
+    ASSERT(stmt->data.import_stmt.items[0].is_stdlib);
+    ASSERT_STR_EQ(stmt->data.import_stmt.items[0].module, "std");
+}
+
+static void test_parse_import_multi(void) {
+    AstNode *prog = parse("import @std, @math");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_IMPORT_STMT);
+    ASSERT_EQ(stmt->data.import_stmt.count, 2);
+    ASSERT_STR_EQ(stmt->data.import_stmt.items[0].module, "std");
+    ASSERT_STR_EQ(stmt->data.import_stmt.items[1].module, "math");
+}
+
+static void test_parse_if_or_otherwise(void) {
+    AstNode *prog = parse("if x > 0 { } or x == 0 { } otherwise { }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_IF_STMT);
+    ASSERT_NOT_NULL(stmt->data.if_stmt.consequence);
+    ASSERT_NOT_NULL(stmt->data.if_stmt.alternative);
+    ASSERT_EQ(stmt->data.if_stmt.alternative->kind, NODE_IF_STMT);
+}
+
+static void test_parse_for_range(void) {
+    AstNode *prog = parse("for i in range(0, 10) { }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_FOR_STMT);
+    ASSERT_STR_EQ(stmt->data.for_stmt.var_name, "i");
+    ASSERT_NOT_NULL(stmt->data.for_stmt.iterable);
+    ASSERT_EQ(stmt->data.for_stmt.iterable->kind, NODE_RANGE_EXPR);
+}
+
+static void test_parse_while(void) {
+    AstNode *prog = parse("as_long_as x < 10 { }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_WHILE_STMT);
+}
+
+static void test_parse_loop(void) {
+    AstNode *prog = parse("loop { break }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_LOOP_STMT);
+}
+
+static void test_parse_struct_decl(void) {
+    AstNode *prog = parse("const Person struct { name string\n age int }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_STRUCT_DECL);
+    ASSERT_STR_EQ(stmt->data.struct_decl.name, "Person");
+    ASSERT_EQ(stmt->data.struct_decl.field_count, 2);
+}
+
+static void test_parse_enum_decl(void) {
+    AstNode *prog = parse("const Color enum { RED\n GREEN\n BLUE }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_ENUM_DECL);
+    ASSERT_STR_EQ(stmt->data.enum_decl.name, "Color");
+    ASSERT_EQ(stmt->data.enum_decl.value_count, 3);
+}
+
+static void test_parse_struct_literal(void) {
+    AstNode *prog = parse("temp p = Person{name: \"Alice\", age: 30}");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_VAR_DECL);
+    ASSERT_NOT_NULL(stmt->data.var_decl.value);
+    ASSERT_EQ(stmt->data.var_decl.value->kind, NODE_STRUCT_VALUE);
+    ASSERT_EQ(stmt->data.var_decl.value->data.struct_value.count, 2);
+}
+
+static void test_parse_array_literal(void) {
+    AstNode *prog = parse("temp nums [int] = {1, 2, 3}");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_VAR_DECL);
+    ASSERT_STR_EQ(stmt->data.var_decl.type_name, "[int]");
+    ASSERT_NOT_NULL(stmt->data.var_decl.value);
+    ASSERT_EQ(stmt->data.var_decl.value->kind, NODE_ARRAY_VALUE);
+    ASSERT_EQ(stmt->data.var_decl.value->data.array_value.count, 3);
+}
+
+static void test_parse_ensure(void) {
+    AstNode *prog = parse("ensure cleanup()");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_ENSURE_STMT);
+}
+
+static void test_parse_when(void) {
+    AstNode *prog = parse("when x { is 1 { } is 2 { } default { } }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_WHEN_STMT);
+    ASSERT_EQ(stmt->data.when_stmt.case_count, 2);
+    ASSERT_NOT_NULL(stmt->data.when_stmt.default_body);
+}
+
+static void test_parse_error_reports(void) {
+    AstNode *prog = parse("temp x int =");
+    (void)prog;
+    ASSERT(diag_has_errors(diag));
+}
+
+int main(void) {
+    arena = arena_create(256 * 1024);
+    printf("\n");
+    RUN_TEST(test_parse_var_decl);
+    RUN_TEST(test_parse_const_decl);
+    RUN_TEST(test_parse_func_decl);
+    RUN_TEST(test_parse_func_no_return);
+    RUN_TEST(test_parse_import_single);
+    RUN_TEST(test_parse_import_multi);
+    RUN_TEST(test_parse_if_or_otherwise);
+    RUN_TEST(test_parse_for_range);
+    RUN_TEST(test_parse_while);
+    RUN_TEST(test_parse_loop);
+    RUN_TEST(test_parse_struct_decl);
+    RUN_TEST(test_parse_enum_decl);
+    RUN_TEST(test_parse_struct_literal);
+    RUN_TEST(test_parse_array_literal);
+    RUN_TEST(test_parse_ensure);
+    RUN_TEST(test_parse_when);
+    RUN_TEST(test_parse_error_reports);
+    PRINT_RESULTS();
+    return _test_fail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
Adds comprehensive testing infrastructure for EZC.

### Unit Tests (35 tests, all passing)
- **test.h** — minimal C test framework with ASSERT macros
- **test_lexer.c** (18 tests) — tokens, literals, keywords, comments, line tracking, hash attributes, full hello world tokenization
- **test_parser.c** (17 tests) — var/const declarations, functions, imports, control flow, structs, enums, arrays, ensure, when/is, error reporting

### Parity Test Script
- **tests/run_parity.sh** — compiles examples with `ezc`, runs with `ez` interpreter, diffs output
- Skip list for unimplemented features
- Colored pass/fail/skip output with summary

### Makefile Targets
- `make test-unit` — run lexer + parser unit tests
- `make test-parity` — run parity tests against interpreter
- `make test` — run both

### Current Results
- Unit: 35/35 passing
- Parity: 5 pass, 3 fail (formatting differences), 6 skipped

## Test plan
- [x] All 35 unit tests pass
- [x] Parity script runs without crashing
- [x] Skip list correctly skips unimplemented features
- [x] `make test` runs both suites