### PR TITLE
fix(ezc): runtime discovery

### DIFF
--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -56,6 +56,8 @@ install: build
 	install -d /usr/local/lib/ezc/stdlib
 	install -m 644 src/runtime/ez_runtime.h /usr/local/lib/ezc/runtime/
 	install -m 644 src/runtime/ez_runtime.c /usr/local/lib/ezc/runtime/
+	install -m 644 src/runtime/ez_array.h /usr/local/lib/ezc/runtime/
+	install -m 644 src/runtime/ez_array.c /usr/local/lib/ezc/runtime/
 	install -m 644 src/stdlib/ez_std.h /usr/local/lib/ezc/stdlib/
 	install -m 644 src/stdlib/ez_std.c /usr/local/lib/ezc/stdlib/
 

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -12,6 +12,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 
 #include "util/arena.h"
 #include "util/error.h"
@@ -69,11 +72,48 @@ static bool write_file(const char *path, const char *content) {
     return true;
 }
 
-/* Get the directory where the ezc binary lives (for finding runtime headers) */
-static const char *get_runtime_dir(const char *argv0) {
-    (void)argv0;
-    /* For now, look relative to CWD or use a known path */
-    /* TODO: resolve relative to binary location */
+/* Resolve the directory containing the ezc binary itself */
+static const char *get_self_dir(const char *argv0) {
+    static char buf[1024];
+
+#ifdef __APPLE__
+    /* macOS: use _NSGetExecutablePath */
+    uint32_t size = sizeof(buf);
+    if (_NSGetExecutablePath(buf, &size) == 0) {
+        char *resolved = realpath(buf, NULL);
+        if (resolved) {
+            strncpy(buf, resolved, sizeof(buf) - 1);
+            free(resolved);
+            char *slash = strrchr(buf, '/');
+            if (slash) *slash = '\0';
+            return buf;
+        }
+    }
+#endif
+
+#ifdef __linux__
+    /* Linux: read /proc/self/exe */
+    ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+    if (len > 0) {
+        buf[len] = '\0';
+        char *slash = strrchr(buf, '/');
+        if (slash) *slash = '\0';
+        return buf;
+    }
+#endif
+
+    /* Fallback: try to resolve argv[0] */
+    if (argv0) {
+        char *resolved = realpath(argv0, NULL);
+        if (resolved) {
+            strncpy(buf, resolved, sizeof(buf) - 1);
+            free(resolved);
+            char *slash = strrchr(buf, '/');
+            if (slash) *slash = '\0';
+            return buf;
+        }
+    }
+
     return NULL;
 }
 
@@ -93,25 +133,50 @@ static char *output_name_from_input(const char *input) {
     return out;
 }
 
-/* Find the runtime source directory */
+/*
+ * Find the runtime directory containing ez_runtime.h and ez_std.h.
+ *
+ * Search order:
+ *   1. EZC_RUNTIME env var (explicit override)
+ *   2. Relative to binary: ../lib/ezc (installed layout)
+ *   3. Relative to binary: src (development layout — binary is in ezc/)
+ *   4. Relative to CWD: ezc/src (running from project root)
+ *   5. /usr/local/lib/ezc (system install)
+ */
 static const char *find_runtime_dir(const char *argv0) {
-    /* Try relative to binary */
     static char path[1024];
 
-    /* Try the source tree layout first (for development) */
-    /* Check if ezc/src/runtime/ez_runtime.h exists relative to CWD */
+    /* 1. Environment variable override */
+    const char *env = getenv("EZC_RUNTIME");
+    if (env && access(env, R_OK) == 0) {
+        snprintf(path, sizeof(path), "%s/runtime/ez_runtime.h", env);
+        if (access(path, R_OK) == 0) return env;
+    }
+
+    /* 2-3. Relative to binary location */
+    const char *self_dir = get_self_dir(argv0);
+    if (self_dir) {
+        /* Installed layout: binary in /usr/local/bin, runtime in /usr/local/lib/ezc */
+        snprintf(path, sizeof(path), "%s/../lib/ezc/runtime/ez_runtime.h", self_dir);
+        if (access(path, R_OK) == 0) {
+            snprintf(path, sizeof(path), "%s/../lib/ezc", self_dir);
+            return path;
+        }
+
+        /* Development layout: binary in ezc/, runtime in ezc/src/runtime */
+        snprintf(path, sizeof(path), "%s/src/runtime/ez_runtime.h", self_dir);
+        if (access(path, R_OK) == 0) {
+            snprintf(path, sizeof(path), "%s/src", self_dir);
+            return path;
+        }
+    }
+
+    /* 4. Relative to CWD (running from project root) */
     if (access("ezc/src/runtime/ez_runtime.h", R_OK) == 0) {
         return "ezc/src";
     }
 
-    /* Check relative to binary location */
-    const char *dir = get_runtime_dir(argv0);
-    if (dir) {
-        snprintf(path, sizeof(path), "%s/../src", dir);
-        return path;
-    }
-
-    /* Fallback: try common install locations */
+    /* 5. System install location */
     if (access("/usr/local/lib/ezc/runtime/ez_runtime.h", R_OK) == 0) {
         return "/usr/local/lib/ezc";
     }
@@ -245,11 +310,31 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    /* Check that a C compiler is available */
+    if (system("cc --version >/dev/null 2>&1") != 0 &&
+        system("gcc --version >/dev/null 2>&1") != 0 &&
+        system("clang --version >/dev/null 2>&1") != 0) {
+        fprintf(stderr, "ezc: no C compiler found.\n");
+        fprintf(stderr, "  Install gcc or clang to compile EZ programs.\n");
+        fprintf(stderr, "  On macOS: xcode-select --install\n");
+        fprintf(stderr, "  On Ubuntu: sudo apt install gcc\n");
+        codegen_destroy(&cg);
+        arena_destroy(arena);
+        free(source);
+        free(default_output);
+        return 1;
+    }
+
     /* Find runtime directory */
     const char *runtime_dir = find_runtime_dir(argv[0]);
     if (!runtime_dir) {
-        fprintf(stderr, "ezc: cannot find runtime headers. "
-            "Run from the project root or install the runtime.\n");
+        fprintf(stderr, "ezc: cannot find runtime headers.\n");
+        fprintf(stderr, "  Searched:\n");
+        fprintf(stderr, "    - $EZC_RUNTIME environment variable\n");
+        fprintf(stderr, "    - relative to ezc binary\n");
+        fprintf(stderr, "    - ./ezc/src/ (project root)\n");
+        fprintf(stderr, "    - /usr/local/lib/ezc/\n");
+        fprintf(stderr, "  Try: cd <project-root> && make -C ezc install\n");
         codegen_destroy(&cg);
         arena_destroy(arena);
         free(source);


### PR DESCRIPTION
## Summary
EZC now finds its runtime headers from anywhere, not just the project root.

### Before
```
$ cd /tmp
$ /path/to/ezc hello.ez -o hello
ezc: cannot find runtime headers.
```

### After
```
$ cd /tmp
$ /path/to/ezc hello.ez -o hello
$ ./hello
Hello, World!
```

### How it works
The binary resolves its own location using `_NSGetExecutablePath` (macOS) or `/proc/self/exe` (Linux), then searches for runtime headers relative to that path.

**Search order:**
1. `$EZC_RUNTIME` env var (explicit override)
2. `<binary>/../lib/ezc/` (installed layout)
3. `<binary>/src/` (development layout)
4. `./ezc/src/` (project root CWD)
5. `/usr/local/lib/ezc/` (system install)

### Also
- Check for C compiler with helpful install instructions if missing
- Detailed error message listing all searched paths when runtime not found
- Install target now includes `ez_array.c/h`

## Test plan
- [x] Works from project root (`./ezc/ezc file.ez`)
- [x] Works from ezc directory (`./ezc ../file.ez`)
- [x] Works from any directory with full path (`/path/to/ezc file.ez`)
- [x] Works with `EZC_RUNTIME` env var override
- [x] All existing tests still pass