### PR TITLE
fix(ezc): shared return types, struct field type resolution

### DIFF
--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -679,21 +679,40 @@ static AstNode *parse_func_declaration(Parser *p) {
         node->data.func_decl.return_types = arena_alloc(p->arena, sizeof(const char *) * ret_cap);
 
         if (cur_token_is(p, TOK_LPAREN)) {
-            /* Multiple/named return types: -> (int, string) or -> (x int, y int) */
+            /* Multiple/named return types:
+             *   -> (int, string)        plain types
+             *   -> (x int, y int)       named returns
+             *   -> (x, y int)           shared type
+             */
             next_token(p);
             while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
                 if (cur_token_is(p, TOK_IDENT) && peek_token_is(p, TOK_IDENT)) {
                     /* Named return: name type — skip name, use type */
                     next_token(p);
+                    node->data.func_decl.return_types[node->data.func_decl.return_type_count++] =
+                        p->cur_token.literal;
                 } else if (cur_token_is(p, TOK_IDENT) && peek_token_is(p, TOK_COMMA)) {
-                    /* Could be shared type: -> (x, y int) — just a name, type comes later */
-                    /* For now, skip the name */
-                    next_token(p); /* skip comma */
-                    next_token(p); /* next name or type */
-                    continue;
+                    /* Shared type: (x, y int) — count names, assign same type to all */
+                    int shared = 1;
+                    while (peek_token_is(p, TOK_COMMA)) {
+                        next_token(p); /* skip comma */
+                        next_token(p); /* next name */
+                        shared++;
+                        if (!peek_token_is(p, TOK_COMMA)) break;
+                    }
+                    /* cur is last name, peek should be the shared type */
+                    if (peek_token_is(p, TOK_IDENT)) {
+                        next_token(p);
+                        for (int s = 0; s < shared; s++) {
+                            node->data.func_decl.return_types[node->data.func_decl.return_type_count++] =
+                                p->cur_token.literal;
+                        }
+                    }
+                } else {
+                    /* Plain type */
+                    node->data.func_decl.return_types[node->data.func_decl.return_type_count++] =
+                        p->cur_token.literal;
                 }
-                node->data.func_decl.return_types[node->data.func_decl.return_type_count++] =
-                    p->cur_token.literal;
                 if (peek_token_is(p, TOK_COMMA)) {
                     next_token(p);
                 }

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -287,6 +287,10 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
         break;
 
     case NODE_STRUCT_VALUE:
+        /* Resolve field value types */
+        for (int i = 0; i < node->data.struct_value.count; i++) {
+            resolve_expr(tc, node->data.struct_value.field_values[i]);
+        }
         result = type_struct(node->data.struct_value.name);
         break;
 


### PR DESCRIPTION
## Summary
Two targeted fixes that unblock more examples.

### Shared return type parsing
`-> (min, max int)` now correctly produces 2 return types of `int`. Previously it produced 1, causing `min_max` to be single-return instead of multi-return.

### Struct literal field type resolution
The type checker now resolves expressions inside struct literal field values. This fixes array element type detection when arrays are initialized inside struct instantiation (e.g., `Team{members: {"Alice", "Bob"}}`).

## Results
**9/14 basic examples now pass** (up from 8)
- `structs.ez` is newly passing

## Test plan
- [x] `-> (min, max int)` produces 2 return types
- [x] `-> (x int, y int)` still works (named returns)
- [x] `-> (int, string)` still works (plain types)
- [x] Struct with array field initializes correctly
- [x] `structs.ez` compiles and runs
- [x] All 9 passing examples still work