### PR TITLE
feat(ezc): map type

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -76,6 +76,11 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
         return "EzArray";
     }
 
+    /* Map type: map[K:V] — use EzMap */
+    if (strncmp(type_name, "map[", 4) == 0) {
+        return "EzMap";
+    }
+
     /* If starts with uppercase, it's a user-defined type */
     if (type_name[0] >= 'A' && type_name[0] <= 'Z') {
         static char buf[256];
@@ -272,6 +277,39 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         break;
     }
 
+    case NODE_MAP_VALUE: {
+        /* Map literal: emit inline construction with ez_map_set calls.
+         * We need a temp variable, so wrap in a GCC statement expression. */
+        int count = node->data.map_value.count;
+
+        /* Determine key/value C types from first pair */
+        const char *c_key_type = "EzString";
+        const char *c_val_type = "int64_t";
+        if (count > 0) {
+            EzType *kt = cg->type_table ? typetable_get(cg->type_table, node->data.map_value.keys[0]) : NULL;
+            EzType *vt = cg->type_table ? typetable_get(cg->type_table, node->data.map_value.values[0]) : NULL;
+            if (kt && kt->kind == TK_INT) c_key_type = "int64_t";
+            if (vt && vt->kind == TK_FLOAT) c_val_type = "double";
+            else if (vt && vt->kind == TK_STRING) c_val_type = "EzString";
+            else if (vt && vt->kind == TK_BOOL) c_val_type = "bool";
+        }
+
+        /* Use GCC statement expression: ({ EzMap m = ...; ez_map_set(...); m; }) */
+        static int map_lit_counter = 0;
+        emitf(cg, "({ EzMap _ml%d = ez_map_new(ez_default_arena, sizeof(%s), sizeof(%s), %d); ",
+            map_lit_counter, c_key_type, c_val_type, count > 4 ? count * 2 : 8);
+        for (int i = 0; i < count; i++) {
+            emitf(cg, "{ %s _mk = ", c_key_type);
+            emit_expression(cg, node->data.map_value.keys[i]);
+            emitf(cg, "; %s _mv = ", c_val_type);
+            emit_expression(cg, node->data.map_value.values[i]);
+            emitf(cg, "; ez_map_set(ez_default_arena, &_ml%d, &_mk, &_mv); } ", map_lit_counter);
+        }
+        emitf(cg, "_ml%d; })", map_lit_counter);
+        map_lit_counter++;
+        break;
+    }
+
     case NODE_STRUCT_VALUE:
         /* Struct literal: (EzStruct_Name){.field = value, ...} */
         emitf(cg, "(EzStruct_%s){", node->data.struct_value.name);
@@ -359,8 +397,22 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             emitf(cg, ", %s, ", c_elem);
             emit_expression(cg, node->data.index_expr.index);
             emit(cg, ")");
+        } else if (left_t && left_t->kind == TK_MAP) {
+            /* Map key access: *(type *)ez_map_get(&m, &key) */
+            const char *c_val = "int64_t";
+            if (left_t->value_type) {
+                EzType *vt = type_from_name(left_t->value_type);
+                if (vt->kind == TK_FLOAT) c_val = "double";
+                else if (vt->kind == TK_STRING) c_val = "EzString";
+                else if (vt->kind == TK_BOOL) c_val = "bool";
+            }
+            emitf(cg, "(*(%s *)ez_map_get(&", c_val);
+            emit_expression(cg, node->data.index_expr.left);
+            emit(cg, ", &(");
+            emit_expression(cg, node->data.index_expr.index);
+            emit(cg, ")))");
         } else {
-            /* String indexing or fallback to C array indexing */
+            /* String indexing or fallback */
             emit_expression(cg, node->data.index_expr.left);
             emit(cg, "[");
             emit_expression(cg, node->data.index_expr.index);
@@ -439,6 +491,10 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
                 emit(cg, "(int64_t)(");
                 emit_expression(cg, arg);
                 emit(cg, ").len");
+            } else if (t && t->kind == TK_MAP) {
+                emit(cg, "(int64_t)(");
+                emit_expression(cg, arg);
+                emit(cg, ").count");
             } else {
                 /* Default: try .len for EzArray */
                 emit(cg, "(int64_t)(");
@@ -546,6 +602,18 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
         return;
     }
 
+    /* Map type: map[K:V] */
+    if (type_name && strncmp(type_name, "map[", 4) == 0) {
+        emitf(cg, "EzMap %s = ", node->data.var_decl.name);
+        if (node->data.var_decl.value) {
+            emit_expression(cg, node->data.var_decl.value);
+        } else {
+            emit(cg, "ez_map_new(ez_default_arena, sizeof(EzString), sizeof(int64_t), 8)");
+        }
+        emit(cg, ";\n");
+        return;
+    }
+
     const char *c_type = ez_type_to_c_cg(cg, type_name);
 
     /* Skip blank identifiers (_) */
@@ -610,6 +678,24 @@ static void emit_assign_statement(CodeGen *cg, AstNode *node) {
             emit(cg, ", ");
             emit_expression(cg, node->data.assign.value);
             emit(cg, ");\n");
+            return;
+        }
+        if (left_t && left_t->kind == TK_MAP) {
+            /* Map key assignment: ez_map_set(arena, &m, &key, &value) */
+            const char *c_val = "int64_t";
+            if (left_t->value_type) {
+                EzType *vt = type_from_name(left_t->value_type);
+                if (vt->kind == TK_FLOAT) c_val = "double";
+                else if (vt->kind == TK_STRING) c_val = "EzString";
+                else if (vt->kind == TK_BOOL) c_val = "bool";
+            }
+            emitf(cg, "{ %s _mv = ", c_val);
+            emit_expression(cg, node->data.assign.value);
+            emit(cg, "; ez_map_set(ez_default_arena, &");
+            emit_expression(cg, left);
+            emit(cg, ", &(");
+            emit_expression(cg, node->data.assign.target->data.index_expr.index);
+            emit(cg, "), &_mv); }\n");
             return;
         }
     }
@@ -1078,6 +1164,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
     emit(cg, "/* Generated by EZC */\n");
     emit(cg, "#include \"ez_runtime.h\"\n");
     emit(cg, "#include \"ez_array.h\"\n");
+    emit(cg, "#include \"ez_map.h\"\n");
     if (cg->has_std) {
         emit(cg, "#include \"ez_std.h\"\n");
     }

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -192,6 +192,7 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 case TK_BOOL:   emit(cg, "%s"); break;
                 case TK_CHAR:   emit(cg, "%c"); break;
                 case TK_ARRAY:  emit(cg, "%s"); break;
+                case TK_MAP:    emit(cg, "%s"); break;
                 case TK_ENUM:   emit(cg, "%lld"); break;
                 default:        emit(cg, "%lld"); break;
                 }
@@ -235,6 +236,9 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 break;
             case TK_ARRAY:
                 emit(cg, "\"[...]\"");
+                break;
+            case TK_MAP:
+                emit(cg, "\"{...}\"");
                 break;
             default:
                 emit(cg, "(long long)(");
@@ -604,11 +608,28 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
 
     /* Map type: map[K:V] */
     if (type_name && strncmp(type_name, "map[", 4) == 0) {
+        /* Parse K:V from type string to determine C types */
+        EzType *mt = type_from_name(type_name);
+        const char *c_kt = "EzString";
+        const char *c_vt = "int64_t";
+        if (mt && mt->key_type) {
+            EzType *kt = type_from_name(mt->key_type);
+            if (kt->kind == TK_INT) c_kt = "int64_t";
+        }
+        if (mt && mt->value_type) {
+            EzType *vt = type_from_name(mt->value_type);
+            if (vt->kind == TK_FLOAT) c_vt = "double";
+            else if (vt->kind == TK_STRING) c_vt = "EzString";
+            else if (vt->kind == TK_BOOL) c_vt = "bool";
+        }
+
         emitf(cg, "EzMap %s = ", node->data.var_decl.name);
-        if (node->data.var_decl.value) {
+        if (node->data.var_decl.value &&
+            node->data.var_decl.value->kind == NODE_MAP_VALUE) {
             emit_expression(cg, node->data.var_decl.value);
         } else {
-            emit(cg, "ez_map_new(ez_default_arena, sizeof(EzString), sizeof(int64_t), 8)");
+            /* Empty map or no initializer */
+            emitf(cg, "ez_map_new(ez_default_arena, sizeof(%s), sizeof(%s), 8)", c_kt, c_vt);
         }
         emit(cg, ";\n");
         return;

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -347,11 +347,11 @@ int main(int argc, char **argv) {
     snprintf(cmd, sizeof(cmd),
         "cc -std=c11 -O2 -Wall -Wno-unused-function "
         "-I%s/runtime -I%s/stdlib "
-        "-o %s %s %s/runtime/ez_runtime.c %s/runtime/ez_array.c %s/stdlib/ez_std.c "
+        "-o %s %s %s/runtime/ez_runtime.c %s/runtime/ez_array.c %s/runtime/ez_map.c %s/stdlib/ez_std.c "
         "-lm 2>&1",
         runtime_dir, runtime_dir,
         output_file, c_file,
-        runtime_dir, runtime_dir, runtime_dir);
+        runtime_dir, runtime_dir, runtime_dir, runtime_dir);
 
     int ret = system(cmd);
     if (ret != 0) {

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -281,14 +281,73 @@ static AstNode *parse_prefix(Parser *p) {
     case TOK_AMPERSAND: return parse_prefix_expression(p);
     case TOK_LPAREN:    return parse_grouped_expression(p);
     case TOK_LBRACE: {
-        /* Array literal: {1, 2, 3} */
-        AstNode *node = ast_alloc(p->arena, NODE_ARRAY_VALUE, p->cur_token);
+        /* Could be array literal {1, 2, 3} or map literal {"k": v, ...}
+         * Detect map by checking for colon after first expression */
+        Token brace_tok = p->cur_token;
+        next_token(p); /* skip { */
+
+        /* Empty: {} — treat as empty array (context-dependent) */
+        if (cur_token_is(p, TOK_RBRACE)) {
+            AstNode *node = ast_alloc(p->arena, NODE_ARRAY_VALUE, brace_tok);
+            node->data.array_value.count = 0;
+            node->data.array_value.elements = NULL;
+            return node;
+        }
+
+        /* Parse first expression */
+        AstNode *first = parse_expression(p, PREC_LOWEST);
+
+        if (peek_token_is(p, TOK_COLON)) {
+            /* Map literal: {"key": value, ...} */
+            AstNode *node = ast_alloc(p->arena, NODE_MAP_VALUE, brace_tok);
+            int cap = 8;
+            node->data.map_value.count = 0;
+            node->data.map_value.keys = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+            node->data.map_value.values = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+
+            /* First key already parsed */
+            node->data.map_value.keys[0] = first;
+            next_token(p); /* skip : */
+            next_token(p);
+            node->data.map_value.values[0] = parse_expression(p, PREC_LOWEST);
+            node->data.map_value.count = 1;
+
+            while (peek_token_is(p, TOK_COMMA)) {
+                next_token(p); /* skip , */
+                next_token(p);
+                if (cur_token_is(p, TOK_RBRACE)) break;
+                if (node->data.map_value.count >= cap) {
+                    cap *= 2;
+                    AstNode **nk = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+                    AstNode **nv = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+                    memcpy(nk, node->data.map_value.keys, sizeof(AstNode *) * node->data.map_value.count);
+                    memcpy(nv, node->data.map_value.values, sizeof(AstNode *) * node->data.map_value.count);
+                    node->data.map_value.keys = nk;
+                    node->data.map_value.values = nv;
+                }
+                node->data.map_value.keys[node->data.map_value.count] =
+                    parse_expression(p, PREC_LOWEST);
+                if (!expect_peek(p, TOK_COLON)) return NULL;
+                next_token(p);
+                node->data.map_value.values[node->data.map_value.count] =
+                    parse_expression(p, PREC_LOWEST);
+                node->data.map_value.count++;
+            }
+            if (peek_token_is(p, TOK_RBRACE)) next_token(p);
+            return node;
+        }
+
+        /* Array literal: {expr, expr, ...} */
+        AstNode *node = ast_alloc(p->arena, NODE_ARRAY_VALUE, brace_tok);
         int cap = 8;
         node->data.array_value.count = 0;
         node->data.array_value.elements = arena_alloc(p->arena, sizeof(AstNode *) * cap);
+        node->data.array_value.elements[node->data.array_value.count++] = first;
 
-        next_token(p); /* skip { */
-        while (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+        while (peek_token_is(p, TOK_COMMA)) {
+            next_token(p); /* skip , */
+            next_token(p);
+            if (cur_token_is(p, TOK_RBRACE)) break;
             if (node->data.array_value.count >= cap) {
                 cap *= 2;
                 AstNode **new_elems = arena_alloc(p->arena, sizeof(AstNode *) * cap);
@@ -298,11 +357,8 @@ static AstNode *parse_prefix(Parser *p) {
             }
             node->data.array_value.elements[node->data.array_value.count++] =
                 parse_expression(p, PREC_LOWEST);
-            if (peek_token_is(p, TOK_COMMA)) {
-                next_token(p);
-            }
-            next_token(p);
         }
+        if (peek_token_is(p, TOK_RBRACE)) next_token(p);
         return node;
     }
     case TOK_RANGE: {
@@ -540,15 +596,30 @@ static AstNode *parse_var_declaration(Parser *p) {
 
             return block;
     } else if (peek_token_is(p, TOK_LBRACKET)) {
-        /* Array type: [int], [string], etc. */
-        next_token(p); /* skip [ */
-        next_token(p); /* element type */
-        const char *elem_type = p->cur_token.literal;
-        if (!expect_peek(p, TOK_RBRACKET)) return NULL;
-        /* Build type string like "[int]" */
-        char *type_str = arena_alloc(p->arena, strlen(elem_type) + 3);
-        sprintf(type_str, "[%s]", elem_type);
-        node->data.var_decl.type_name = type_str;
+        /* Could be array type [int] or map type annotation already parsed as "map" */
+        if (node->data.var_decl.type_name &&
+            strcmp(node->data.var_decl.type_name, "map") == 0) {
+            /* Map type: map[K:V] */
+            next_token(p); /* skip [ */
+            next_token(p); /* key type */
+            const char *key_type = p->cur_token.literal;
+            if (!expect_peek(p, TOK_COLON)) return NULL;
+            next_token(p); /* value type */
+            const char *val_type = p->cur_token.literal;
+            if (!expect_peek(p, TOK_RBRACKET)) return NULL;
+            char *type_str = arena_alloc(p->arena, strlen(key_type) + strlen(val_type) + 6);
+            sprintf(type_str, "map[%s:%s]", key_type, val_type);
+            node->data.var_decl.type_name = type_str;
+        } else {
+            /* Array type: [int], [string], etc. */
+            next_token(p); /* skip [ */
+            next_token(p); /* element type */
+            const char *elem_type = p->cur_token.literal;
+            if (!expect_peek(p, TOK_RBRACKET)) return NULL;
+            char *type_str = arena_alloc(p->arena, strlen(elem_type) + 3);
+            sprintf(type_str, "[%s]", elem_type);
+            node->data.var_decl.type_name = type_str;
+        }
     }
 
     /* = value */

--- a/ezc/src/runtime/ez_map.c
+++ b/ezc/src/runtime/ez_map.c
@@ -1,0 +1,157 @@
+/*
+ * ez_map.c - Hash map implementation
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "ez_map.h"
+#include <string.h>
+
+/* FNV-1a hash */
+static uint64_t hash_bytes(const void *data, int32_t size) {
+    const uint8_t *bytes = (const uint8_t *)data;
+    uint64_t hash = 14695981039346656037ULL;
+    for (int32_t i = 0; i < size; i++) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+/* Hash for EzString keys — hash the string data, not the struct */
+static uint64_t hash_ez_string(const void *key, int32_t key_size) {
+    if (key_size == (int32_t)sizeof(EzString)) {
+        const EzString *s = (const EzString *)key;
+        return hash_bytes(s->data, s->len);
+    }
+    return hash_bytes(key, key_size);
+}
+
+/* Compare keys — special handling for EzString */
+static bool keys_equal(const void *a, const void *b, int32_t key_size) {
+    if (key_size == (int32_t)sizeof(EzString)) {
+        const EzString *sa = (const EzString *)a;
+        const EzString *sb = (const EzString *)b;
+        if (sa->len != sb->len) return false;
+        return memcmp(sa->data, sb->data, (size_t)sa->len) == 0;
+    }
+    return memcmp(a, b, (size_t)key_size) == 0;
+}
+
+static void *key_ptr(EzMap *m, int32_t idx) {
+    return (char *)m->keys + (size_t)idx * (size_t)m->key_size;
+}
+
+static void *val_ptr(EzMap *m, int32_t idx) {
+    return (char *)m->values + (size_t)idx * (size_t)m->value_size;
+}
+
+EzMap ez_map_new(EzArena *arena, int32_t key_size, int32_t value_size, int32_t initial_cap) {
+    if (initial_cap < 8) initial_cap = 8;
+    EzMap m;
+    m.key_size = key_size;
+    m.value_size = value_size;
+    m.count = 0;
+    m.capacity = initial_cap;
+    m.keys = ez_arena_alloc(arena, (size_t)initial_cap * (size_t)key_size);
+    m.values = ez_arena_alloc(arena, (size_t)initial_cap * (size_t)value_size);
+    m.states = ez_arena_alloc(arena, (size_t)initial_cap);
+    memset(m.states, 0, (size_t)initial_cap);
+    return m;
+}
+
+static int32_t find_slot(EzMap *m, const void *key) {
+    uint64_t h = hash_ez_string(key, m->key_size);
+    int32_t idx = (int32_t)(h % (uint64_t)m->capacity);
+    for (int32_t i = 0; i < m->capacity; i++) {
+        int32_t probe = (idx + i) % m->capacity;
+        if (m->states[probe] == 0) return -1; /* empty — not found */
+        if (m->states[probe] == 1 && keys_equal(key_ptr(m, probe), key, m->key_size)) {
+            return probe;
+        }
+    }
+    return -1;
+}
+
+static void rehash(EzArena *arena, EzMap *m) {
+    int32_t old_cap = m->capacity;
+    void *old_keys = m->keys;
+    void *old_values = m->values;
+    uint8_t *old_states = m->states;
+
+    m->capacity = old_cap * 2;
+    m->keys = ez_arena_alloc(arena, (size_t)m->capacity * (size_t)m->key_size);
+    m->values = ez_arena_alloc(arena, (size_t)m->capacity * (size_t)m->value_size);
+    m->states = ez_arena_alloc(arena, (size_t)m->capacity);
+    memset(m->states, 0, (size_t)m->capacity);
+    m->count = 0;
+
+    for (int32_t i = 0; i < old_cap; i++) {
+        if (old_states[i] == 1) {
+            ez_map_set(arena, m,
+                (char *)old_keys + (size_t)i * (size_t)m->key_size,
+                (char *)old_values + (size_t)i * (size_t)m->value_size);
+        }
+    }
+}
+
+void *ez_map_get(EzMap *m, const void *key) {
+    int32_t idx = find_slot(m, key);
+    if (idx < 0) return NULL;
+    return val_ptr(m, idx);
+}
+
+void ez_map_set(EzArena *arena, EzMap *m, const void *key, const void *value) {
+    /* Check load factor */
+    if (m->count * 4 >= m->capacity * 3) {
+        rehash(arena, m);
+    }
+
+    uint64_t h = hash_ez_string(key, m->key_size);
+    int32_t idx = (int32_t)(h % (uint64_t)m->capacity);
+    for (int32_t i = 0; i < m->capacity; i++) {
+        int32_t probe = (idx + i) % m->capacity;
+        if (m->states[probe] == 0 || m->states[probe] == 2) {
+            /* Empty or tombstone — insert here */
+            memcpy(key_ptr(m, probe), key, (size_t)m->key_size);
+            memcpy(val_ptr(m, probe), value, (size_t)m->value_size);
+            m->states[probe] = 1;
+            m->count++;
+            return;
+        }
+        if (m->states[probe] == 1 && keys_equal(key_ptr(m, probe), key, m->key_size)) {
+            /* Update existing */
+            memcpy(val_ptr(m, probe), value, (size_t)m->value_size);
+            return;
+        }
+    }
+}
+
+bool ez_map_has(EzMap *m, const void *key) {
+    return find_slot(m, key) >= 0;
+}
+
+bool ez_map_remove(EzMap *m, const void *key) {
+    int32_t idx = find_slot(m, key);
+    if (idx < 0) return false;
+    m->states[idx] = 2; /* tombstone */
+    m->count--;
+    return true;
+}
+
+void *ez_map_get_str(EzMap *m, EzString key) {
+    return ez_map_get(m, &key);
+}
+
+void ez_map_set_str(EzArena *arena, EzMap *m, EzString key, const void *value) {
+    ez_map_set(arena, m, &key, value);
+}
+
+void *ez_map_key_at(EzMap *m, int32_t internal_idx) {
+    return key_ptr(m, internal_idx);
+}
+
+void *ez_map_value_at(EzMap *m, int32_t internal_idx) {
+    return val_ptr(m, internal_idx);
+}

--- a/ezc/src/runtime/ez_map.h
+++ b/ezc/src/runtime/ez_map.h
@@ -1,0 +1,49 @@
+/*
+ * ez_map.h - Hash map type for EZC
+ *
+ * Open-addressing hash table with linear probing.
+ * Keys and values stored as fixed-size blobs.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZ_MAP_H
+#define EZ_MAP_H
+
+#include "ez_runtime.h"
+
+typedef struct {
+    void *keys;
+    void *values;
+    uint8_t *states;        /* 0=empty, 1=occupied, 2=tombstone */
+    int32_t count;
+    int32_t capacity;
+    int32_t key_size;
+    int32_t value_size;
+} EzMap;
+
+/* Create an empty map */
+EzMap ez_map_new(EzArena *arena, int32_t key_size, int32_t value_size, int32_t initial_cap);
+
+/* Get a pointer to the value for a key, or NULL if not found */
+void *ez_map_get(EzMap *m, const void *key);
+
+/* Set a key-value pair (inserts or updates) */
+void ez_map_set(EzArena *arena, EzMap *m, const void *key, const void *value);
+
+/* Check if a key exists */
+bool ez_map_has(EzMap *m, const void *key);
+
+/* Remove a key */
+bool ez_map_remove(EzMap *m, const void *key);
+
+/* String-keyed convenience functions */
+void *ez_map_get_str(EzMap *m, EzString key);
+void ez_map_set_str(EzArena *arena, EzMap *m, EzString key, const void *value);
+
+/* Get key at internal index (for iteration) */
+void *ez_map_key_at(EzMap *m, int32_t internal_idx);
+void *ez_map_value_at(EzMap *m, int32_t internal_idx);
+
+#endif

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -286,6 +286,25 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
         }
         break;
 
+    case NODE_MAP_VALUE: {
+        /* Resolve key and value types */
+        for (int i = 0; i < node->data.map_value.count; i++) {
+            resolve_expr(tc, node->data.map_value.keys[i]);
+            resolve_expr(tc, node->data.map_value.values[i]);
+        }
+        EzType *t = type_alloc();
+        t->kind = TK_MAP;
+        t->name = "map";
+        if (node->data.map_value.count > 0) {
+            EzType *kt = typetable_get(tc->type_table, node->data.map_value.keys[0]);
+            EzType *vt = typetable_get(tc->type_table, node->data.map_value.values[0]);
+            t->key_type = kt ? type_name(kt) : "unknown";
+            t->value_type = vt ? type_name(vt) : "unknown";
+        }
+        result = t;
+        break;
+    }
+
     case NODE_STRUCT_VALUE:
         /* Resolve field value types */
         for (int i = 0; i < node->data.struct_value.count; i++) {

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -24,7 +24,7 @@ EzType TYPE_UNKNOWN = {TK_UNKNOWN,"unknown",NULL, NULL, NULL};
 static EzType type_pool[256];
 static int type_pool_count = 0;
 
-static EzType *type_alloc(void) {
+EzType *type_alloc(void) {
     if (type_pool_count >= 256) return &TYPE_UNKNOWN;
     return &type_pool[type_pool_count++];
 }
@@ -110,6 +110,32 @@ EzType *type_from_name(const char *name) {
             elem[len - 2] = '\0';
             return type_array(elem);
         }
+    }
+
+    /* Map type: map[K:V] */
+    if (strncmp(name, "map[", 4) == 0) {
+        EzType *t = type_alloc();
+        t->kind = TK_MAP;
+        t->name = name;
+        /* Parse key:value types from "map[string:int]" */
+        const char *start = name + 4;
+        const char *colon = strchr(start, ':');
+        if (colon) {
+            size_t klen = (size_t)(colon - start);
+            char *key = malloc(klen + 1);
+            memcpy(key, start, klen);
+            key[klen] = '\0';
+            t->key_type = key;
+
+            const char *vstart = colon + 1;
+            size_t vlen = strlen(vstart);
+            if (vlen > 0 && vstart[vlen - 1] == ']') vlen--;
+            char *val = malloc(vlen + 1);
+            memcpy(val, vstart, vlen);
+            val[vlen] = '\0';
+            t->value_type = val;
+        }
+        return t;
     }
 
     /* Uppercase = struct type */

--- a/ezc/src/typechecker/types.h
+++ b/ezc/src/typechecker/types.h
@@ -51,6 +51,9 @@ EzType *type_array(const char *elem_type);
 EzType *type_struct(const char *name);
 EzType *type_enum(const char *name);
 
+/* Allocate a new type (from internal pool) */
+EzType *type_alloc(void);
+
 /* Type queries */
 bool type_is_numeric(EzType *t);
 bool type_is_integer(EzType *t);


### PR DESCRIPTION
## Summary
Adds the map type to EZC — the last major composite data type.

### EzMap Runtime
- Open-addressing hash table with FNV-1a hashing and linear probing
- String key comparison by value (not pointer)
- Auto-rehash at 75% load factor
- Arena-allocated backing storage
- Get, set, has, remove operations

### Parser
- Parse `map[K:V]` type syntax (e.g., `map[string:int]`)
- Parse map literals `{"key": value, ...}` — distinguished from array literals by detecting `:` after first expression
- Empty map declarations handled correctly

### Codegen
- Map literals use GCC statement expressions with `ez_map_set` calls
- Map key access: `*(type *)ez_map_get(&m, &key)`
- Map key assignment: `ez_map_set(arena, &m, &key, &value)`
- `len()` on maps uses `.count`
- String interpolation of maps emits `{...}` placeholder

### Type Checker
- Parse `map[K:V]` type strings to extract key/value types
- Resolve `NODE_MAP_VALUE` with key/value type inference

## Test plan
- [x] Map creation with string:int pairs
- [x] Map key access returns correct value
- [x] Map key assignment updates value
- [x] `len()` returns map entry count
- [x] All 85 existing tests pass
- [x] 10/14 examples still passing (maps.ez needs @maps stdlib)