### PR TITLE
feat(ezc): Error type, transparent ref(), 15/15 examples passing

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -70,6 +70,7 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
     if (strcmp(type_name, "char") == 0)   return "int32_t";
     if (strcmp(type_name, "byte") == 0)   return "uint8_t";
     if (strcmp(type_name, "string") == 0) return "EzString";
+    if (strcmp(type_name, "Error") == 0) return "EzError *";
 
     /* Pointer type: ^T — use C pointer */
     if (type_name[0] == '^') {
@@ -206,6 +207,7 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 case TK_CHAR:   emit(cg, "%c"); break;
                 case TK_ARRAY:  emit(cg, "%s"); break;
                 case TK_MAP:    emit(cg, "%s"); break;
+                case TK_ERROR:  emit(cg, "%s"); break;
                 case TK_ENUM:   emit(cg, "%lld"); break;
                 default:        emit(cg, "%lld"); break;
                 }
@@ -252,6 +254,13 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 break;
             case TK_MAP:
                 emit(cg, "\"{...}\"");
+                break;
+            case TK_ERROR:
+                /* Print error message */
+                emit_expression(cg, part);
+                emit(cg, " ? ");
+                emit_expression(cg, part);
+                emit(cg, "->message.data : \"nil\"");
                 break;
             default:
                 emit(cg, "(long long)(");
@@ -458,7 +467,7 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             }
 
             emit_expression(cg, node->data.member.object);
-            if (obj_t && obj_t->kind == TK_POINTER) {
+            if (obj_t && (obj_t->kind == TK_POINTER || obj_t->kind == TK_ERROR)) {
                 emitf(cg, "->%s", node->data.member.member);
             } else {
                 emitf(cg, ".%s", node->data.member.member);
@@ -668,8 +677,8 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
             return;
         }
 
-        if (strcmp(func, "error") == 0 && node->data.call.arg_count == 1) {
-            emit(cg, "ez_std_error(");
+        if (strcmp(func, "error") == 0 && node->data.call.arg_count >= 1) {
+            emit(cg, "ez_error_new(ez_default_arena, ");
             emit_expression(cg, node->data.call.args[0]);
             emit(cg, ")");
             return;
@@ -1014,9 +1023,23 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
 
         /* @io module functions */
         if (module && strcmp(module, "io") == 0) {
-            bool needs_arena = (strcmp(func, "read_file") == 0);
+            /* Fallible functions: use _result version that returns (value, Error) tuple */
+            bool is_fallible = (strcmp(func, "read_file") == 0 ||
+                strcmp(func, "write_file") == 0 ||
+                strcmp(func, "delete_file") == 0 || strcmp(func, "remove") == 0);
+            if (is_fallible) {
+                const char *actual_func = func;
+                if (strcmp(func, "remove") == 0) actual_func = "delete_file";
+                emitf(cg, "ez_io_%s_result(ez_default_arena, ", actual_func);
+                for (int i = 0; i < node->data.call.arg_count; i++) {
+                    if (i > 0) emit(cg, ", ");
+                    emit_expression(cg, node->data.call.args[i]);
+                }
+                emit(cg, ")");
+                return;
+            }
+            /* Non-fallible functions */
             emitf(cg, "ez_io_%s(", func);
-            if (needs_arena) emit(cg, "ez_default_arena, ");
             for (int i = 0; i < node->data.call.arg_count; i++) {
                 if (i > 0) emit(cg, ", ");
                 emit_expression(cg, node->data.call.args[i]);
@@ -1254,8 +1277,10 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
             c_type = "double";
         } else if (val->kind == NODE_BOOL_VALUE) {
             c_type = "bool";
-        } else if (val->kind == NODE_CALL_EXPR || val->kind == NODE_NEW_EXPR) {
-            /* Use __auto_type for function calls and new() to infer types */
+        } else if (val->kind == NODE_CALL_EXPR || val->kind == NODE_NEW_EXPR ||
+                   val->kind == NODE_MEMBER_EXPR) {
+            /* Use __auto_type for function calls, new(), and member access
+             * (needed for multi-var unpacking: temp x = _tmp.v0) */
             c_type = "__auto_type";
         }
     }

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -105,6 +105,21 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
 }
 
 /* Check if a variable name is a mutable parameter in the current function */
+static bool is_ref_var(CodeGen *cg, const char *name) {
+    for (int i = 0; i < cg->ref_var_count; i++) {
+        if (strcmp(cg->ref_vars[i], name) == 0) return true;
+    }
+    return false;
+}
+
+static void register_ref_var(CodeGen *cg, const char *name) {
+    if (cg->ref_var_count >= cg->ref_var_cap) {
+        cg->ref_var_cap = cg->ref_var_cap ? cg->ref_var_cap * 2 : 8;
+        cg->ref_vars = realloc(cg->ref_vars, sizeof(const char *) * cg->ref_var_cap);
+    }
+    cg->ref_vars[cg->ref_var_count++] = name;
+}
+
 static bool is_mutable_param(CodeGen *cg, const char *name) {
     if (!cg->current_func) return false;
     for (int i = 0; i < cg->current_func->data.func_decl.param_count; i++) {
@@ -136,6 +151,8 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         if (strcmp(name, "EXIT_SUCCESS") == 0) { emit(cg, "0"); break; }
         if (strcmp(name, "EXIT_FAILURE") == 0) { emit(cg, "1"); break; }
         if (is_mutable_param(cg, name)) {
+            emitf(cg, "(*%s)", name);
+        } else if (is_ref_var(cg, name)) {
             emitf(cg, "(*%s)", name);
         } else {
             emit(cg, name);
@@ -467,7 +484,10 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             }
 
             emit_expression(cg, node->data.member.object);
-            if (obj_t && (obj_t->kind == TK_POINTER || obj_t->kind == TK_ERROR)) {
+            /* Ref vars are already dereferenced by label emission — use . not -> */
+            bool obj_is_ref = (node->data.member.object->kind == NODE_LABEL &&
+                is_ref_var(cg, node->data.member.object->data.label.value));
+            if (!obj_is_ref && obj_t && (obj_t->kind == TK_POINTER || obj_t->kind == TK_ERROR)) {
                 emitf(cg, "->%s", node->data.member.member);
             } else {
                 emitf(cg, ".%s", node->data.member.member);
@@ -1285,6 +1305,14 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
         }
     }
 
+    /* Detect ref() assignment — register as transparent reference */
+    if (node->data.var_decl.value && node->data.var_decl.value->kind == NODE_CALL_EXPR) {
+        AstNode *fn = node->data.var_decl.value->data.call.function;
+        if (fn->kind == NODE_LABEL && strcmp(fn->data.label.value, "ref") == 0) {
+            register_ref_var(cg, node->data.var_decl.name);
+        }
+    }
+
     if (!node->data.var_decl.mutable) {
         emit(cg, "const ");
     }
@@ -1801,6 +1829,9 @@ CodeGen codegen_create(const char *file) {
     cg.func_count = 0;
     cg.func_cap = 0;
     cg.type_table = NULL;
+    cg.ref_vars = NULL;
+    cg.ref_var_count = 0;
+    cg.ref_var_cap = 0;
     return cg;
 }
 

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -35,6 +35,11 @@ typedef struct {
 
     /* Type table from type checker (for type-aware codegen) */
     TypeTable *type_table;
+
+    /* Ref variables (transparent references from ref()) */
+    const char **ref_vars;
+    int ref_var_count;
+    int ref_var_cap;
 } CodeGen;
 
 CodeGen codegen_create(const char *file);

--- a/ezc/src/runtime/ez_runtime.c
+++ b/ezc/src/runtime/ez_runtime.c
@@ -84,6 +84,15 @@ size_t ez_arena_usage(EzArena *arena) {
     return total;
 }
 
+/* --- Error --- */
+
+EzError *ez_error_new(EzArena *arena, EzString message) {
+    EzError *err = (EzError *)ez_arena_alloc(arena, sizeof(EzError));
+    err->message = ez_string_new(arena, message.data, message.len);
+    err->code = ez_string_lit("");
+    return err;
+}
+
 /* --- String --- */
 
 EzString ez_string_new(EzArena *arena, const char *s, int32_t len) {

--- a/ezc/src/runtime/ez_runtime.h
+++ b/ezc/src/runtime/ez_runtime.h
@@ -48,6 +48,16 @@ typedef struct {
     int32_t len;
 } EzString;
 
+/* --- Error --- */
+
+typedef struct {
+    EzString message;
+    EzString code;
+} EzError;
+
+/* Create an error on the default arena */
+EzError *ez_error_new(EzArena *arena, EzString message);
+
 /* Create a string from a C string literal (no copy, points to static data) */
 static inline EzString ez_string_lit(const char *s) {
     EzString str;

--- a/ezc/src/stdlib/ez_io.c
+++ b/ezc/src/stdlib/ez_io.c
@@ -69,3 +69,52 @@ bool ez_io_delete_file(EzString path) {
 bool ez_io_rename(EzString old_path, EzString new_path) {
     return rename(old_path.data, new_path.data) == 0;
 }
+
+/* Tuple-returning versions */
+
+EzResult_string ez_io_read_file_result(EzArena *arena, EzString path) {
+    EzResult_string r;
+    FILE *f = fopen(path.data, "rb");
+    if (!f) {
+        r.v0 = ez_string_lit("");
+        r.v1 = ez_error_new(arena, ez_string_format(arena, "cannot read '%s'", path.data));
+        return r;
+    }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = ez_arena_alloc(arena, (size_t)size + 1);
+    size_t read = fread(buf, 1, (size_t)size, f);
+    buf[read] = '\0';
+    fclose(f);
+    r.v0 = (EzString){ buf, (int32_t)read };
+    r.v1 = NULL;
+    return r;
+}
+
+EzResult_bool ez_io_write_file_result(EzArena *arena, EzString path, EzString content) {
+    EzResult_bool r;
+    FILE *f = fopen(path.data, "wb");
+    if (!f) {
+        r.v0 = false;
+        r.v1 = ez_error_new(arena, ez_string_format(arena, "cannot write '%s'", path.data));
+        return r;
+    }
+    fwrite(content.data, 1, (size_t)content.len, f);
+    fclose(f);
+    r.v0 = true;
+    r.v1 = NULL;
+    return r;
+}
+
+EzResult_bool ez_io_delete_file_result(EzArena *arena, EzString path) {
+    EzResult_bool r;
+    if (unlink(path.data) == 0) {
+        r.v0 = true;
+        r.v1 = NULL;
+    } else {
+        r.v0 = false;
+        r.v1 = ez_error_new(arena, ez_string_format(arena, "cannot delete '%s'", path.data));
+    }
+    return r;
+}

--- a/ezc/src/stdlib/ez_io.h
+++ b/ezc/src/stdlib/ez_io.h
@@ -29,4 +29,12 @@ bool ez_io_rename(EzString old_path, EzString new_path);
 #define ez_io_remove ez_io_delete_file
 #define ez_io_exists ez_io_file_exists
 
+/* Tuple-returning versions for (value, Error) pattern */
+typedef struct { EzString v0; EzError *v1; } EzResult_string;
+typedef struct { bool v0; EzError *v1; } EzResult_bool;
+
+EzResult_string ez_io_read_file_result(EzArena *arena, EzString path);
+EzResult_bool ez_io_write_file_result(EzArena *arena, EzString path, EzString content);
+EzResult_bool ez_io_delete_file_result(EzArena *arena, EzString path);
+
 #endif

--- a/ezc/src/typechecker/scope.h
+++ b/ezc/src/typechecker/scope.h
@@ -14,6 +14,7 @@ typedef struct {
     const char *name;
     EzType *type;
     bool mutable;
+    bool is_ref;    /* true if created via ref() — transparent reference */
 } Symbol;
 
 typedef struct Scope {

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -258,13 +258,18 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                     result = &TYPE_VOID;
                 }
             } else if (strcmp(mod, "io") == 0) {
+                /* Fallible I/O: the type checker returns the primary value type.
+                 * The codegen emits _result() versions that return (T, Error) tuples.
+                 * The .v0 access gets __auto_type in C, but the EZ type system
+                 * sees it as the value type for interpolation purposes. */
                 if (strcmp(mfn, "read_file") == 0) {
                     result = &TYPE_STRING;
+                } else if (strcmp(mfn, "write_file") == 0 ||
+                    strcmp(mfn, "delete_file") == 0 || strcmp(mfn, "remove") == 0) {
+                    result = &TYPE_BOOL;
                 } else if (strcmp(mfn, "file_exists") == 0 || strcmp(mfn, "exists") == 0 ||
                            strcmp(mfn, "is_file") == 0 || strcmp(mfn, "is_directory") == 0 ||
-                           strcmp(mfn, "write_file") == 0 || strcmp(mfn, "append_file") == 0 ||
-                           strcmp(mfn, "delete_file") == 0 || strcmp(mfn, "remove") == 0 ||
-                           strcmp(mfn, "rename") == 0) {
+                           strcmp(mfn, "append_file") == 0 || strcmp(mfn, "rename") == 0) {
                     result = &TYPE_BOOL;
                 } else if (strcmp(mfn, "file_size") == 0) {
                     result = &TYPE_INT;
@@ -316,10 +321,12 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
             } else if (strcmp(fn_name, "to_float") == 0) {
                 result = &TYPE_FLOAT;
             } else if (strcmp(fn_name, "to_string") == 0 || strcmp(fn_name, "typeof") == 0 ||
-                       strcmp(fn_name, "input") == 0 || strcmp(fn_name, "error") == 0) {
+                       strcmp(fn_name, "input") == 0) {
                 result = &TYPE_STRING;
             } else if (strcmp(fn_name, "to_bool") == 0) {
                 result = &TYPE_BOOL;
+            } else if (strcmp(fn_name, "error") == 0) {
+                result = type_from_name("Error");
             } else if (strcmp(fn_name, "exit") == 0 || strcmp(fn_name, "panic") == 0 ||
                        strcmp(fn_name, "assert") == 0 || strcmp(fn_name, "eprintln") == 0 ||
                        strcmp(fn_name, "eprint") == 0 ||
@@ -370,10 +377,20 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                 break;
             }
 
-            /* Otherwise it's a struct field access */
+            /* Otherwise it's a struct field or multi-return access */
             Symbol *sym = scope_lookup(tc->current_scope, obj_name);
             if (sym && sym->type->kind == TK_STRUCT) {
                 result = struct_field_type(tc, sym->type->name, member);
+            } else if (sym && member[0] == 'v' && member[1] >= '0' && member[1] <= '9') {
+                /* Multi-return .v0/.v1 access — .v0 returns the primary type */
+                if (member[1] == '0') {
+                    result = sym->type;
+                } else {
+                    result = type_from_name("Error");
+                }
+            } else if (sym && sym->type->kind == TK_POINTER) {
+                /* Pointer auto-deref field access */
+                result = struct_field_type(tc, sym->type->element_type, member);
             }
         }
         break;

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -495,6 +495,17 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
         if (strcmp(node->data.var_decl.name, "_") != 0) {
             scope_define(tc->current_scope, node->data.var_decl.name,
                 declared, node->data.var_decl.mutable);
+
+            /* Mark as transparent ref if assigned from ref() */
+            if (node->data.var_decl.value &&
+                node->data.var_decl.value->kind == NODE_CALL_EXPR) {
+                AstNode *fn = node->data.var_decl.value->data.call.function;
+                if (fn->kind == NODE_LABEL && strcmp(fn->data.label.value, "ref") == 0) {
+                    Symbol *sym = scope_lookup_local(tc->current_scope,
+                        node->data.var_decl.name);
+                    if (sym) sym->is_ref = true;
+                }
+            }
         }
         break;
     }

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -108,6 +108,12 @@ EzType *type_from_name(const char *name) {
     if (strcmp(name, "string") == 0) return &TYPE_STRING;
     if (strcmp(name, "void") == 0)   return &TYPE_VOID;
     if (strcmp(name, "nil") == 0)    return &TYPE_NIL;
+    if (strcmp(name, "Error") == 0) {
+        EzType *t = type_alloc();
+        t->kind = TK_ERROR;
+        t->name = "Error";
+        return t;
+    }
 
     /* Pointer type: ^int, ^Person, etc. */
     if (name[0] == '^') {

--- a/ezc/src/typechecker/types.h
+++ b/ezc/src/typechecker/types.h
@@ -23,6 +23,7 @@ typedef enum {
     TK_STRUCT,
     TK_ENUM,
     TK_POINTER,
+    TK_ERROR,
     TK_FUNCTION,
     TK_NIL,
     TK_UNKNOWN,


### PR DESCRIPTION
## Summary
Two foundational features that complete the EZ language model in EZC.

### Error Type (#1197)
- `EzError` struct with `.message` and `.code` fields
- `error("msg")` returns `EzError *` (nil = no error)
- I/O functions return `(value, Error)` tuples via `_result()` variants
- `.message` field access uses `->` (pointer deref)
- Error in string interpolation prints message or "nil"
- `nil` comparison works for error checking

### Transparent References
- `ref(x)` returns a pointer but auto-derefs on read and write
- `alias = 42` where `alias = ref(x)` changes `x` to 42
- `p4.x = 500` where `p4 = ref(p3)` writes through the reference
- Matches interpreter semantics — no explicit `^` needed

### Multi-return .v0 type resolution
- `.v0` on a known function result resolves to the value type
- `.v1` resolves to Error type
- Fixes type-aware interpolation for unpacked variables

## Results
**15/15 basic examples pass. Every single one.**

| Example | Status |
|---------|--------|
| arrays, calculator, control_flow | PASS |
| ensure, enums, fibonacci, fizzbuzz | PASS |
| functions, hello, maps, memory | PASS |
| primes, references, structs, variables | PASS |

99/99 unit + e2e tests passing.

## Test plan
- [x] `error("msg")` creates Error with message
- [x] `if err != nil` works for error checking
- [x] `temp content, err = io.read_file(path)` unpacks correctly
- [x] `temp _, _ = io.write_file(path, data)` discards both values
- [x] `ref(x)` creates transparent reference
- [x] Assignment through ref modifies original
- [x] Struct field access through ref works
- [x] All 15 examples compile and run
- [x] All 99 tests pass