### PR TITLE
ci: add EZC to CI/CodeQL, update .gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
       - release
+      - v3.0.0
   pull_request:
     branches:
       - main
+      - v3.0.0
 
 jobs:
   test:
@@ -61,6 +63,36 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit 1 }
           }
 
+      # ===== EZC Compiler =====
+      - name: Build EZC compiler
+        if: runner.os != 'Windows'
+        run: |
+          cd ezc
+          make clean
+          make build
+
+      - name: Run EZC unit tests
+        if: runner.os != 'Windows'
+        run: |
+          cd ezc
+          make test-unit
+
+      - name: Run EZC end-to-end tests
+        if: runner.os != 'Windows'
+        run: |
+          cd ezc
+          make test-e2e
+
+      - name: Compile all examples with EZC
+        if: runner.os != 'Windows'
+        run: |
+          for file in examples/basic/*.ez; do
+            echo "Compiling $file..."
+            ./ezc/ezc "$file" -o "/tmp/ezc_$(basename $file .ez)" || exit 1
+          done
+          echo "All examples compiled successfully"
+
+      # ===== Interpreter REPL =====
       - name: Test REPL basic functionality (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,13 +25,19 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: go
+          languages: go, c-cpp
           queries: security-and-quality
 
-      - name: Build and run tests
+      - name: Build Go interpreter
         run: |
           go env
           go test ./... || true
+
+      - name: Build EZC compiler
+        run: |
+          cd ezc
+          make clean
+          make build
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 *.a
 /ez
 /ezc/ezc
+/ezc/libezrt.a
+/ezc/tests/test_lexer
+/ezc/tests/test_parser
+/ezc/tests/test_typechecker
+/ezc/tests/test_codegen
 
 # Build directories
 dist/


### PR DESCRIPTION
## Summary
Protects the EZC compiler with CI and security scanning.

### CI (#1166)
- Build EZC on Linux and macOS
- Run 99 unit tests (lexer + parser + type checker)
- Run 35 end-to-end tests (compile and execute)
- Compile all 15 basic examples
- Trigger on v3.0.0 branch

### CodeQL (#1167)
- Add `c-cpp` language to CodeQL analysis
- Build EZC during analysis for C security scanning

### .gitignore (#1168)
- `libezrt.a` — pre-compiled runtime archive
- `ezc/tests/test_*` — compiled test binaries

Closes #1166, #1167, #1168