### PR TITLE
feat(ezc): string ops, integration test runner

### DIFF
--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -120,4 +120,7 @@ test-e2e: build tests/test_codegen
 test-parity: build
 	@./tests/run_parity.sh
 
+test-integration: build
+	@./tests/run_integration.sh
+
 test: test-unit test-e2e test-parity

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -372,11 +372,42 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         break;
 
     case NODE_INFIX_EXPR: {
-        /* Only wrap in parens if the parent is also an expression.
-         * Skip parens for top-level comparisons to avoid ((x == y)) warnings. */
         const char *op = node->data.infix.op;
+
+        /* Check if either operand is a string — need special handling */
+        EzType *lt = cg->type_table ? typetable_get(cg->type_table, node->data.infix.left) : NULL;
+        EzType *rt = cg->type_table ? typetable_get(cg->type_table, node->data.infix.right) : NULL;
+        bool left_is_str = (lt && lt->kind == TK_STRING) || node->data.infix.left->kind == NODE_STRING_VALUE;
+        bool right_is_str = (rt && rt->kind == TK_STRING) || node->data.infix.right->kind == NODE_STRING_VALUE;
+
+        if ((left_is_str || right_is_str) && strcmp(op, "+") == 0) {
+            /* String concatenation */
+            emit(cg, "ez_string_concat(ez_default_arena, ");
+            emit_expression(cg, node->data.infix.left);
+            emit(cg, ", ");
+            emit_expression(cg, node->data.infix.right);
+            emit(cg, ")");
+            break;
+        }
+        if ((left_is_str || right_is_str) && strcmp(op, "==") == 0) {
+            emit(cg, "ez_string_eq(");
+            emit_expression(cg, node->data.infix.left);
+            emit(cg, ", ");
+            emit_expression(cg, node->data.infix.right);
+            emit(cg, ")");
+            break;
+        }
+        if ((left_is_str || right_is_str) && strcmp(op, "!=") == 0) {
+            emit(cg, "!ez_string_eq(");
+            emit_expression(cg, node->data.infix.left);
+            emit(cg, ", ");
+            emit_expression(cg, node->data.infix.right);
+            emit(cg, ")");
+            break;
+        }
+
+        /* Normal infix — smart parens */
         bool needs_parens = true;
-        /* Check if both children are simple (no further nesting needed) */
         NodeKind lk = node->data.infix.left->kind;
         NodeKind rk = node->data.infix.right->kind;
         bool l_simple = (lk == NODE_LABEL || lk == NODE_INT_VALUE ||

--- a/ezc/src/runtime/ez_runtime.c
+++ b/ezc/src/runtime/ez_runtime.c
@@ -126,6 +126,16 @@ EzString ez_string_format(EzArena *arena, const char *fmt, ...) {
     return str;
 }
 
+EzString ez_string_concat(EzArena *arena, EzString a, EzString b) {
+    int32_t new_len = a.len + b.len;
+    char *data = (char *)ez_arena_alloc(arena, (size_t)new_len + 1);
+    memcpy(data, a.data, (size_t)a.len);
+    memcpy(data + a.len, b.data, (size_t)b.len);
+    data[new_len] = '\0';
+    EzString s = { data, new_len };
+    return s;
+}
+
 /* --- Runtime Init/Shutdown --- */
 
 void ez_runtime_init(void) {

--- a/ezc/src/runtime/ez_runtime.h
+++ b/ezc/src/runtime/ez_runtime.h
@@ -72,6 +72,15 @@ EzString ez_string_new(EzArena *arena, const char *s, int32_t len);
 /* String formatting (for interpolation) */
 EzString ez_string_format(EzArena *arena, const char *fmt, ...);
 
+/* String comparison */
+static inline bool ez_string_eq(EzString a, EzString b) {
+    if (a.len != b.len) return false;
+    return memcmp(a.data, b.data, (size_t)a.len) == 0;
+}
+
+/* String concatenation */
+EzString ez_string_concat(EzArena *arena, EzString a, EzString b);
+
 /* --- Runtime Init/Shutdown --- */
 
 void ez_runtime_init(void);

--- a/ezc/tests/run_integration.sh
+++ b/ezc/tests/run_integration.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# run_integration.sh - Run EZC against the interpreter's integration test suite
+#
+# Usage: ./ezc/tests/run_integration.sh [--verbose]
+#
+# Copyright (c) 2025-Present Marshall A Burns
+# Licensed under the MIT License. See LICENSE for details.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+EZC="$ROOT_DIR/ezc/ezc"
+TMP_DIR="/tmp/ezc_integration_$$"
+
+mkdir -p "$TMP_DIR"
+trap "rm -rf $TMP_DIR" EXIT
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+VERBOSE=false
+
+if [ "$1" = "--verbose" ]; then
+    VERBOSE=true
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+run_test() {
+    local file="$1"
+    local name
+    name=$(basename "$file" .ez)
+    TOTAL=$((TOTAL + 1))
+
+    local bin="$TMP_DIR/$name"
+    local compile_out
+    compile_out=$("$EZC" "$file" -o "$bin" 2>&1)
+    if [ $? -eq 0 ]; then
+        # Try to run the binary
+        local run_out
+        run_out=$("$bin" 2>&1)
+        if [ $? -eq 0 ]; then
+            printf "  ${GREEN}PASS${RESET}  %s\n" "$name"
+            PASS=$((PASS + 1))
+        else
+            printf "  ${RED}FAIL${RESET}  %s (runtime error)\n" "$name"
+            if $VERBOSE; then echo "$run_out" | head -3 | sed 's/^/        /'; fi
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        printf "  ${RED}FAIL${RESET}  %s (compile error)\n" "$name"
+        if $VERBOSE; then echo "$compile_out" | head -3 | sed 's/^/        /'; fi
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+printf "${BOLD}EZC Integration Tests${RESET}\n"
+echo "Running EZC against the interpreter's test suite"
+echo ""
+
+# Build if needed
+if [ ! -f "$EZC" ]; then
+    echo "Building ezc..."
+    (cd "$ROOT_DIR/ezc" && make build) || { echo "Build failed"; exit 1; }
+fi
+
+# Core tests
+printf "${BOLD}Core Tests:${RESET}\n"
+for file in "$ROOT_DIR"/integration-tests/pass/core/*.ez; do
+    run_test "$file"
+done
+
+# Named returns tests
+echo ""
+printf "${BOLD}Named Returns:${RESET}\n"
+if [ -d "$ROOT_DIR/integration-tests/pass/named_returns" ]; then
+    for file in "$ROOT_DIR"/integration-tests/pass/named_returns/*.ez; do
+        [ -f "$file" ] && run_test "$file"
+    done
+fi
+
+# Summary
+echo ""
+printf "${BOLD}Results:${RESET} "
+if [ $FAIL -eq 0 ]; then
+    printf "${GREEN}%d passed${RESET}" "$PASS"
+else
+    printf "${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}" "$PASS" "$FAIL"
+fi
+printf " (${TOTAL} total)\n"
+echo ""
+
+exit 0


### PR DESCRIPTION
## Summary
Two additions: string operator codegen and an integration test runner.

### String Comparison and Concatenation
- `str1 == str2` → `ez_string_eq(str1, str2)` (memcmp-based)
- `str1 != str2` → `!ez_string_eq(str1, str2)`
- `str1 + str2` → `ez_string_concat(ez_default_arena, str1, str2)`
- Type-aware: only triggers when type checker knows operand is string

### Integration Test Runner
`make test-integration` runs EZC against the interpreter's `integration-tests/pass/core/*.ez` suite (40 tests).

Current results: **11/40 core tests passing**
- Passing: as_long_as_loop, ensure_statement, error_handling, escape_sequences, loop_statement, operators, short_circuit, string_interpolation, suppress_attribute, typeof, variables

### Remaining gaps (29 failing tests)
- String enums (#enum(string))
- Octal/hex number literals (0o10, 0xFF)
- Default parameters
- @random module
- new(Type) → struct type inference
- when/is with string values
- Copy semantics with ref'd arrays
- Fixed-size array syntax

## Test plan
- [x] String equality works in if/when conditions
- [x] String concatenation with + operator
- [x] 99/99 unit + e2e tests pass
- [x] 15/15 examples pass
- [x] Integration runner executes and reports results