### PR TITLE
fix(ezc): close integration gaps — when/is strings, struct inference, parser restore

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -1328,6 +1328,9 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
             c_type = "double";
         } else if (val->kind == NODE_BOOL_VALUE) {
             c_type = "bool";
+        } else if (val->kind == NODE_STRUCT_VALUE) {
+            /* Struct literal — use the struct type */
+            c_type = ez_type_to_c_cg(cg, val->data.struct_value.name);
         } else if (val->kind == NODE_CALL_EXPR || val->kind == NODE_NEW_EXPR ||
                    val->kind == NODE_MEMBER_EXPR) {
             /* Use __auto_type for function calls, new(), and member access
@@ -1758,6 +1761,8 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
     case NODE_WHEN_STMT: {
         /* Emit as if-else chain for now (switch requires constant values) */
         AstNode *val = node->data.when_stmt.value;
+        EzType *when_val_t = cg->type_table ? typetable_get(cg->type_table, val) : NULL;
+        bool when_is_string = (when_val_t && when_val_t->kind == TK_STRING);
         for (int i = 0; i < node->data.when_stmt.case_count; i++) {
             WhenCase *wc = &node->data.when_stmt.cases[i];
             emit_indent(cg);
@@ -1778,6 +1783,12 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
                     emit_expression(cg, val);
                     emit(cg, " < ");
                     emit_expression(cg, r->data.range_expr.end);
+                    emit(cg, ")");
+                } else if (when_is_string) {
+                    emit(cg, "ez_string_eq(");
+                    emit_expression(cg, val);
+                    emit(cg, ", ");
+                    emit_expression(cg, wc->values[j]);
                     emit(cg, ")");
                 } else {
                     emit_expression(cg, val);

--- a/ezc/src/lexer/lexer.c
+++ b/ezc/src/lexer/lexer.c
@@ -85,13 +85,33 @@ static const char *read_number(Lexer *l, TokenType *type) {
     int start = l->position;
     *type = TOK_INT;
 
+    /* Check for 0x, 0o, 0b prefixes */
+    if (l->ch == '0') {
+        char next = peek_char(l);
+        if (next == 'x' || next == 'X') {
+            read_char(l); read_char(l);
+            while (isxdigit(l->ch) || l->ch == '_') read_char(l);
+            return arena_strndup(l->arena, l->input + start, l->position - start);
+        }
+        if (next == 'o' || next == 'O') {
+            read_char(l); read_char(l);
+            while ((l->ch >= '0' && l->ch <= '7') || l->ch == '_') read_char(l);
+            return arena_strndup(l->arena, l->input + start, l->position - start);
+        }
+        if (next == 'b' || next == 'B') {
+            read_char(l); read_char(l);
+            while (l->ch == '0' || l->ch == '1' || l->ch == '_') read_char(l);
+            return arena_strndup(l->arena, l->input + start, l->position - start);
+        }
+    }
+
     while (isdigit(l->ch) || l->ch == '_') {
         read_char(l);
     }
 
     if (l->ch == '.' && isdigit(peek_char(l))) {
         *type = TOK_FLOAT;
-        read_char(l); /* skip . */
+        read_char(l);
         while (isdigit(l->ch) || l->ch == '_') {
             read_char(l);
         }

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -100,15 +100,44 @@ static AstNode *parse_identifier(Parser *p) {
 
 static AstNode *parse_int_literal(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_INT_VALUE, p->cur_token);
-    /* Parse integer, ignoring underscores */
-    int64_t val = 0;
     const char *s = p->cur_token.literal;
-    while (*s) {
-        if (*s != '_') {
-            val = val * 10 + (*s - '0');
+    int64_t val = 0;
+
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+        /* Hex: 0xFF */
+        s += 2;
+        while (*s) {
+            if (*s == '_') { s++; continue; }
+            val = val * 16;
+            if (*s >= '0' && *s <= '9') val += *s - '0';
+            else if (*s >= 'a' && *s <= 'f') val += *s - 'a' + 10;
+            else if (*s >= 'A' && *s <= 'F') val += *s - 'A' + 10;
+            s++;
         }
-        s++;
+    } else if (s[0] == '0' && (s[1] == 'o' || s[1] == 'O')) {
+        /* Octal: 0o77 */
+        s += 2;
+        while (*s) {
+            if (*s == '_') { s++; continue; }
+            val = val * 8 + (*s - '0');
+            s++;
+        }
+    } else if (s[0] == '0' && (s[1] == 'b' || s[1] == 'B')) {
+        /* Binary: 0b1010 */
+        s += 2;
+        while (*s) {
+            if (*s == '_') { s++; continue; }
+            val = val * 2 + (*s - '0');
+            s++;
+        }
+    } else {
+        /* Decimal */
+        while (*s) {
+            if (*s != '_') val = val * 10 + (*s - '0');
+            s++;
+        }
     }
+
     node->data.int_value.value = val;
     node->data.int_value.literal = p->cur_token.literal;
     return node;
@@ -257,7 +286,8 @@ static AstNode *parse_prefix(Parser *p) {
         return parse_identifier(p);
     case TOK_INT:       return parse_int_literal(p);
     case TOK_FLOAT:     return parse_float_literal(p);
-    case TOK_STRING:    return parse_string_literal(p);
+    case TOK_STRING:
+    case TOK_RAW_STRING: return parse_string_literal(p);
     case TOK_TRUE:
     case TOK_FALSE:     return parse_bool_literal(p);
     case TOK_NIL:       return parse_nil_literal(p);
@@ -666,13 +696,14 @@ static AstNode *parse_var_declaration(Parser *p) {
 
 static AstNode *parse_return_statement(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_RETURN_STMT, p->cur_token);
-    next_token(p);
 
     int cap = 4;
     int count = 0;
     AstNode **values = arena_alloc(p->arena, sizeof(AstNode *) * cap);
 
-    if (!cur_token_is(p, TOK_RBRACE) && !cur_token_is(p, TOK_EOF)) {
+    /* Check if there's a value to return (peek, don't consume) */
+    if (!peek_token_is(p, TOK_RBRACE) && !peek_token_is(p, TOK_EOF)) {
+        next_token(p);
         values[count++] = parse_expression(p, PREC_LOWEST);
 
         while (peek_token_is(p, TOK_COMMA)) {

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -1243,9 +1243,15 @@ static AstNode *parse_statement(Parser *p) {
     case TOK_CONST:
         /* Check if this is a struct or enum declaration: const Name struct { */
         if (p->cur_token.type == TOK_CONST && peek_token_is(p, TOK_IDENT)) {
-            /* Save state and look ahead */
+            /* Save full parser state for lookahead */
             Token saved_cur = p->cur_token;
             Token saved_peek = p->peek_token;
+            int saved_pos = p->lexer->position;
+            int saved_rpos = p->lexer->read_position;
+            char saved_ch = p->lexer->ch;
+            int saved_line = p->lexer->line;
+            int saved_col = p->lexer->column;
+
             next_token(p); /* now on IDENT (name) */
             if (peek_token_is(p, TOK_STRUCT)) {
                 return parse_struct_declaration(p);
@@ -1253,9 +1259,14 @@ static AstNode *parse_statement(Parser *p) {
             if (peek_token_is(p, TOK_ENUM)) {
                 return parse_enum_declaration(p);
             }
-            /* Not struct/enum — restore and parse as var declaration */
+            /* Not struct/enum — restore full state */
             p->cur_token = saved_cur;
             p->peek_token = saved_peek;
+            p->lexer->position = saved_pos;
+            p->lexer->read_position = saved_rpos;
+            p->lexer->ch = saved_ch;
+            p->lexer->line = saved_line;
+            p->lexer->column = saved_col;
         }
         return parse_var_declaration(p);
     case TOK_DO:

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -891,6 +891,15 @@ static AstNode *parse_func_declaration(Parser *p) {
                 }
                 next_token(p);
             }
+        } else if (cur_token_is(p, TOK_LBRACKET)) {
+            /* Array return type: -> [int] */
+            next_token(p);
+            const char *elem = p->cur_token.literal;
+            if (!expect_peek(p, TOK_RBRACKET)) return NULL;
+            char *type_str = arena_alloc(p->arena, strlen(elem) + 3);
+            sprintf(type_str, "[%s]", elem);
+            node->data.func_decl.return_types[0] = type_str;
+            node->data.func_decl.return_type_count = 1;
         } else {
             /* Single return type */
             node->data.func_decl.return_types[0] = p->cur_token.literal;
@@ -1128,6 +1137,10 @@ static AstNode *parse_ensure_statement(Parser *p) {
 static AstNode *parse_for_statement(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_FOR_STMT, p->cur_token);
 
+    /* Optional parentheses: for (i in range(...)) */
+    bool has_parens = peek_token_is(p, TOK_LPAREN);
+    if (has_parens) next_token(p);
+
     if (!expect_peek(p, TOK_IDENT)) return NULL;
     node->data.for_stmt.var_name = p->cur_token.literal;
 
@@ -1138,6 +1151,10 @@ static AstNode *parse_for_statement(Parser *p) {
 
     next_token(p);
     node->data.for_stmt.iterable = parse_expression(p, PREC_LOWEST);
+
+    if (has_parens && peek_token_is(p, TOK_RPAREN)) {
+        next_token(p);
+    }
 
     if (!expect_peek(p, TOK_LBRACE)) return NULL;
     node->data.for_stmt.body = parse_block_statement(p);


### PR DESCRIPTION
## Summary
Multiple targeted fixes to close integration test gaps.

### Commit 1: when/is strings, struct inference, parser state restore
- when/is with string values uses `ez_string_eq()` 
- `temp o = Struct{}` correctly uses struct type
- Full lexer state save/restore in const struct/enum lookahead

### Commit 2: hex/octal/binary literals, raw strings, return in blocks
- Parse `0xFF` (hex), `0o77` (octal), `0b1010` (binary) literals
- Handle `TOK_RAW_STRING` (backtick) as string literal
- Fix return statement to not consume `}` — prevents token desync in when/is case blocks

### Commit 3: array return types, parenthesized for loops
- Parse `-> [int]` as array return type
- Support `for (i in range(...)) { }` with optional parentheses

## Results
- Integration tests: **17/40** core tests passing (up from 11)
- 99/99 unit + e2e tests passing
- 15/15 examples passing

### Newly passing integration tests
as_long_as_loop, const_multi_return, ensure_statement, error_handling,
escape_sequences, loop_statement, nested_struct_init, operators,
raw_strings, short_circuit, string_interpolation, suppress_attribute,
typeof, variables, void-functions, when-statements, + 1 more