### PR TITLE
feat(ezc): add `mut` and `while` keywords

### DIFF
--- a/ezc/src/lexer/token.c
+++ b/ezc/src/lexer/token.c
@@ -34,6 +34,7 @@ static const KeywordEntry keywords[] = {
     {"is",          TOK_IS},
     {"loop",        TOK_LOOP},
     {"module",      TOK_MODULE},
+    {"mut",         TOK_TEMP},
     {"new",         TOK_NEW},
     {"nil",         TOK_NIL},
     {"not_in",      TOK_NOT_IN},
@@ -48,6 +49,7 @@ static const KeywordEntry keywords[] = {
     {"use",         TOK_USE},
     {"using",       TOK_USING},
     {"when",        TOK_WHEN},
+    {"while",       TOK_AS_LONG_AS},
 };
 
 #define KEYWORD_COUNT (sizeof(keywords) / sizeof(keywords[0]))


### PR DESCRIPTION
## Summary
Two new keyword aliases for EZ 3.0.

### `mut` — alias for `temp`
```ez
mut count int = 0
mut name string = "Alice"
```
`temp` still works for backwards compatibility.

### `while` — alias for `as_long_as`
```ez
while count < 10 {
    count++
}
```
`as_long_as` still works for backwards compatibility.

Both map to the same tokens (`TOK_TEMP`, `TOK_AS_LONG_AS`) — zero parser or codegen changes needed.

## Test plan
- [x] `mut x int = 42` compiles correctly
- [x] `while x < 10 { }` compiles correctly
- [x] `temp` and `as_long_as` still work
- [x] 99/99 tests pass
- [x] 15/15 examples pass