### PR TITLE
Add 74 new unit and e2e tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -24,9 +24,9 @@ Unit tests validate individual compiler components:
 - **Parser Tests** (`ezc/tests/test_parser.c` — 81 tests): Declarations, imports, control flow, structs, enums, function references, attributes, map/array types, visibility, error reporting, grouped params, compound assignments, nested structures, import aliases, precedence.
 - **Typechecker Tests** (`ezc/tests/test_typechecker.c` — 137 tests): Scope management, type resolution, expression inference, built-in return types, error detection, enum/map type resolution, deep scope nesting, bigint types, char/uint numerics, valid program verification (nested structs, enums, multi-return, when, struct functions).
 
-### End-to-End Tests (81 tests)
+### End-to-End Tests (97 tests)
 
-E2E tests (`ezc/tests/test_codegen.c`) compile EZ programs, run them, and verify output. Covers variables, control flow, functions, data structures, string features, function references, struct functions, enums, maps, pointers, and runtime checks.
+E2E tests (`ezc/tests/test_codegen.c`) compile EZ programs, run them, and verify output. Covers variables, control flow, functions, data structures, string features, function references, struct functions, enums, maps, pointers, runtime checks, boolean logic, string comparison, negative arithmetic, variable shadowing, nested control flow, map mutation, for_each with index, const values, empty containers, nested function calls, string indexing, enum comparison, grouped parameters, and scope lifetime.
 
 **Running:**
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -16,13 +16,13 @@ This runs all Go tooling tests, compiler unit tests, compiler e2e tests, and int
 
 The EZ compiler has a comprehensive test suite written in C, located in `ezc/tests/`.
 
-### Unit Tests (230 tests)
+### Unit Tests (288 tests)
 
 Unit tests validate individual compiler components:
 
-- **Lexer Tests** (`ezc/tests/test_lexer.c` — 55 tests): Token scanning, keyword recognition, literal formats, comment handling, attribute tokens, v3 keyword aliases, operator disambiguation.
-- **Parser Tests** (`ezc/tests/test_parser.c` — 66 tests): Declarations, imports, control flow, structs, enums, function references, attributes, map/array types, visibility, error reporting.
-- **Typechecker Tests** (`ezc/tests/test_typechecker.c` — 109 tests): Scope management, type resolution, expression inference, built-in return types, error detection, enum/map type resolution.
+- **Lexer Tests** (`ezc/tests/test_lexer.c` — 70 tests): Token scanning, keyword recognition, literal formats, comment handling, attribute tokens, v3 keyword aliases, operator disambiguation, edge cases (empty strings, zero literals, multiline comments, adjacent operators).
+- **Parser Tests** (`ezc/tests/test_parser.c` — 81 tests): Declarations, imports, control flow, structs, enums, function references, attributes, map/array types, visibility, error reporting, grouped params, compound assignments, nested structures, import aliases, precedence.
+- **Typechecker Tests** (`ezc/tests/test_typechecker.c` — 137 tests): Scope management, type resolution, expression inference, built-in return types, error detection, enum/map type resolution, deep scope nesting, bigint types, char/uint numerics, valid program verification (nested structs, enums, multi-return, when, struct functions).
 
 ### End-to-End Tests (81 tests)
 

--- a/ezc/tests/test_codegen.c
+++ b/ezc/tests/test_codegen.c
@@ -1271,6 +1271,254 @@ static void test_e2e_percent_assign(void) {
     ASSERT_STR_EQ(out, "2");
 }
 
+/* ===== Boolean Logic ===== */
+
+static void test_e2e_bool_and_or(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut a bool = true\n"
+        "  mut b bool = false\n"
+        "  if a && !b { println(\"and-ok\") }\n"
+        "  if a || b { println(\"or-ok\") }\n"
+        "  if !(a && b) { println(\"not-ok\") }\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "and-ok\nor-ok\nnot-ok");
+}
+
+static void test_e2e_short_circuit(void) {
+    char *out = compile_and_run(
+        ""
+        "mut called int = 0\n"
+        "do side() -> bool { called++\n return true }\n"
+        "do main() {\n"
+        "  if false && side() { println(\"bad\") }\n"
+        "  println(called)\n"
+        "  if true || side() { println(\"good\") }\n"
+        "  println(called)\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "0\ngood\n0");
+}
+
+/* ===== String Comparison ===== */
+
+static void test_e2e_string_compare(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut a string = \"hello\"\n"
+        "  mut b string = \"hello\"\n"
+        "  mut c string = \"world\"\n"
+        "  if a == b { println(\"eq\") }\n"
+        "  if a != c { println(\"neq\") }\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "eq\nneq");
+}
+
+/* ===== Negative Arithmetic ===== */
+
+static void test_e2e_negative_arithmetic(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut x int = -10\n"
+        "  mut y int = 3\n"
+        "  println(x + y)\n"
+        "  println(x * y)\n"
+        "  println(x / y)\n"
+        "  println(-x)\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "-7\n-30\n-3\n10");
+}
+
+/* ===== Variable Shadowing ===== */
+
+static void test_e2e_variable_shadowing(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut x int = 1\n"
+        "  println(x)\n"
+        "  if true {\n"
+        "    mut x int = 2\n"
+        "    println(x)\n"
+        "  }\n"
+        "  println(x)\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "1\n2\n1");
+}
+
+/* ===== Nested Control Flow ===== */
+
+static void test_e2e_nested_control_flow(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut total int = 0\n"
+        "  for i in range(0, 3) {\n"
+        "    when i {\n"
+        "      is 0 { total += 10 }\n"
+        "      is 1 { total += 20 }\n"
+        "      default { total += 30 }\n"
+        "    }\n"
+        "  }\n"
+        "  println(total)\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "60");
+}
+
+/* ===== Map Mutation ===== */
+
+static void test_e2e_map_set(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut m map[string:int] = {\"a\": 1}\n"
+        "  m[\"a\"] = 99\n"
+        "  m[\"b\"] = 42\n"
+        "  println(m[\"a\"])\n"
+        "  println(m[\"b\"])\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "99\n42");
+}
+
+/* ===== For_each with Index ===== */
+
+static void test_e2e_foreach_index(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut arr [string] = {\"a\", \"b\", \"c\"}\n"
+        "  for_each i, item in arr {\n"
+        "    println(\"${i}:${item}\")\n"
+        "  }\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "0:a\n1:b\n2:c");
+}
+
+/* ===== Const Values ===== */
+
+static void test_e2e_const_values(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  const PI float = 3.14\n"
+        "  const NAME string = \"EZ\"\n"
+        "  const FLAG bool = true\n"
+        "  println(PI)\n"
+        "  println(NAME)\n"
+        "  println(FLAG)\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "3.14\nEZ\ntrue");
+}
+
+/* ===== Empty Containers ===== */
+
+static void test_e2e_empty_array(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut arr [int] = {}\n"
+        "  println(len(arr))\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "0");
+}
+
+static void test_e2e_empty_map(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut m map[string:int] = {:}\n"
+        "  println(len(m))\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "0");
+}
+
+/* ===== Nested Function Calls ===== */
+
+static void test_e2e_nested_calls(void) {
+    char *out = compile_and_run(
+        ""
+        "do add(a int, b int) -> int { return a + b }\n"
+        "do mul(a int, b int) -> int { return a * b }\n"
+        "do main() {\n"
+        "  println(add(1, mul(2, 3)))\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "7");
+}
+
+/* ===== String Indexing ===== */
+
+static void test_e2e_string_index(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut s string = \"hello\"\n"
+        "  println(s[0])\n"
+        "  println(s[4])\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "h\no");
+}
+
+/* ===== Enum Comparison ===== */
+
+static void test_e2e_enum_compare(void) {
+    char *out = compile_and_run(
+        ""
+        "const Dir enum { UP\n DOWN\n LEFT\n RIGHT }\n"
+        "do main() {\n"
+        "  mut d = Dir.LEFT\n"
+        "  if d == Dir.LEFT { println(\"left\") }\n"
+        "  if d != Dir.UP { println(\"not up\") }\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "left\nnot up");
+}
+
+/* ===== Grouped Parameters ===== */
+
+static void test_e2e_grouped_params(void) {
+    char *out = compile_and_run(
+        ""
+        "do add3(a, b, c int) -> int { return a + b + c }\n"
+        "do main() {\n"
+        "  println(add3(10, 20, 30))\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    ASSERT_STR_EQ(out, "60");
+}
+
+/* ===== Scope Lifetime ===== */
+
+static void test_e2e_loop_scope(void) {
+    char *out = compile_and_run(
+        ""
+        "do main() {\n"
+        "  mut total int = 0\n"
+        "  for i in range(0, 3) {\n"
+        "    mut local int = i * 10\n"
+        "    total += local\n"
+        "  }\n"
+        "  println(total)\n"
+        "}");
+    ASSERT_NOT_NULL(out);
+    /* 0 + 10 + 20 = 30 */
+    ASSERT_STR_EQ(out, "30");
+}
+
 int main(void) {
     /* Must run from the ezc/ directory */
     if (access("./ezc", X_OK) != 0) {
@@ -1402,6 +1650,50 @@ int main(void) {
     /* P5: Range with step, percent assign */
     RUN_TEST(test_e2e_range_with_step);
     RUN_TEST(test_e2e_percent_assign);
+
+    /* Boolean logic */
+    RUN_TEST(test_e2e_bool_and_or);
+    RUN_TEST(test_e2e_short_circuit);
+
+    /* String comparison */
+    RUN_TEST(test_e2e_string_compare);
+
+    /* Negative arithmetic */
+    RUN_TEST(test_e2e_negative_arithmetic);
+
+    /* Variable shadowing */
+    RUN_TEST(test_e2e_variable_shadowing);
+
+    /* Nested control flow */
+    RUN_TEST(test_e2e_nested_control_flow);
+
+    /* Map mutation */
+    RUN_TEST(test_e2e_map_set);
+
+    /* For_each with index */
+    RUN_TEST(test_e2e_foreach_index);
+
+    /* Const values */
+    RUN_TEST(test_e2e_const_values);
+
+    /* Empty containers */
+    RUN_TEST(test_e2e_empty_array);
+    RUN_TEST(test_e2e_empty_map);
+
+    /* Nested function calls */
+    RUN_TEST(test_e2e_nested_calls);
+
+    /* String indexing */
+    RUN_TEST(test_e2e_string_index);
+
+    /* Enum comparison */
+    RUN_TEST(test_e2e_enum_compare);
+
+    /* Grouped parameters */
+    RUN_TEST(test_e2e_grouped_params);
+
+    /* Scope lifetime */
+    RUN_TEST(test_e2e_loop_scope);
 
     PRINT_RESULTS();
     return _test_fail > 0 ? 1 : 0;

--- a/ezc/tests/test_lexer.c
+++ b/ezc/tests/test_lexer.c
@@ -486,6 +486,128 @@ static void test_char_escape_tab(void) {
     ASSERT_STR_EQ(t.literal, "\\t");
 }
 
+/* --- Additional lexer coverage --- */
+
+static void test_zero_literal(void) {
+    Lexer *l = lex("0");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_INT);
+    ASSERT_STR_EQ(t.literal, "0");
+}
+
+static void test_negative_float_tokens(void) {
+    /* -3.14 should tokenize as MINUS then FLOAT */
+    Lexer *l = lex("-3.14");
+    ASSERT_EQ(next(l).type, TOK_MINUS);
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_FLOAT);
+    ASSERT_STR_EQ(t.literal, "3.14");
+}
+
+static void test_adjacent_operators(void) {
+    /* >= should be GT_EQ, not GT + ASSIGN */
+    Lexer *l = lex(">= <= == !=");
+    ASSERT_EQ(next(l).type, TOK_GT_EQ);
+    ASSERT_EQ(next(l).type, TOK_LT_EQ);
+    ASSERT_EQ(next(l).type, TOK_EQ);
+    ASSERT_EQ(next(l).type, TOK_NOT_EQ);
+}
+
+static void test_arrow_vs_minus(void) {
+    /* -> should be ARROW, - > should be MINUS GT */
+    Lexer *l = lex("->");
+    ASSERT_EQ(next(l).type, TOK_ARROW);
+}
+
+static void test_string_with_interpolation_marker(void) {
+    /* String containing ${...} is still a string token */
+    Lexer *l = lex("\"hello ${name} world\"");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_STRING);
+}
+
+static void test_multiline_block_comment(void) {
+    Lexer *l = lex("a /* this is\na multiline\ncomment */ b");
+    Token t1 = next(l);
+    ASSERT_EQ(t1.type, TOK_IDENT);
+    ASSERT_STR_EQ(t1.literal, "a");
+    Token t2 = next(l);
+    ASSERT_EQ(t2.type, TOK_IDENT);
+    ASSERT_STR_EQ(t2.literal, "b");
+}
+
+static void test_empty_string(void) {
+    Lexer *l = lex("\"\"");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_STRING);
+    ASSERT_STR_EQ(t.literal, "");
+}
+
+static void test_multiple_strings(void) {
+    Lexer *l = lex("\"hello\" \"world\"");
+    Token t1 = next(l);
+    ASSERT_EQ(t1.type, TOK_STRING);
+    ASSERT_STR_EQ(t1.literal, "hello");
+    Token t2 = next(l);
+    ASSERT_EQ(t2.type, TOK_STRING);
+    ASSERT_STR_EQ(t2.literal, "world");
+}
+
+static void test_consecutive_operators(void) {
+    /* ++ -- should not be confused */
+    Lexer *l = lex("++ -- **");
+    ASSERT_EQ(next(l).type, TOK_INCREMENT);
+    ASSERT_EQ(next(l).type, TOK_DECREMENT);
+    ASSERT_EQ(next(l).type, TOK_POWER);
+}
+
+static void test_large_integer_literal(void) {
+    Lexer *l = lex("9999999999");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_INT);
+    ASSERT_STR_EQ(t.literal, "9999999999");
+}
+
+static void test_char_single_quote(void) {
+    Lexer *l = lex("'x'");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_CHAR);
+    ASSERT_STR_EQ(t.literal, "x");
+}
+
+static void test_keyword_panic(void) {
+    Lexer *l = lex("panic");
+    ASSERT_EQ(next(l).type, TOK_IDENT); /* panic is a builtin func, not keyword */
+}
+
+static void test_mixed_tokens_line(void) {
+    /* Realistic code line */
+    Lexer *l = lex("mut x int = 42");
+    ASSERT_EQ(next(l).type, TOK_TEMP);      /* mut */
+    ASSERT_EQ(next(l).type, TOK_IDENT);     /* x */
+    ASSERT_EQ(next(l).type, TOK_IDENT);     /* int */
+    ASSERT_EQ(next(l).type, TOK_ASSIGN);    /* = */
+    ASSERT_EQ(next(l).type, TOK_INT);       /* 42 */
+    ASSERT_EQ(next(l).type, TOK_EOF);
+}
+
+static void test_line_tracking_with_comment(void) {
+    /* Comments should not affect line tracking */
+    Lexer *l = lex("a\n// comment\nb");
+    Token t1 = next(l);
+    ASSERT_EQ(t1.line, 1);
+    Token t2 = next(l);
+    ASSERT_EQ(t2.line, 3);
+    ASSERT_STR_EQ(t2.literal, "b");
+}
+
+static void test_hex_upper_lower(void) {
+    Lexer *l = lex("0xABCD");
+    Token t = next(l);
+    ASSERT_EQ(t.type, TOK_INT);
+    ASSERT_STR_EQ(t.literal, "0xABCD");
+}
+
 int main(void) {
     arena = arena_create(64 * 1024);
     printf("\n");
@@ -555,6 +677,23 @@ int main(void) {
     RUN_TEST(test_error_E1017_unclosed_raw_string);
     RUN_TEST(test_error_E1010_bad_octal);
     RUN_TEST(test_error_E1010_bad_binary);
+
+    /* Additional lexer coverage */
+    RUN_TEST(test_zero_literal);
+    RUN_TEST(test_negative_float_tokens);
+    RUN_TEST(test_adjacent_operators);
+    RUN_TEST(test_arrow_vs_minus);
+    RUN_TEST(test_string_with_interpolation_marker);
+    RUN_TEST(test_multiline_block_comment);
+    RUN_TEST(test_empty_string);
+    RUN_TEST(test_multiple_strings);
+    RUN_TEST(test_consecutive_operators);
+    RUN_TEST(test_large_integer_literal);
+    RUN_TEST(test_char_single_quote);
+    RUN_TEST(test_keyword_panic);
+    RUN_TEST(test_mixed_tokens_line);
+    RUN_TEST(test_line_tracking_with_comment);
+    RUN_TEST(test_hex_upper_lower);
 
     PRINT_RESULTS();
     return _test_fail > 0 ? 1 : 0;

--- a/ezc/tests/test_parser.c
+++ b/ezc/tests/test_parser.c
@@ -647,6 +647,155 @@ static void test_parse_error_unexpected_token(void) {
     ASSERT(diag_has_errors(diag));
 }
 
+/* --- Additional parser coverage --- */
+
+static void test_parse_for_each_stmt(void) {
+    AstNode *prog = parse("do main() { mut arr [int] = {1,2,3}\n for_each x in arr { } }");
+    AstNode *stmt = body_stmt(prog, 1);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_FOR_EACH_STMT);
+}
+
+static void test_parse_while_alias(void) {
+    /* while is an alias for as_long_as */
+    AstNode *prog = parse("while true { break }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_WHILE_STMT);
+}
+
+static void test_parse_empty_block(void) {
+    AstNode *prog = parse("do main() { }");
+    AstNode *fn = first_stmt(prog);
+    ASSERT_NOT_NULL(fn);
+    ASSERT_EQ(fn->kind, NODE_FUNC_DECL);
+    ASSERT_NOT_NULL(fn->data.func_decl.body);
+    ASSERT_EQ(fn->data.func_decl.body->kind, NODE_BLOCK_STMT);
+    ASSERT_EQ(fn->data.func_decl.body->data.block.count, 0);
+}
+
+static void test_parse_grouped_params(void) {
+    AstNode *prog = parse("do add(a, b int) -> int { return a + b }");
+    AstNode *fn = first_stmt(prog);
+    ASSERT_NOT_NULL(fn);
+    ASSERT_EQ(fn->kind, NODE_FUNC_DECL);
+    ASSERT_EQ(fn->data.func_decl.param_count, 2);
+    ASSERT_STR_EQ(fn->data.func_decl.params[0].type_name, "int");
+    ASSERT_STR_EQ(fn->data.func_decl.params[1].type_name, "int");
+}
+
+static void test_parse_compound_assign_mul(void) {
+    AstNode *prog = parse("do main() { mut x int = 2\n x *= 5 }");
+    AstNode *stmt = body_stmt(prog, 1);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_ASSIGN_STMT);
+}
+
+static void test_parse_compound_assign_div(void) {
+    AstNode *prog = parse("do main() { mut x int = 10\n x /= 2 }");
+    AstNode *stmt = body_stmt(prog, 1);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_ASSIGN_STMT);
+}
+
+static void test_parse_compound_assign_mod(void) {
+    AstNode *prog = parse("do main() { mut x int = 10\n x %= 3 }");
+    AstNode *stmt = body_stmt(prog, 1);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_ASSIGN_STMT);
+}
+
+static void test_parse_multiple_when_cases(void) {
+    AstNode *prog = parse(
+        "when x { is 1 { } is 2 { } is 3 { } is 4 { } default { } }");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_WHEN_STMT);
+    ASSERT_EQ(stmt->data.when_stmt.case_count, 4);
+}
+
+static void test_parse_nested_if(void) {
+    AstNode *prog = parse(
+        "do main() {\n"
+        "  if true {\n"
+        "    if false { }\n"
+        "  }\n"
+        "}");
+    AstNode *outer_if = body_stmt(prog, 0);
+    ASSERT_NOT_NULL(outer_if);
+    ASSERT_EQ(outer_if->kind, NODE_IF_STMT);
+    /* The inner if is inside the consequence block */
+    AstNode *inner = outer_if->data.if_stmt.consequence->data.block.stmts[0];
+    ASSERT_EQ(inner->kind, NODE_IF_STMT);
+}
+
+static void test_parse_struct_nested_field(void) {
+    AstNode *prog = parse(
+        "const Inner struct { val int }\n"
+        "const Outer struct { inner Inner }");
+    ASSERT_EQ(prog->data.program.stmt_count, 2);
+    AstNode *outer = prog->data.program.stmts[1];
+    ASSERT_EQ(outer->kind, NODE_STRUCT_DECL);
+    ASSERT_STR_EQ(outer->data.struct_decl.fields[0].type_name, "Inner");
+}
+
+static void test_parse_in_operator(void) {
+    AstNode *prog = parse("do main() { mut arr [int] = {1,2,3}\n mut x = 1 in arr }");
+    AstNode *val = body_stmt(prog, 1);
+    ASSERT_NOT_NULL(val);
+    ASSERT_EQ(val->kind, NODE_VAR_DECL);
+    ASSERT_EQ(val->data.var_decl.value->kind, NODE_INFIX_EXPR);
+    ASSERT_STR_EQ(val->data.var_decl.value->data.infix.op, "in");
+}
+
+static void test_parse_precedence_power(void) {
+    /* 2 ** 3 ** 2 — power is right-associative */
+    AstNode *prog = parse("do main() { mut x = 2 ** 3 + 1 }");
+    AstNode *val = var_value(prog);
+    ASSERT_NOT_NULL(val);
+    /* ** has higher precedence than +, so this is (2**3) + 1 */
+    ASSERT_EQ(val->kind, NODE_INFIX_EXPR);
+    ASSERT_STR_EQ(val->data.infix.op, "+");
+    ASSERT_EQ(val->data.infix.left->kind, NODE_INFIX_EXPR);
+    ASSERT_STR_EQ(val->data.infix.left->data.infix.op, "**");
+}
+
+static void test_parse_return_multiple_values(void) {
+    AstNode *prog = parse(
+        "do pair() -> (int, string) {\n"
+        "  return 42, \"hello\"\n"
+        "}");
+    AstNode *fn = first_stmt(prog);
+    ASSERT_NOT_NULL(fn);
+    ASSERT_EQ(fn->kind, NODE_FUNC_DECL);
+    ASSERT_EQ(fn->data.func_decl.return_type_count, 2);
+    ASSERT_STR_EQ(fn->data.func_decl.return_types[0], "int");
+    ASSERT_STR_EQ(fn->data.func_decl.return_types[1], "string");
+}
+
+static void test_parse_import_alias(void) {
+    /* EZ alias syntax: import alias @module */
+    AstNode *prog = parse("import m @math");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_IMPORT_STMT);
+    ASSERT_STR_EQ(stmt->data.import_stmt.items[0].module, "math");
+    ASSERT_STR_EQ(stmt->data.import_stmt.items[0].alias, "m");
+}
+
+static void test_parse_enum_with_values(void) {
+    AstNode *prog = parse(
+        "const Priority enum {\n"
+        "  LOW = 1\n"
+        "  MED = 2\n"
+        "  HIGH = 3\n"
+        "}");
+    AstNode *stmt = first_stmt(prog);
+    ASSERT_NOT_NULL(stmt);
+    ASSERT_EQ(stmt->kind, NODE_ENUM_DECL);
+    ASSERT_EQ(stmt->data.enum_decl.value_count, 3);
+}
+
 int main(void) {
     arena = arena_create(256 * 1024);
     printf("\n");
@@ -725,6 +874,23 @@ int main(void) {
     RUN_TEST(test_parse_named_return);
     RUN_TEST(test_parse_error_bad_var_decl);
     RUN_TEST(test_parse_error_unexpected_token);
+
+    /* Additional parser coverage */
+    RUN_TEST(test_parse_for_each_stmt);
+    RUN_TEST(test_parse_while_alias);
+    RUN_TEST(test_parse_empty_block);
+    RUN_TEST(test_parse_grouped_params);
+    RUN_TEST(test_parse_compound_assign_mul);
+    RUN_TEST(test_parse_compound_assign_div);
+    RUN_TEST(test_parse_compound_assign_mod);
+    RUN_TEST(test_parse_multiple_when_cases);
+    RUN_TEST(test_parse_nested_if);
+    RUN_TEST(test_parse_struct_nested_field);
+    RUN_TEST(test_parse_in_operator);
+    RUN_TEST(test_parse_precedence_power);
+    RUN_TEST(test_parse_return_multiple_values);
+    RUN_TEST(test_parse_import_alias);
+    RUN_TEST(test_parse_enum_with_values);
 
     PRINT_RESULTS();
     return _test_fail > 0 ? 1 : 0;

--- a/ezc/tests/test_typechecker.c
+++ b/ezc/tests/test_typechecker.c
@@ -961,6 +961,244 @@ static void test_warning_W3003_partial_array_init(void) {
     diag_destroy(d);
 }
 
+/* --- Additional typechecker coverage --- */
+
+static void test_resolve_char_literal(void) {
+    EzType *t = expr_type("'A'");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_CHAR);
+}
+
+static void test_resolve_modulo(void) {
+    EzType *t = expr_type("10 % 3");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_INT);
+}
+
+static void test_resolve_power(void) {
+    EzType *t = expr_type("2 ** 3");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_INT);
+}
+
+static void test_resolve_equality(void) {
+    EzType *t = expr_type("1 == 1");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_BOOL);
+}
+
+static void test_resolve_inequality(void) {
+    EzType *t = expr_type("1 != 2");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_BOOL);
+}
+
+static void test_resolve_or_logic(void) {
+    EzType *t = expr_type("true || false");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_BOOL);
+}
+
+static void test_resolve_string_comparison(void) {
+    EzType *t = expr_type("\"a\" == \"b\"");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_BOOL);
+}
+
+static void test_resolve_float_negation(void) {
+    EzType *t = expr_type("-3.14");
+    ASSERT_NOT_NULL(t);
+    ASSERT_EQ(t->kind, TK_FLOAT);
+}
+
+static void test_scope_deeply_nested(void) {
+    Scope *s1 = scope_create(NULL);
+    scope_define(s1, "a", &TYPE_INT, true);
+    Scope *s2 = scope_create(s1);
+    scope_define(s2, "b", &TYPE_STRING, true);
+    Scope *s3 = scope_create(s2);
+    scope_define(s3, "c", &TYPE_BOOL, true);
+
+    /* s3 can see all three */
+    ASSERT_NOT_NULL(scope_lookup(s3, "a"));
+    ASSERT_NOT_NULL(scope_lookup(s3, "b"));
+    ASSERT_NOT_NULL(scope_lookup(s3, "c"));
+
+    /* s1 can only see a */
+    ASSERT_NOT_NULL(scope_lookup(s1, "a"));
+    ASSERT(scope_lookup(s1, "b") == NULL);
+    ASSERT(scope_lookup(s1, "c") == NULL);
+}
+
+static void test_scope_local_only(void) {
+    Scope *outer = scope_create(NULL);
+    scope_define(outer, "x", &TYPE_INT, true);
+    Scope *inner = scope_create(outer);
+
+    /* lookup_local should NOT find outer's x */
+    ASSERT(scope_lookup_local(inner, "x") == NULL);
+    /* but regular lookup should */
+    ASSERT_NOT_NULL(scope_lookup(inner, "x"));
+}
+
+static void test_type_from_name_bigint(void) {
+    EzType *t1 = type_from_name("i128");
+    ASSERT_NOT_NULL(t1);
+    EzType *t2 = type_from_name("u128");
+    ASSERT_NOT_NULL(t2);
+    EzType *t3 = type_from_name("i256");
+    ASSERT_NOT_NULL(t3);
+    EzType *t4 = type_from_name("u256");
+    ASSERT_NOT_NULL(t4);
+}
+
+static void test_type_is_numeric_uint(void) {
+    ASSERT(type_is_numeric(&TYPE_UINT));
+}
+
+static void test_error_E3002_bool_arithmetic(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { mut x = true + false }");
+    ASSERT(has_code(d, "E3002"));
+    diag_destroy(d);
+}
+
+static void test_error_E3001_bool_to_int(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { mut x int = true }");
+    ASSERT(has_code(d, "E3001"));
+    diag_destroy(d);
+}
+
+static void test_error_E3001_int_to_string(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { mut x string = 42 }");
+    ASSERT(has_code(d, "E3001"));
+    diag_destroy(d);
+}
+
+static void test_error_E3005_const_array_reassign(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { const arr [int] = {1,2,3}\n arr = {4,5,6} }");
+    ASSERT(has_code(d, "E3005"));
+    diag_destroy(d);
+}
+
+static void test_error_E3009_foreach_int(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { for_each x in 42 { } }");
+    ASSERT(has_code(d, "E3009"));
+    diag_destroy(d);
+}
+
+static void test_error_E4003_duplicate_var_same_scope(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { mut x int = 1\n mut x string = \"hi\" }");
+    ASSERT(has_code(d, "E4003"));
+    diag_destroy(d);
+}
+
+static void test_error_E5008_too_many_args(void) {
+    DiagnosticList *d = check_diag(
+        "do add(a int, b int) -> int { return a + b }\n"
+        "do main() { add(1, 2, 3) }");
+    ASSERT(has_code(d, "E5008"));
+    diag_destroy(d);
+}
+
+static void test_error_E3008_index_string(void) {
+    /* String indexing should work, so this should not error */
+    DiagnosticList *d = check_diag(
+        "do main() { mut s string = \"hello\"\n mut c = s[0] }");
+    ASSERT(!has_code(d, "E3008"));
+    diag_destroy(d);
+}
+
+static void test_valid_nested_struct(void) {
+    /* Nested struct access should typecheck without errors */
+    DiagnosticList *d = check_diag(
+        "const Inner struct { val int }\n"
+        "const Outer struct { inner Inner }\n"
+        "do main() {\n"
+        "    mut o Outer = Outer{inner: Inner{val: 42}}\n"
+        "    mut v int = o.inner.val\n"
+        "    println(\"${v}\")\n"
+        "}");
+    ASSERT(!diag_has_errors(d));
+    diag_destroy(d);
+}
+
+static void test_valid_enum_member_access(void) {
+    DiagnosticList *d = check_diag(
+        "const Color enum { RED\n GREEN\n BLUE }\n"
+        "do main() { mut c = Color.RED\n println(\"${c}\") }");
+    ASSERT(!diag_has_errors(d));
+    diag_destroy(d);
+}
+
+static void test_valid_multi_return(void) {
+    DiagnosticList *d = check_diag(
+        "do swap(a int, b int) -> (int, int) { return b, a }\n"
+        "do main() { mut x int, y int = swap(1, 2)\n println(\"${x} ${y}\") }");
+    ASSERT(!diag_has_errors(d));
+    diag_destroy(d);
+}
+
+static void test_valid_when_stmt(void) {
+    DiagnosticList *d = check_diag(
+        "do main() {\n"
+        "    mut x int = 2\n"
+        "    when x {\n"
+        "        is 1 { println(\"one\") }\n"
+        "        is 2 { println(\"two\") }\n"
+        "        default { println(\"other\") }\n"
+        "    }\n"
+        "}");
+    ASSERT(!diag_has_errors(d));
+    diag_destroy(d);
+}
+
+static void test_valid_struct_function_return(void) {
+    DiagnosticList *d = check_diag(
+        "const Point struct {\n"
+        "    x int\n"
+        "    y int\n"
+        "    do origin() -> Point {\n"
+        "        return Point{x: 0, y: 0}\n"
+        "    }\n"
+        "}\n"
+        "do main() { mut p Point = Point.origin()\n println(\"${p.x}\") }");
+    ASSERT(!diag_has_errors(d));
+    diag_destroy(d);
+}
+
+static void test_error_E2050_continue_outside_loop(void) {
+    DiagnosticList *d = check_diag(
+        "do main() { continue }");
+    ASSERT(has_code(d, "E2050"));
+    diag_destroy(d);
+}
+
+static void test_error_E3024_some_paths_missing_return(void) {
+    DiagnosticList *d = check_diag(
+        "do foo(x int) -> int {\n"
+        "    if x > 0 { return 1 }\n"
+        "    if x < 0 { return -1 }\n"
+        "}\n"
+        "do main() { foo(1) }");
+    ASSERT(has_code(d, "E3035") || has_code(d, "E3024"));
+    diag_destroy(d);
+}
+
+static void test_error_E4007_duplicate_struct(void) {
+    DiagnosticList *d = check_diag(
+        "const Foo struct { x int }\n"
+        "const Foo struct { y int }\n"
+        "do main() { }");
+    ASSERT(has_code(d, "E4007"));
+    diag_destroy(d);
+}
+
 int main(void) {
     arena = arena_create(256 * 1024);
     printf("\n");
@@ -1125,6 +1363,36 @@ int main(void) {
     RUN_TEST(test_warning_W2001_unused_import);
     RUN_TEST(test_warning_W2011_named_return_unused);
     RUN_TEST(test_warning_W3003_partial_array_init);
+
+    /* Additional typechecker coverage */
+    RUN_TEST(test_resolve_char_literal);
+    RUN_TEST(test_resolve_modulo);
+    RUN_TEST(test_resolve_power);
+    RUN_TEST(test_resolve_equality);
+    RUN_TEST(test_resolve_inequality);
+    RUN_TEST(test_resolve_or_logic);
+    RUN_TEST(test_resolve_string_comparison);
+    RUN_TEST(test_resolve_float_negation);
+    RUN_TEST(test_scope_deeply_nested);
+    RUN_TEST(test_scope_local_only);
+    RUN_TEST(test_type_from_name_bigint);
+    RUN_TEST(test_type_is_numeric_uint);
+    RUN_TEST(test_error_E3002_bool_arithmetic);
+    RUN_TEST(test_error_E3001_bool_to_int);
+    RUN_TEST(test_error_E3001_int_to_string);
+    RUN_TEST(test_error_E3005_const_array_reassign);
+    RUN_TEST(test_error_E3009_foreach_int);
+    RUN_TEST(test_error_E4003_duplicate_var_same_scope);
+    RUN_TEST(test_error_E5008_too_many_args);
+    RUN_TEST(test_error_E3008_index_string);
+    RUN_TEST(test_valid_nested_struct);
+    RUN_TEST(test_valid_enum_member_access);
+    RUN_TEST(test_valid_multi_return);
+    RUN_TEST(test_valid_when_stmt);
+    RUN_TEST(test_valid_struct_function_return);
+    RUN_TEST(test_error_E2050_continue_outside_loop);
+    RUN_TEST(test_error_E3024_some_paths_missing_return);
+    RUN_TEST(test_error_E4007_duplicate_struct);
 
     PRINT_RESULTS();
     return _test_fail > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

- Adds **58 new unit tests** across lexer (15), parser (15), and typechecker (28)
- Adds **16 new e2e codegen tests** covering previously untested runtime behaviors
- Updates TESTING.md with accurate counts (311 -> 385 total compiler tests)

### Unit test coverage added
- **Lexer:** zero/large literals, empty strings, negative float tokenization, multiline block comments, adjacent/consecutive operators, arrow disambiguation, interpolation markers, line tracking with comments, hex casing
- **Parser:** for_each statement, while alias, empty blocks, grouped params, compound assignments (*=, /=, %=), multiple when cases, nested if, nested struct fields, in operator, power precedence, multi-return types, import alias, enum with values
- **Typechecker:** char/modulo/power/equality/inequality/or/string comparison type resolution, float negation, deep scope nesting, local-only scope lookup, bigint types, uint numerics, error detection (bool arithmetic, type mismatches, const reassign, foreach on non-iterable, duplicate vars, arg count), valid program verification (nested structs, enums, multi-return, when, struct functions, continue/break outside loop, missing returns, duplicate structs)

### E2E coverage added
- Boolean logic (&&, ||, !) and short-circuit evaluation
- String comparison (==, !=)
- Negative number arithmetic
- Variable shadowing across scopes
- Nested control flow (for + when)
- Map mutation (overwrite + add keys)
- for_each with index variable
- Const values (float, string, bool)
- Empty array and empty map
- Nested function calls in expressions
- String indexing
- Enum comparison
- Grouped parameters
- Loop scope lifetime

### Pre-existing failures discovered (not introduced by this PR)
- `test_warning_W2001_unused_import` — typechecker doesn't emit W2001 in unit test context
- `test_e2e_arrays_sort` — codegen emits undeclared `ez_arrays_sort` function

## Test plan
- [x] `make test-unit` — 288 total (287 pass, 1 pre-existing W2001 failure)
- [x] `make test-e2e` — 97 total (96 pass, 1 pre-existing arrays_sort failure)
- [x] All 74 new tests pass