### PR TITLE
fix(fmt): implement lexer-based indentation engine for ez fmt

### DIFF
--- a/cmd/ez/fmt.go
+++ b/cmd/ez/fmt.go
@@ -4,104 +4,25 @@ package main
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/marshallburns/ez/internal/ezc"
 )
 
-// defaultFmtIndentSpaces is the width a leading tab is expanded to when
-// normalizing indentation in formatEZSource.
-const defaultFmtIndentSpaces = 4
-
-// formatEZSource applies conservative formatting rules and returns the
-// rewritten source. Rules are intentionally limited so `ez fmt` cannot
-// accidentally alter the meaning of legal .ez code:
-//
-//  1. Strip trailing whitespace from every line.
-//  2. Convert leading tabs in each line to defaultFmtIndentSpaces spaces
-//     (only inside the indent prefix; tabs inside string literals or
-//     after non-whitespace are left alone).
-//  3. Collapse three-or-more consecutive blank lines down to exactly two.
-//  4. Ensure the output ends with exactly one trailing newline.
-//
-// The function is byte-stable: feeding the output back through it
-// produces the same bytes, so `ez fmt --check` is a reliable CI gate.
-func formatEZSource(src []byte) []byte {
-	// Split preserving the trailing-newline situation; a trailing empty
-	// element after the final \n signals "file ended with a newline".
-	lines := strings.Split(string(src), "\n")
-	endsWithNewline := len(lines) > 0 && lines[len(lines)-1] == ""
-	if endsWithNewline {
-		lines = lines[:len(lines)-1]
-	}
-
-	for i, line := range lines {
-		// Rule 2: leading-tab indent normalization.
-		var indent strings.Builder
-		j := 0
-		for j < len(line) {
-			c := line[j]
-			if c == '\t' {
-				for k := 0; k < defaultFmtIndentSpaces; k++ {
-					indent.WriteByte(' ')
-				}
-				j++
-			} else if c == ' ' {
-				indent.WriteByte(' ')
-				j++
-			} else {
-				break
-			}
-		}
-		rest := line[j:]
-		// Rule 1: trim trailing whitespace.
-		rest = strings.TrimRight(rest, " \t")
-		// An all-whitespace line collapses to "" so blank-line detection
-		// in rule 3 catches it.
-		if rest == "" {
-			lines[i] = ""
-		} else {
-			lines[i] = indent.String() + rest
-		}
-	}
-
-	// Rule 3: collapse 3+ consecutive blank lines to exactly 2.
-	var out []string
-	blank := 0
-	for _, line := range lines {
-		if line == "" {
-			blank++
-			if blank <= 2 {
-				out = append(out, line)
-			}
-		} else {
-			blank = 0
-			out = append(out, line)
-		}
-	}
-
-	// Rule 4: trim trailing blank lines, then append exactly one newline.
-	for len(out) > 0 && out[len(out)-1] == "" {
-		out = out[:len(out)-1]
-	}
-	return []byte(strings.Join(out, "\n") + "\n")
-}
-
 // collectFmtFiles expands the user-supplied args into a deduplicated list
-// of .ez file paths, mirroring the arg shape used by `ez doc`:
+// of .ez file paths. Supported forms:
 //
-//   - "./..." or "<dir>/..." -> recursive walk for .ez files
-//   - "foo.ez"               -> single file
-//   - "<dir>"                -> non-recursive directory scan
-//
-// Errors on individual entries are printed to stderr and the bad entry
-// is skipped; the function never aborts the whole run on a single
-// missing arg, matching how `generateDocs` in doc.go behaves.
+//   - "file.ez"           — single file
+//   - "dir"               — all .ez files directly inside dir (non-recursive)
+//   - "dir/subdir"        — all .ez files directly inside dir/subdir
+//   - "./..." or "dir/..." — recursive walk for .ez files
 func collectFmtFiles(args []string) []string {
 	seen := make(map[string]struct{})
 	var files []string
+
 	add := func(p string) {
 		ap, err := filepath.Abs(p)
 		if err != nil {
@@ -116,10 +37,9 @@ func collectFmtFiles(args []string) []string {
 	}
 
 	for _, arg := range args {
-		switch {
-		case strings.HasSuffix(arg, "/..."):
+		if strings.HasSuffix(arg, "/...") || arg == "..." {
 			baseDir := strings.TrimSuffix(arg, "/...")
-			if baseDir == "" || baseDir == "." {
+			if baseDir == "" || baseDir == "." || baseDir == "..." {
 				baseDir = "."
 			}
 			filepath.Walk(baseDir, func(p string, info os.FileInfo, err error) error {
@@ -131,9 +51,16 @@ func collectFmtFiles(args []string) []string {
 				}
 				return nil
 			})
-		case strings.HasSuffix(arg, ".ez"):
-			add(arg)
-		default:
+			continue
+		}
+
+		info, err := os.Stat(arg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
+			continue
+		}
+
+		if info.IsDir() {
 			entries, err := os.ReadDir(arg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
@@ -144,14 +71,17 @@ func collectFmtFiles(args []string) []string {
 					add(filepath.Join(arg, e.Name()))
 				}
 			}
+		} else if strings.HasSuffix(arg, ".ez") {
+			add(arg)
+		} else {
+			fmt.Fprintf(os.Stderr, "ez fmt: '%s' is not a .ez file or directory\n", arg)
 		}
 	}
 	return files
 }
 
 // runFmt is the entry point invoked by the Cobra fmtCmd. It returns the
-// exit code the caller should propagate (0 success, 1 if --check found
-// unformatted files, 2 on file I/O error).
+// exit code the caller should propagate (0 success, 1 on error).
 func runFmt(args []string, checkMode bool) int {
 	files := collectFmtFiles(args)
 	if len(files) == 0 {
@@ -160,30 +90,67 @@ func runFmt(args []string, checkMode bool) int {
 	}
 
 	exit := 0
+	changed := 0
+
 	for _, path := range files {
-		src, err := os.ReadFile(path)
+		orig, err := os.ReadFile(path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
-			exit = 2
+			exit = 1
 			continue
 		}
-		out := formatEZSource(src)
-		if bytes.Equal(src, out) {
-			continue
-		}
+
 		if checkMode {
-			fmt.Printf("would format: %s\n", path)
-			if exit == 0 {
+			// Copy to temp, format it, compare
+			tmp, err := os.CreateTemp("", "ez-fmt-check-*.ez")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
 				exit = 1
+				continue
+			}
+			tmpName := tmp.Name()
+			tmp.Write(orig)
+			tmp.Close()
+
+			ezc.Fmt(tmpName)
+
+			formatted, err := os.ReadFile(tmpName)
+			os.Remove(tmpName)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
+				exit = 1
+				continue
+			}
+			if string(orig) != string(formatted) {
+				fmt.Printf("would format: %s\n", path)
+				if exit == 0 {
+					exit = 1
+				}
 			}
 			continue
 		}
-		if err := os.WriteFile(path, out, 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "ez fmt: writing %s: %v\n", path, err)
-			exit = 2
+
+		// Normal mode: format in place
+		code, err := ezc.Fmt(path)
+		if err != nil || code != 0 {
+			fmt.Fprintf(os.Stderr, "ez fmt: failed to format '%s'\n", path)
+			exit = 1
 			continue
 		}
-		fmt.Printf("formatted: %s\n", path)
+		after, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
+			exit = 1
+			continue
+		}
+		if string(orig) != string(after) {
+			fmt.Printf("formatted: %s\n", path)
+			changed++
+		}
+	}
+
+	if !checkMode && changed == 0 {
+		fmt.Printf("ez fmt: %d file(s) checked, already formatted\n", len(files))
 	}
 	return exit
 }

--- a/ezc/Makefile
+++ b/ezc/Makefile
@@ -33,7 +33,8 @@ SRC = src/main.c \
       src/typechecker/types.c \
       src/typechecker/scope.c \
       src/typechecker/typechecker.c \
-      src/codegen/codegen.c
+      src/codegen/codegen.c \
+      src/fmt/fmt.c
 
 OBJ = $(SRC:.c=.o)
 BIN = ezc

--- a/ezc/src/fmt/fmt.c
+++ b/ezc/src/fmt/fmt.c
@@ -101,19 +101,21 @@ static bool line_is_in_raw_string(const char *src, int target_line) {
     int line = 1;
     bool in_raw = false;
     bool in_str = false;  /* regular double-quoted string */
-    for (const char *p = src; *p && line < target_line; p++) {
-        if (*p == '\n') { line++; continue; }
+    const char *p = src;
+    while (*p && line < target_line) {
+        if (*p == '\n') { line++; p++; continue; }
         if (in_raw) {
             if (*p == '`') in_raw = false;
-            continue;
+            p++; continue;
         }
         if (in_str) {
-            if (*p == '\\') { p++; continue; } /* skip escape */
+            if (*p == '\\' && *(p + 1)) { p += 2; continue; } /* skip escape */
             if (*p == '"')  { in_str = false; }
-            continue;
+            p++; continue;
         }
-        if (*p == '`') { in_raw = true; continue; }
-        if (*p == '"') { in_str = true; continue; }
+        if (*p == '`') { in_raw = true; p++; continue; }
+        if (*p == '"') { in_str = true; p++; continue; }
+        p++;
     }
     return in_raw;
 }

--- a/ezc/src/fmt/fmt.c
+++ b/ezc/src/fmt/fmt.c
@@ -1,0 +1,169 @@
+/*
+ * fmt.c - EZ source formatter
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#include "fmt.h"
+#include "../lexer/lexer.h"
+#include "../lexer/token.h"
+#include "../util/arena.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#define FMT_INDENT_WIDTH 4
+#define FMT_ARENA_SIZE   (1024 * 1024)  /* 1 MB — enough for any source file */
+
+/* Count the number of newlines in src to find the maximum line number. */
+static int count_lines(const char *src) {
+    int n = 1;
+    for (const char *p = src; *p; p++) {
+        if (*p == '\n') n++;
+    }
+    return n;
+}
+
+/*
+ * Build a depth table: depth_at[line] = indentation depth at the START of
+ * that line (1-indexed).  Lines that contain no tokens (blank lines or
+ * comment-only lines) inherit the depth of the nearest preceding token line.
+ *
+ * TOK_RBRACE decrements the depth BEFORE the line is recorded, so a closing
+ * brace line gets the outer depth.  TOK_LBRACE increments the depth AFTER
+ * the line is recorded, so the opening-brace line itself stays at the current
+ * depth and the body lines inside get depth+1.
+ */
+static int *build_depth_table(const char *src, const char *filename, int max_line) {
+    int *table = calloc(max_line + 2, sizeof(int));
+    if (!table) return NULL;
+
+    /* -1 = not yet assigned by a token */
+    for (int i = 0; i <= max_line + 1; i++) table[i] = -1;
+
+    Arena *arena = arena_create(FMT_ARENA_SIZE);
+    if (!arena) { free(table); return NULL; }
+
+    Lexer *l = lexer_create(arena, src, filename);
+    if (!l) { arena_destroy(arena); free(table); return NULL; }
+
+    int depth = 0;
+    Token tok;
+    while ((tok = lexer_next_token(l)).type != TOK_EOF) {
+        if (tok.type == TOK_ILLEGAL) break;
+        if (tok.type == TOK_NEWLINE) continue;
+
+        int line = tok.line;
+        if (line < 1 || line > max_line) continue;
+
+        /* Closing brace: dedent first, then record */
+        if (tok.type == TOK_RBRACE) {
+            if (depth > 0) depth--;
+        }
+
+        /* Record depth for this line if not yet set */
+        if (table[line] < 0) {
+            table[line] = depth;
+        }
+
+        /* Opening brace: indent for subsequent lines */
+        if (tok.type == TOK_LBRACE) {
+            depth++;
+        }
+    }
+
+    arena_destroy(arena);
+
+    /* Forward-fill gaps: blank lines and comment-only lines inherit the
+     * depth of the most recent token-bearing line. */
+    int current = 0;
+    for (int i = 1; i <= max_line; i++) {
+        if (table[i] >= 0) {
+            current = table[i];
+        } else {
+            table[i] = current;
+        }
+    }
+
+    return table;
+}
+
+/*
+ * Returns true if `line` (NUL-terminated, with leading whitespace already
+ * stripped) is inside a raw string that started on an earlier line.
+ * We track this by counting unpaired backticks across the whole source up to
+ * the given line number.  An odd count means we are inside a raw string.
+ */
+static bool line_is_in_raw_string(const char *src, int target_line) {
+    int line = 1;
+    bool in_raw = false;
+    bool in_str = false;  /* regular double-quoted string */
+    for (const char *p = src; *p && line < target_line; p++) {
+        if (*p == '\n') { line++; continue; }
+        if (in_raw) {
+            if (*p == '`') in_raw = false;
+            continue;
+        }
+        if (in_str) {
+            if (*p == '\\') { p++; continue; } /* skip escape */
+            if (*p == '"')  { in_str = false; }
+            continue;
+        }
+        if (*p == '`') { in_raw = true; continue; }
+        if (*p == '"') { in_str = true; continue; }
+    }
+    return in_raw;
+}
+
+int ez_fmt_source(const char *src, const char *filename, FILE *out) {
+    int max_line = count_lines(src);
+    int *depth_table = build_depth_table(src, filename, max_line);
+    if (!depth_table) return 1;
+
+    /* Walk the source line by line, re-indenting each one. */
+    const char *p = src;
+    int line_num = 1;
+
+    while (*p) {
+        /* Find end of this line */
+        const char *line_start = p;
+        while (*p && *p != '\n') p++;
+        int line_len = (int)(p - line_start);
+
+        /* Advance past newline for next iteration */
+        if (*p == '\n') p++;
+
+        /* Skip leading whitespace to get the trimmed content */
+        const char *content = line_start;
+        while (content < line_start + line_len && (*content == ' ' || *content == '\t'))
+            content++;
+        int content_len = (int)((line_start + line_len) - content);
+
+        if (content_len == 0) {
+            /* Blank line: emit as-is (no indentation) */
+            fputc('\n', out);
+        } else if (line_is_in_raw_string(src, line_num)) {
+            /* Inside a raw string: preserve the original line verbatim */
+            fwrite(line_start, 1, line_len, out);
+            fputc('\n', out);
+        } else {
+            /* Emit corrected indentation + original content */
+            int depth = (line_num <= max_line) ? depth_table[line_num] : 0;
+            if (depth < 0) depth = 0;
+            for (int i = 0; i < depth * FMT_INDENT_WIDTH; i++) fputc(' ', out);
+            fwrite(content, 1, content_len, out);
+            fputc('\n', out);
+        }
+
+        line_num++;
+    }
+
+    /* Ensure file ends with exactly one newline (already handled above if
+     * the source ended with \n; if it didn't, the last fputc above adds one). */
+
+    free(depth_table);
+    return 0;
+}

--- a/ezc/src/fmt/fmt.h
+++ b/ezc/src/fmt/fmt.h
@@ -1,0 +1,25 @@
+/*
+ * fmt.h - EZ source formatter
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_FMT_H
+#define EZC_FMT_H
+
+#include <stdio.h>
+
+/*
+ * ez_fmt_source:
+ *   Format the EZ source in `src` (NUL-terminated) and write the result to
+ *   `out`. Returns 0 on success, non-zero if the source could not be lexed.
+ *
+ *   Strategy: lex the source to build a per-line indentation depth table,
+ *   then re-emit each original source line with corrected leading whitespace.
+ *   All content (comments, string literals, operators) is preserved verbatim —
+ *   only the leading indentation of each line is touched.
+ */
+int ez_fmt_source(const char *src, const char *filename, FILE *out);
+
+#endif

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -26,6 +26,7 @@
 #include "parser/parser.h"
 #include "typechecker/typechecker.h"
 #include "codegen/codegen.h"
+#include "fmt/fmt.h"
 
 #ifndef EZ_VERSION
 #define EZ_VERSION "unknown"
@@ -610,6 +611,7 @@ int main(int argc, char **argv) {
     bool emit_c_only = false;
     bool check_only = false;
     bool run_mode = false;
+    bool fmt_mode = false;
     bool verbose = false;
     bool show_time = false;
     bool no_color = false;
@@ -681,6 +683,10 @@ int main(int argc, char **argv) {
             run_mode = true;
             continue;
         }
+        if (strcmp(argv[i], "--fmt") == 0) {
+            fmt_mode = true;
+            continue;
+        }
         if (argv[i][0] == '-') {
             fprintf(stderr, "ez: unknown option '%s'\n", argv[i]);
             return 1;
@@ -696,6 +702,48 @@ int main(int argc, char **argv) {
     /* Read source file */
     char *source = read_file(input_file);
     if (!source) return 1;
+
+    /* fmt mode: reformat and write back, then exit */
+    if (fmt_mode) {
+        FILE *tmp = tmpfile();
+        if (!tmp) {
+            fprintf(stderr, "ez: fmt: could not create temp file\n");
+            free(source);
+            return 1;
+        }
+        int rc = ez_fmt_source(source, input_file, tmp);
+        if (rc != 0) {
+            fprintf(stderr, "ez: fmt: failed to format '%s'\n", input_file);
+            fclose(tmp);
+            free(source);
+            return 1;
+        }
+        /* Read formatted output back */
+        long fmt_len = ftell(tmp);
+        rewind(tmp);
+        char *fmt_buf = malloc(fmt_len + 1);
+        if (!fmt_buf || (long)fread(fmt_buf, 1, fmt_len, tmp) != fmt_len) {
+            fprintf(stderr, "ez: fmt: failed to read formatted output\n");
+            fclose(tmp);
+            free(source);
+            return 1;
+        }
+        fmt_buf[fmt_len] = '\0';
+        fclose(tmp);
+        /* Write back to the original file */
+        FILE *f = fopen(input_file, "w");
+        if (!f) {
+            fprintf(stderr, "ez: fmt: cannot write '%s'\n", input_file);
+            free(fmt_buf);
+            free(source);
+            return 1;
+        }
+        fwrite(fmt_buf, 1, fmt_len, f);
+        fclose(f);
+        free(fmt_buf);
+        free(source);
+        return 0;
+    }
 
     /* Create compiler arena and diagnostics */
     Arena *arena = arena_create(EZ_COMPILER_ARENA_SIZE);

--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -730,10 +731,18 @@ int main(int argc, char **argv) {
         }
         fmt_buf[fmt_len] = '\0';
         fclose(tmp);
-        /* Write back to the original file */
-        FILE *f = fopen(input_file, "w");
+        /* Write back to the original file with explicit 0644 permissions */
+        int wfd = open(input_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (wfd < 0) {
+            fprintf(stderr, "ez: fmt: cannot write '%s'\n", input_file);
+            free(fmt_buf);
+            free(source);
+            return 1;
+        }
+        FILE *f = fdopen(wfd, "w");
         if (!f) {
             fprintf(stderr, "ez: fmt: cannot write '%s'\n", input_file);
+            close(wfd);
             free(fmt_buf);
             free(source);
             return 1;

--- a/internal/ezc/ezc.go
+++ b/internal/ezc/ezc.go
@@ -155,6 +155,30 @@ func Version() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// Fmt formats a single .ez file in place using the ezc --fmt flag.
+// Returns 0 on success, non-zero on failure.
+func Fmt(file string) (int, error) {
+	ezcPath, err := Find()
+	if err != nil {
+		return 1, err
+	}
+	return executeSilent(ezcPath, []string{"--fmt", file})
+}
+
+// executeSilent runs ezc without streaming I/O, for use by fmt/check internals.
+func executeSilent(ezcPath string, args []string) (int, error) {
+	cmd := exec.Command(ezcPath, args...)
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}
+
 // execute runs the ezc binary with the given args, streaming I/O.
 func execute(ezcPath string, args []string) (int, error) {
 	cmd := exec.Command(ezcPath, args...)


### PR DESCRIPTION
Fixes silent output and incorrect indentation in `ez fmt`.

- Rewrote `ez fmt` to delegate to `ezc --fmt` for actual formatting
- `ezc --fmt` uses the lexer to build a brace-depth table, then re-indents every line accordingly
- Supports `ez fmt file.ez`, `ez fmt dirname/`, and `ez fmt ./...` (recursive)
- Prints "already formatted" when no changes are needed