### PR TITLE
fix(typechecker): type_of on inferred wide integer vars now returns width-specific type

### DIFF
--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -4015,12 +4015,7 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                     diag_error_msg(tc->diag, "E3043", strdup(msg),
                         NODE_FILE(tc, node), node->token.line, node->token.column, 0);
                 }
-                if (strcmp(fn_name, "byte") == 0)
-                    result = &TYPE_BYTE;
-                else if (is_unsigned_type(fn_name))
-                    result = &TYPE_UINT;
-                else
-                    result = &TYPE_INT;
+                result = type_from_name(fn_name);
             } else if (strcmp(fn_name, "string") == 0 && node->data.call.arg_count == 1) {
                 result = &TYPE_STRING;
             } else if (strcmp(fn_name, "float") == 0 && node->data.call.arg_count == 1) {


### PR DESCRIPTION
Fixes #1810

## Problem
`type_of` on variables declared with inferred wide integer constructors (e.g. `mut a = i128(42)`) returned the base type ("int" / "uint") instead of the width-specific name ("i128", "u128", "i256", "u256").

Explicitly annotated vars (`mut b i128 = i128(42)`) worked correctly.

## Root cause
In `typechecker.c`, the dispatch for numeric constructor calls (`i128()`, `u128()`, etc.) always returned the base singletons `&TYPE_INT` or `&TYPE_UINT` (or `&TYPE_BYTE`).

The inferred-var path in codegen (`register_bigint_var` for `!type_name && value`) looks up the initializer in the typetable via `typetable_get(..., node->data.var_decl.value)` and only registers if `vt->name` is a bigint type. Because the call node was typed with the base name, registration was skipped and `resolve_bigint_type` / `type_of` fell back to the typetable entry.

## Fix
Return `type_from_name(fn_name)` for all these constructors. `type_from_name` already has entries for "i128", "u128", etc. (with the correct `TK_INT`/`TK_UINT` kind but the precise `.name`). This makes the typetable entry for the initializer carry the width-specific name, so the inferred registration succeeds and `type_of` on the resulting label returns the right string.

The `resolve_bigint_type` path for direct `i128(42)` calls already returned the specific name; this makes inference consistent.

## Testing
- Existing explicit-annotation tests in `integration-tests/pass/core/bigint.ez` continue to pass.
- The reproduction cases from the issue now behave correctly (inferred vars get width-specific `type_of` results).

Closes #1810