### PR TITLE
feat: tagged union enums with pattern destructuring

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `ezc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 320 codes** (215 errors, 16 warnings, 89 panics)
+**Total: 327 codes** (222 errors, 16 warnings, 89 panics)
 
 ---
 
@@ -73,6 +73,7 @@
 | `E2080` | syntax | invalid character in C header path; only [A-Za-z0-9./_+-] are permitted |
 | `E2081` | syntax | '^' is a dereference operator, not a type modifier; for a pointer return type write '^%s', not '%s^' |
 | `E2082` | syntax | arrays of typed func signatures are not supported; use '[func]' or '[func, N]' with '()func_name' elements instead |
+| `E2083` | syntax | enum variant '%s' cannot have both a payload and an explicit value |
 | `E3001` | types | type mismatch; a value of one type is used where a different type is expected |
 | `E3002` | types | this operator does not work on this type; for example, strings cannot be subtracted |
 | `E3003` | types | invalid array index type; array indices must be integers |
@@ -170,6 +171,12 @@
 | `E3108` | types | fmt.%s: format string has %d directive(s) but %d argument(s) were passed (too many) |
 | `E3109` | types | #json struct '%s' cannot have default field values; field '%s' has a default |
 | `E3110` | types | implicit enum selector '.%s' requires type context; use the full form 'EnumName.%s' or add a type annotation |
+| `E3111` | types | payload types are not allowed on string enum variants |
+| `E3112` | types | payload types are not allowed on #flags enum variants |
+| `E3113` | types | variant '%s' of enum '%s' expects %d payload value(s), got %d |
+| `E3114` | types | variant '%s' of enum '%s' has no payload; remove the arguments |
+| `E3115` | types | enum '%s' is not a tagged enum; variant '%s' cannot be called |
+| `E3116` | types | wrong number of bindings for variant '%s'; expected %d, got %d |
 | `E4001` | names | this variable does not exist; check the spelling or make sure it is declared above this line |
 | `E4002` | names | this function does not exist; check the spelling or make sure it is defined |
 | `E4003` | names | variable '%s' already declared in this scope (line %d) |
@@ -371,4 +378,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-06-14 18:11:21 UTC*
+*Generated on 2026-06-14 23:50:32 UTC*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -630,6 +630,66 @@ mut dirs [Direction] = {.NORTH, .SOUTH}
 
 The full `EnumName.VARIANT` form is always valid and is required when no type context is available.
 
+**Tagged Enums (Variants with Data):**
+
+Enum variants can carry associated data (payloads), making the enum a tagged union. A variant's payload is declared with positional types in parentheses:
+
+```ez
+const Shape enum {
+    Circle(float)
+    Rect(float, float)
+    Point
+}
+```
+
+An enum becomes a tagged union if ANY variant has a payload. Variants without payloads (like `Point` above) are plain tag-only variants. Payloads and explicit values (`= 5`) are mutually exclusive per variant. String enums and `#flags` enums cannot have payloads.
+
+**Construction:**
+
+Tagged enum values are constructed by calling the variant with arguments:
+
+```ez
+mut s Shape = Shape.Circle(3.14)
+mut r Shape = Shape.Rect(10.0, 20.0)
+mut p Shape = Shape.Point
+```
+
+The implicit selector syntax also works with tagged constructors:
+
+```ez
+mut s Shape = .Circle(3.14)
+```
+
+**Destructuring with `when/is`:**
+
+Use pattern destructuring in `when/is` to extract payload values:
+
+```ez
+when shape {
+    is Circle(radius) {
+        println("Circle with radius ${radius}")
+    }
+    is Rect(w, h) {
+        println("Rectangle ${w} x ${h}")
+    }
+    is Point {
+        println("Just a point")
+    }
+}
+```
+
+Implicit selector patterns also work in `when/is`:
+
+```ez
+when shape {
+    is .Circle(r) { println("radius: ${r}") }
+    is .Rect(w, h) { println("${w}x${h}") }
+    is .Point { println("point") }
+}
+```
+
+The number of bindings in a pattern must match the variant's payload count. `#strict` exhaustiveness checking works with tagged enums.
+
 ### 3.3 Type Inference
 
 EZ is a statically-typed language with full type inference. The type of every variable is known at compile time, but explicit type annotations are optional when the compiler can determine the type from the initializer.

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -29,6 +29,8 @@ static void emit_statement(CodeGen *cg, AstNode *node);
 static void emit_expression(CodeGen *cg, AstNode *node);
 static void emit_call_expression(CodeGen *cg, AstNode *node);
 static bool codegen_is_enum(CodeGen *cg, const char *name);
+static bool cg_enum_is_tagged(CodeGen *cg, const char *name);
+static int cg_enum_index(CodeGen *cg, const char *name);
 static void emit_to_string(CodeGen *cg, AstNode *arg);
 static bool emit_narrowing_cast(CodeGen *cg, const char *target, AstNode *val, int line);
 
@@ -2152,7 +2154,11 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                     if (r != mod && codegen_is_enum(cg, r)) resolved_enum = r;
                 }
                 if (resolved_enum) {
-                    emitf(cg, "EzEnum_%s_%s", resolved_enum, mem);
+                    if (cg_enum_is_tagged(cg, resolved_enum)) {
+                        emitf(cg, "(EzEnum_%s){ .tag = EzEnum_%s_TAG_%s }", resolved_enum, resolved_enum, mem);
+                    } else {
+                        emitf(cg, "EzEnum_%s_%s", resolved_enum, mem);
+                    }
                     break;
                 }
             }
@@ -2164,7 +2170,11 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
              * member's first-letter casing (lowercase variants like
              * `type_change` are valid). */
             if (codegen_is_enum(cg, mod)) {
-                emitf(cg, "EzEnum_%s_%s", mod, mem);
+                if (cg_enum_is_tagged(cg, mod)) {
+                    emitf(cg, "(EzEnum_%s){ .tag = EzEnum_%s_TAG_%s }", mod, mod, mem);
+                } else {
+                    emitf(cg, "EzEnum_%s_%s", mod, mem);
+                }
                 break;
             }
 
@@ -2645,7 +2655,11 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
         const char *ename = node->data.implicit_enum.resolved_enum;
         const char *variant = node->data.implicit_enum.variant;
         if (ename) {
-            emitf(cg, "EzEnum_%s_%s", ename, variant);
+            if (cg_enum_is_tagged(cg, ename)) {
+                emitf(cg, "(EzEnum_%s){ .tag = EzEnum_%s_TAG_%s }", ename, ename, variant);
+            } else {
+                emitf(cg, "EzEnum_%s_%s", ename, variant);
+            }
         }
         break;
     }
@@ -5790,6 +5804,64 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
         }
     }
 
+    /* Tagged enum construction: Shape.Circle(3.14) */
+    if (node->data.call.function->kind == NODE_MEMBER_EXPR &&
+        node->data.call.function->data.member.object->kind == NODE_LABEL) {
+        const char *ename = node->data.call.function->data.member.object->data.label.value;
+        const char *vname = node->data.call.function->data.member.member;
+        /* Also check using-module-resolved names */
+        const char *resolved_ename = ename;
+        if (!codegen_is_enum(cg, ename)) {
+            const char *r = resolve_unprefixed_name(cg, ename);
+            if (r != ename && codegen_is_enum(cg, r)) resolved_ename = r;
+        }
+        if (codegen_is_enum(cg, resolved_ename) && cg_enum_is_tagged(cg, resolved_ename)) {
+            /* Emit compound literal: (EzEnum_Shape){ .tag = EzEnum_Shape_TAG_Circle, .data.Circle = { args } } */
+            int eidx = cg_enum_index(cg, resolved_ename);
+            AstNode *decl = cg->enum_decls[eidx];
+            int vidx = -1;
+            for (int vi = 0; vi < decl->data.enum_decl.value_count; vi++) {
+                if (strcmp(decl->data.enum_decl.values[vi].name, vname) == 0) { vidx = vi; break; }
+            }
+            emitf(cg, "(EzEnum_%s){ .tag = EzEnum_%s_TAG_%s", resolved_ename, resolved_ename, vname);
+            if (vidx >= 0 && decl->data.enum_decl.values[vidx].payload_count > 0) {
+                emitf(cg, ", .data.%s = { ", vname);
+                for (int ai = 0; ai < node->data.call.arg_count; ai++) {
+                    if (ai > 0) emit(cg, ", ");
+                    emit_expression(cg, node->data.call.args[ai]);
+                }
+                emit(cg, " }");
+            }
+            emit(cg, " }");
+            return;
+        }
+    }
+
+    /* Tagged enum construction via implicit selector: .Circle(3.14) */
+    if (node->data.call.function->kind == NODE_IMPLICIT_ENUM) {
+        const char *ename = node->data.call.function->data.implicit_enum.resolved_enum;
+        const char *vname = node->data.call.function->data.implicit_enum.variant;
+        if (ename && cg_enum_is_tagged(cg, ename)) {
+            int eidx = cg_enum_index(cg, ename);
+            AstNode *decl = cg->enum_decls[eidx];
+            int vidx = -1;
+            for (int vi = 0; vi < decl->data.enum_decl.value_count; vi++) {
+                if (strcmp(decl->data.enum_decl.values[vi].name, vname) == 0) { vidx = vi; break; }
+            }
+            emitf(cg, "(EzEnum_%s){ .tag = EzEnum_%s_TAG_%s", ename, ename, vname);
+            if (vidx >= 0 && decl->data.enum_decl.values[vidx].payload_count > 0) {
+                emitf(cg, ", .data.%s = { ", vname);
+                for (int ai = 0; ai < node->data.call.arg_count; ai++) {
+                    if (ai > 0) emit(cg, ", ");
+                    emit_expression(cg, node->data.call.args[ai]);
+                }
+                emit(cg, " }");
+            }
+            emit(cg, " }");
+            return;
+        }
+    }
+
     /* Check for struct-namespaced or user-module function call: Name.func() */
     if (node->data.call.function->kind == NODE_MEMBER_EXPR) {
         AstNode *obj = node->data.call.function->data.member.object;
@@ -8331,10 +8403,17 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
         AstNode *val = node->data.when_stmt.value;
         EzType *when_val_t = cg->type_table ? typetable_get(cg->type_table, val) : NULL;
         bool when_is_string = (when_val_t && when_val_t->kind == TK_STRING);
+        bool when_is_tagged = false;
+        const char *when_tagged_ename = NULL;
         if (!when_is_string && when_val_t && when_val_t->kind == TK_ENUM && when_val_t->name) {
             for (int ei = 0; ei < cg->enum_count; ei++) {
-                if (strcmp(cg->enum_names[ei], when_val_t->name) == 0 && cg->enum_is_string[ei]) {
-                    when_is_string = true; break;
+                if (strcmp(cg->enum_names[ei], when_val_t->name) == 0) {
+                    if (cg->enum_is_string[ei]) when_is_string = true;
+                    if (cg->enum_is_tagged[ei]) {
+                        when_is_tagged = true;
+                        when_tagged_ename = when_val_t->name;
+                    }
+                    break;
                 }
             }
         }
@@ -8351,7 +8430,31 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
             }
             for (int j = 0; j < wc->value_count; j++) {
                 if (j > 0) emit(cg, " || ");
-                if (wc->is_range && wc->values[j]->kind == NODE_RANGE_EXPR) {
+                if (wc->values[j]->kind == NODE_WHEN_PATTERN) {
+                    /* Destructuring pattern: compare tag */
+                    const char *vname = wc->values[j]->data.when_pattern.variant;
+                    const char *ename = wc->values[j]->data.when_pattern.enum_name;
+                    if (!ename) ename = when_tagged_ename;
+                    emit_expression(cg, val);
+                    emitf(cg, ".tag == EzEnum_%s_TAG_%s", ename, vname);
+                } else if (when_is_tagged) {
+                    /* Tagged enum, plain variant: compare .tag */
+                    AstNode *cv = wc->values[j];
+                    const char *vname = NULL;
+                    if (cv->kind == NODE_MEMBER_EXPR && cv->data.member.object->kind == NODE_LABEL) {
+                        vname = cv->data.member.member;
+                    } else if (cv->kind == NODE_IMPLICIT_ENUM) {
+                        vname = cv->data.implicit_enum.variant;
+                    }
+                    if (vname) {
+                        emit_expression(cg, val);
+                        emitf(cg, ".tag == EzEnum_%s_TAG_%s", when_tagged_ename, vname);
+                    } else {
+                        emit_expression(cg, val);
+                        emit(cg, ".tag == ");
+                        emit_expression(cg, cv);
+                    }
+                } else if (wc->is_range && wc->values[j]->kind == NODE_RANGE_EXPR) {
                     AstNode *r = wc->values[j];
                     /* Check if step is a negative literal to reverse comparison direction */
                     bool neg_step = (r->data.range_expr.step &&
@@ -8395,6 +8498,36 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
             }
             emit(cg, ") {\n");
             cg->indent++;
+            /* Emit binding declarations for when patterns */
+            for (int j = 0; j < wc->value_count; j++) {
+                if (wc->values[j]->kind == NODE_WHEN_PATTERN) {
+                    AstNode *pat = wc->values[j];
+                    const char *vname = pat->data.when_pattern.variant;
+                    const char *ename = pat->data.when_pattern.enum_name;
+                    if (!ename) ename = when_tagged_ename;
+                    int eidx = cg_enum_index(cg, ename);
+                    if (eidx >= 0) {
+                        AstNode *decl = cg->enum_decls[eidx];
+                        int vidx = -1;
+                        for (int vi = 0; vi < decl->data.enum_decl.value_count; vi++) {
+                            if (strcmp(decl->data.enum_decl.values[vi].name, vname) == 0) { vidx = vi; break; }
+                        }
+                        if (vidx >= 0) {
+                            EnumVal *ev = &decl->data.enum_decl.values[vidx];
+                            int limit = pat->data.when_pattern.binding_count < ev->payload_count
+                                ? pat->data.when_pattern.binding_count : ev->payload_count;
+                            for (int bi = 0; bi < limit; bi++) {
+                                emit_indent(cg);
+                                emitf(cg, "%s %s = ",
+                                    ez_type_to_c_cg(cg, ev->payload_types[bi]),
+                                    pat->data.when_pattern.bindings[bi]);
+                                emit_expression(cg, val);
+                                emitf(cg, ".data.%s._%d;\n", vname, bi);
+                            }
+                        }
+                    }
+                }
+            }
             emit_block(cg, wc->body);
             cg->indent--;
         }
@@ -8506,6 +8639,20 @@ static bool codegen_is_enum(CodeGen *cg, const char *name) {
     return false;
 }
 
+static bool cg_enum_is_tagged(CodeGen *cg, const char *name) {
+    for (int i = 0; i < cg->enum_count; i++) {
+        if (strcmp(cg->enum_names[i], name) == 0) return cg->enum_is_tagged[i];
+    }
+    return false;
+}
+
+static int cg_enum_index(CodeGen *cg, const char *name) {
+    for (int i = 0; i < cg->enum_count; i++) {
+        if (strcmp(cg->enum_names[i], name) == 0) return i;
+    }
+    return -1;
+}
+
 CodeGen codegen_create(const char *file) {
     CodeGen cg;
     cg.output = buf_create(CG_OUTPUT_BUF_INITIAL);
@@ -8516,6 +8663,8 @@ CodeGen codegen_create(const char *file) {
     cg.file = file;
     cg.enum_names = NULL;
     cg.enum_is_string = NULL;
+    cg.enum_is_tagged = NULL;
+    cg.enum_decls = NULL;
     cg.enum_count = 0;
     cg.enum_cap = 0;
     cg.current_func = NULL;
@@ -8721,13 +8870,18 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
             }
 
             /* Register enum name and string flag */
+            bool is_tagged = stmt->data.enum_decl.is_tagged;
             if (cg->enum_count >= cg->enum_cap) {
                 cg->enum_cap = cg->enum_cap ? cg->enum_cap * 2 : 8;
                 cg->enum_names = xrealloc(cg->enum_names, sizeof(const char *) * cg->enum_cap);
                 cg->enum_is_string = xrealloc(cg->enum_is_string, sizeof(bool) * cg->enum_cap);
+                cg->enum_is_tagged = xrealloc(cg->enum_is_tagged, sizeof(bool) * cg->enum_cap);
+                cg->enum_decls = xrealloc(cg->enum_decls, sizeof(AstNode *) * cg->enum_cap);
             }
             cg->enum_names[cg->enum_count] = stmt->data.enum_decl.name;
             cg->enum_is_string[cg->enum_count] = is_string_enum;
+            cg->enum_is_tagged[cg->enum_count] = is_tagged;
+            cg->enum_decls[cg->enum_count] = stmt;
             cg->enum_count++;
 
             if (is_string_enum) {
@@ -8743,6 +8897,47 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
                         str_val, (int)strlen(str_val));
                 }
                 emit(cg, "\n");
+            } else if (is_tagged) {
+                const char *ename = stmt->data.enum_decl.name;
+                /* Tag enum */
+                emitf(cg, "typedef enum {\n");
+                for (int j = 0; j < stmt->data.enum_decl.value_count; j++) {
+                    emitf(cg, "    EzEnum_%s_TAG_%s = %d,\n", ename, stmt->data.enum_decl.values[j].name, j);
+                }
+                emitf(cg, "} EzEnum_%s_Tag;\n\n", ename);
+
+                /* Payload structs (only for variants with payloads) */
+                for (int j = 0; j < stmt->data.enum_decl.value_count; j++) {
+                    EnumVal *ev = &stmt->data.enum_decl.values[j];
+                    if (ev->payload_count > 0) {
+                        emitf(cg, "typedef struct {");
+                        for (int k = 0; k < ev->payload_count; k++) {
+                            if (k > 0) emit(cg, "");
+                            emitf(cg, " %s _%d;", ez_type_to_c_cg(cg, ev->payload_types[k]), k);
+                        }
+                        emitf(cg, " } EzEnum_%s_Data_%s;\n", ename, ev->name);
+                    }
+                }
+
+                /* Tagged union struct */
+                emitf(cg, "typedef struct {\n");
+                emitf(cg, "    EzEnum_%s_Tag tag;\n", ename);
+                /* Only emit union if any variant has a payload */
+                bool has_any_payload = false;
+                for (int j = 0; j < stmt->data.enum_decl.value_count; j++) {
+                    if (stmt->data.enum_decl.values[j].payload_count > 0) { has_any_payload = true; break; }
+                }
+                if (has_any_payload) {
+                    emitf(cg, "    union {\n");
+                    for (int j = 0; j < stmt->data.enum_decl.value_count; j++) {
+                        EnumVal *ev = &stmt->data.enum_decl.values[j];
+                        if (ev->payload_count > 0) {
+                            emitf(cg, "        EzEnum_%s_Data_%s %s;\n", ename, ev->name, ev->name);
+                        }
+                    }
+                    emitf(cg, "    } data;\n");
+                }
+                emitf(cg, "} EzEnum_%s;\n\n", ename);
             } else {
                 bool is_flags = stmt->data.enum_decl.is_flags;
                 emitf(cg, "typedef enum {\n");

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -29,6 +29,8 @@ typedef struct {
     /* Track declared type names for codegen */
     const char **enum_names;
     bool *enum_is_string;
+    bool *enum_is_tagged;    /* parallel: true if tagged union enum */
+    AstNode **enum_decls;    /* parallel: AST nodes for payload type lookup */
     int enum_count;
     int enum_cap;
 

--- a/ezc/src/parser/ast.h
+++ b/ezc/src/parser/ast.h
@@ -37,6 +37,7 @@ typedef enum {
     NODE_BLANK_IDENT,
     NODE_FUNC_REF,
     NODE_IMPLICIT_ENUM,
+    NODE_WHEN_PATTERN,
 
     /* Statements */
     NODE_VAR_DECL,
@@ -89,7 +90,9 @@ typedef struct {
 /* Enum value */
 typedef struct {
     const char *name;
-    AstNode *value; /* optional explicit value */
+    AstNode *value;              /* optional explicit value (plain enums only) */
+    const char **payload_types;  /* NULL if no payload */
+    int payload_count;           /* 0 for plain variants */
 } EnumVal;
 
 /* Import item */
@@ -203,6 +206,15 @@ struct AstNode {
 
         /* NODE_IMPLICIT_ENUM — .VARIANT (resolved by typechecker) */
         struct { const char *variant; const char *resolved_enum; } implicit_enum;
+
+        /* NODE_WHEN_PATTERN — destructuring pattern in when/is */
+        struct {
+            const char *variant;       /* e.g. "Circle" */
+            const char *enum_name;     /* resolved by typechecker, e.g. "Shape" */
+            const char **bindings;     /* binding variable names */
+            int binding_count;
+            bool is_implicit;          /* true if .Circle(r) form */
+        } when_pattern;
 
         /* NODE_VAR_DECL */
         struct {
@@ -324,6 +336,7 @@ struct AstNode {
             EnumVal *values;
             int value_count;
             bool is_flags;
+            bool is_tagged;  /* true if ANY variant has a payload */
         } enum_decl;
 
         /* NODE_MODULE_DECL */

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -2206,6 +2206,7 @@ static AstNode *parse_enum_declaration(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_ENUM_DECL, p->cur_token);
     node->data.enum_decl.name = p->cur_token.literal;
     node->data.enum_decl.is_flags = false;
+    node->data.enum_decl.is_tagged = false;
 
     next_token(p); /* skip 'enum' keyword */
     if (!expect_peek(p, TOK_LBRACE)) return NULL;
@@ -2269,9 +2270,37 @@ static AstNode *parse_enum_declaration(Parser *p) {
         EnumVal *ev = &node->data.enum_decl.values[node->data.enum_decl.value_count];
         ev->name = p->cur_token.literal;
         ev->value = NULL;
+        ev->payload_types = NULL;
+        ev->payload_count = 0;
+
+        /* Check for payload types: VARIANT(type1, type2, ...) */
+        if (peek_token_is(p, TOK_LPAREN)) {
+            next_token(p); /* consume ( */
+            next_token(p); /* first type */
+            int pt_cap = 4;
+            ev->payload_types = arena_alloc(p->arena, sizeof(const char *) * pt_cap);
+            while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
+                if (ev->payload_count >= pt_cap) {
+                    pt_cap *= 2;
+                    const char **new_pt = arena_alloc(p->arena, sizeof(const char *) * pt_cap);
+                    memcpy(new_pt, ev->payload_types, sizeof(const char *) * ev->payload_count);
+                    ev->payload_types = new_pt;
+                }
+                ev->payload_types[ev->payload_count++] = p->cur_token.literal;
+                next_token(p);
+                if (cur_token_is(p, TOK_COMMA)) next_token(p);
+            }
+            /* cur_token is now TOK_RPAREN */
+        }
 
         /* Check for explicit value: VALUE = expr */
         if (peek_token_is(p, TOK_ASSIGN)) {
+            /* E2083: payload and explicit value are mutually exclusive */
+            if (ev->payload_count > 0) {
+                diag_error_codef(p->diag, "E2083",
+                    p->file, p->cur_token.line, p->cur_token.column, 0,
+                    ev->name);
+            }
             next_token(p); /* skip = */
             next_token(p);
             ev->value = parse_expression(p, PREC_LOWEST);
@@ -2290,6 +2319,14 @@ static AstNode *parse_enum_declaration(Parser *p) {
                 strdup("semicolons are not used; put each enum variant on its own line"),
                 p->file, p->cur_token.line, p->cur_token.column, 0);
             next_token(p);
+        }
+    }
+
+    /* Set is_tagged if any variant has a payload */
+    for (int j = 0; j < node->data.enum_decl.value_count; j++) {
+        if (node->data.enum_decl.values[j].payload_count > 0) {
+            node->data.enum_decl.is_tagged = true;
+            break;
         }
     }
 
@@ -2493,9 +2530,124 @@ static AstNode *parse_when_statement(Parser *p) {
 
             /* Parse case values: is 1, 2, 3 { } */
             next_token(p);
+
+            /* Detect destructuring pattern: IDENT(IDENT,...) or .IDENT(IDENT,...)
+             * All tokens inside parens must be bare identifiers (no operators/literals). */
+            {
+                bool try_pattern = false;
+                bool is_implicit_pat = false;
+                Token pat_tok = p->cur_token;
+
+                if (cur_token_is(p, TOK_IDENT) && peek_token_is(p, TOK_LPAREN)) {
+                    /* Save lexer state for lookahead */
+                    int sv_pos  = p->lexer->position;
+                    int sv_rpos = p->lexer->read_position;
+                    char sv_ch  = p->lexer->ch;
+                    int sv_line = p->lexer->line;
+                    int sv_col  = p->lexer->column;
+                    Token sv_cur  = p->cur_token;
+                    Token sv_peek = p->peek_token;
+
+                    const char *vname = p->cur_token.literal;
+                    next_token(p); /* skip IDENT */
+                    next_token(p); /* skip ( */
+                    bool all_idents = true;
+                    int bind_count = 0;
+                    while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
+                        if (!cur_token_is(p, TOK_IDENT)) { all_idents = false; break; }
+                        bind_count++;
+                        next_token(p);
+                        if (cur_token_is(p, TOK_COMMA)) next_token(p);
+                    }
+                    if (all_idents && bind_count > 0 && cur_token_is(p, TOK_RPAREN)) {
+                        try_pattern = true;
+                        (void)vname;
+                    }
+                    /* Restore lexer state */
+                    p->lexer->position = sv_pos;
+                    p->lexer->read_position = sv_rpos;
+                    p->lexer->ch = sv_ch;
+                    p->lexer->line = sv_line;
+                    p->lexer->column = sv_col;
+                    p->cur_token  = sv_cur;
+                    p->peek_token = sv_peek;
+                } else if (cur_token_is(p, TOK_DOT) && peek_token_is(p, TOK_IDENT)) {
+                    /* .IDENT(IDENT,...) form */
+                    int sv_pos  = p->lexer->position;
+                    int sv_rpos = p->lexer->read_position;
+                    char sv_ch  = p->lexer->ch;
+                    int sv_line = p->lexer->line;
+                    int sv_col  = p->lexer->column;
+                    Token sv_cur  = p->cur_token;
+                    Token sv_peek = p->peek_token;
+
+                    next_token(p); /* skip dot */
+                    const char *vname = p->cur_token.literal;
+                    if (peek_token_is(p, TOK_LPAREN)) {
+                        next_token(p); /* skip IDENT */
+                        next_token(p); /* skip ( */
+                        bool all_idents = true;
+                        int bind_count = 0;
+                        while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
+                            if (!cur_token_is(p, TOK_IDENT)) { all_idents = false; break; }
+                            bind_count++;
+                            next_token(p);
+                            if (cur_token_is(p, TOK_COMMA)) next_token(p);
+                        }
+                        if (all_idents && bind_count > 0 && cur_token_is(p, TOK_RPAREN)) {
+                            try_pattern = true;
+                            is_implicit_pat = true;
+                            (void)vname;
+                        }
+                    }
+                    /* Restore lexer state */
+                    p->lexer->position = sv_pos;
+                    p->lexer->read_position = sv_rpos;
+                    p->lexer->ch = sv_ch;
+                    p->lexer->line = sv_line;
+                    p->lexer->column = sv_col;
+                    p->cur_token  = sv_cur;
+                    p->peek_token = sv_peek;
+                }
+
+                if (try_pattern) {
+                    /* Actually consume and build NODE_WHEN_PATTERN */
+                    AstNode *pat = ast_alloc(p->arena, NODE_WHEN_PATTERN, pat_tok);
+                    pat->data.when_pattern.enum_name = NULL;
+                    pat->data.when_pattern.is_implicit = is_implicit_pat;
+
+                    if (is_implicit_pat) {
+                        next_token(p); /* skip dot */
+                    }
+                    pat->data.when_pattern.variant = arena_strdup(p->arena, p->cur_token.literal);
+                    next_token(p); /* skip IDENT (variant) */
+                    next_token(p); /* skip ( */
+
+                    int bc = 0, bc_cap = 4;
+                    pat->data.when_pattern.bindings = arena_alloc(p->arena, sizeof(const char *) * bc_cap);
+                    while (!cur_token_is(p, TOK_RPAREN) && !cur_token_is(p, TOK_EOF)) {
+                        if (bc >= bc_cap) {
+                            bc_cap *= 2;
+                            const char **nb = arena_alloc(p->arena, sizeof(const char *) * bc_cap);
+                            memcpy(nb, pat->data.when_pattern.bindings, sizeof(const char *) * bc);
+                            pat->data.when_pattern.bindings = nb;
+                        }
+                        pat->data.when_pattern.bindings[bc++] = arena_strdup(p->arena, p->cur_token.literal);
+                        next_token(p);
+                        if (cur_token_is(p, TOK_COMMA)) next_token(p);
+                    }
+                    pat->data.when_pattern.binding_count = bc;
+                    /* cur_token is RPAREN, peek should be LBRACE */
+
+                    wc->values[wc->value_count++] = pat;
+                    goto when_case_body;
+                }
+            }
+
             if (cur_token_is(p, TOK_RANGE)) {
                 wc->is_range = true;
             }
+            p->no_struct_literal = true;
             if (wc->value_count < val_cap) {
                 wc->values[wc->value_count++] = parse_expression(p, PREC_LOWEST);
             }
@@ -2514,6 +2666,8 @@ static AstNode *parse_when_statement(Parser *p) {
                 wc->values[wc->value_count++] = parse_expression(p, PREC_LOWEST);
             }
 
+            when_case_body:
+            p->no_struct_literal = false;
             if (!expect_peek(p, TOK_LBRACE)) return NULL;
             wc->body = parse_block_statement(p);
             node->data.when_stmt.case_count++;

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -1499,7 +1499,8 @@ static EzType *tc_resolve_using_constant_type(TypeChecker *tc, const char *name)
 
 static void register_enum(TypeChecker *tc, const char *name,
     const char *display_name, bool is_string,
-    const char **values, int value_count) {
+    const char **values, int value_count,
+    const char ***payload_types, int *payload_counts, bool is_tagged) {
     if (tc->enum_count >= tc->enum_cap) {
         tc->enum_cap = tc->enum_cap ? tc->enum_cap * 2 : 8;
         tc->enum_names = xrealloc(tc->enum_names, sizeof(const char *) * tc->enum_cap);
@@ -1507,12 +1508,18 @@ static void register_enum(TypeChecker *tc, const char *name,
         tc->enum_is_string = xrealloc(tc->enum_is_string, sizeof(bool) * tc->enum_cap);
         tc->enum_values = xrealloc(tc->enum_values, sizeof(const char **) * tc->enum_cap);
         tc->enum_value_counts = xrealloc(tc->enum_value_counts, sizeof(int) * tc->enum_cap);
+        tc->enum_payload_types = xrealloc(tc->enum_payload_types, sizeof(const char ***) * tc->enum_cap);
+        tc->enum_payload_counts = xrealloc(tc->enum_payload_counts, sizeof(int *) * tc->enum_cap);
+        tc->enum_is_tagged = xrealloc(tc->enum_is_tagged, sizeof(bool) * tc->enum_cap);
     }
     tc->enum_names[tc->enum_count] = name;
     tc->enum_display_names[tc->enum_count] = display_name ? display_name : name;
     tc->enum_is_string[tc->enum_count] = is_string;
     tc->enum_values[tc->enum_count] = values;
     tc->enum_value_counts[tc->enum_count] = value_count;
+    tc->enum_payload_types[tc->enum_count] = payload_types;
+    tc->enum_payload_counts[tc->enum_count] = payload_counts;
+    tc->enum_is_tagged[tc->enum_count] = is_tagged;
     tc->enum_count++;
 }
 
@@ -2559,6 +2566,56 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
             }
         }
 
+        /* Tagged enum construction via implicit selector: .Circle(3.14) */
+        if (fn->kind == NODE_IMPLICIT_ENUM) {
+            const char *vname = fn->data.implicit_enum.variant;
+            /* Resolve enum from expected_type */
+            EzType *et = tc->expected_type;
+            if (et && et->kind == TK_ENUM && et->name) {
+                fn->data.implicit_enum.resolved_enum = et->name;
+                int eidx = -1;
+                for (int ei = 0; ei < tc->enum_count; ei++) {
+                    if (strcmp(tc->enum_names[ei], et->name) == 0) { eidx = ei; break; }
+                }
+                if (eidx >= 0) {
+                    int vidx = -1;
+                    for (int vi = 0; vi < tc->enum_value_counts[eidx]; vi++) {
+                        if (strcmp(tc->enum_values[eidx][vi], vname) == 0) { vidx = vi; break; }
+                    }
+                    if (vidx < 0) {
+                        diag_error_codef(tc->diag, "E3047", NODE_FILE(tc, node), node->token.line, node->token.column, 0, et->name, vname);
+                    } else if (tc->enum_is_tagged[eidx]) {
+                        int expected_pc = tc->enum_payload_counts[eidx][vidx];
+                        int got_ac = node->data.call.arg_count;
+                        if (expected_pc == 0 && got_ac > 0) {
+                            diag_error_codef(tc->diag, "E3114", NODE_FILE(tc, node), node->token.line, node->token.column, 0, vname, tc->enum_display_names[eidx]);
+                        } else if (expected_pc != got_ac) {
+                            diag_error_codef(tc->diag, "E3113", NODE_FILE(tc, node), node->token.line, node->token.column, 0, vname, tc->enum_display_names[eidx], expected_pc, got_ac);
+                        } else {
+                            for (int ai = 0; ai < got_ac; ai++) {
+                                EzType *arg_t = resolve_expr(tc, node->data.call.args[ai]);
+                                EzType *exp_t = tc_type_from_name(tc, tc->enum_payload_types[eidx][vidx][ai]);
+                                if (arg_t && exp_t &&
+                                    arg_t->kind != TK_UNKNOWN && exp_t->kind != TK_UNKNOWN &&
+                                    arg_t->kind != exp_t->kind &&
+                                    !(is_int_kind(arg_t->kind) && is_int_kind(exp_t->kind))) {
+                                    diag_error_codef(tc->diag, "E3001", NODE_FILE(tc, node->data.call.args[ai]),
+                                        node->data.call.args[ai]->token.line, node->data.call.args[ai]->token.column, 0);
+                                }
+                            }
+                        }
+                    } else {
+                        diag_error_codef(tc->diag, "E3115", NODE_FILE(tc, node), node->token.line, node->token.column, 0, tc->enum_display_names[eidx], vname);
+                    }
+                }
+                result = type_enum(et->name);
+            } else {
+                diag_error_codef(tc->diag, "E3110", NODE_FILE(tc, node), node->token.line, node->token.column, 0, vname, vname);
+                result = &TYPE_UNKNOWN;
+            }
+            break;
+        }
+
         if (fn->kind == NODE_LABEL) {
             fn_name = fn->data.label.value;
         } else if (fn->kind == NODE_MEMBER_EXPR &&
@@ -2658,6 +2715,57 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                 }
             } else {
                 result = &TYPE_VOID;
+            }
+        } else if (fn->kind == NODE_MEMBER_EXPR && fn->data.member.object->kind == NODE_LABEL &&
+                   is_enum_name(tc, fn->data.member.object->data.label.value)) {
+            /* Tagged enum construction: Shape.Circle(3.14) */
+            const char *ename = fn->data.member.object->data.label.value;
+            const char *vname = fn->data.member.member;
+            int eidx = -1;
+            for (int ei = 0; ei < tc->enum_count; ei++) {
+                if (strcmp(tc->enum_names[ei], ename) == 0) { eidx = ei; break; }
+            }
+            if (eidx >= 0) {
+                /* Find variant index */
+                int vidx = -1;
+                for (int vi = 0; vi < tc->enum_value_counts[eidx]; vi++) {
+                    if (strcmp(tc->enum_values[eidx][vi], vname) == 0) { vidx = vi; break; }
+                }
+                if (vidx < 0) {
+                    diag_error_codef(tc->diag, "E3047", NODE_FILE(tc, node), node->token.line, node->token.column, 0, ename, vname);
+                    result = &TYPE_UNKNOWN;
+                    break;
+                }
+                if (!tc->enum_is_tagged[eidx]) {
+                    /* E3115: plain enum, can't call */
+                    const char *dname = tc->enum_display_names[eidx];
+                    diag_error_codef(tc->diag, "E3115", NODE_FILE(tc, node), node->token.line, node->token.column, 0, dname, vname);
+                    result = type_enum(ename);
+                    break;
+                }
+                int expected_pc = tc->enum_payload_counts[eidx][vidx];
+                int got_ac = node->data.call.arg_count;
+                if (expected_pc == 0 && got_ac > 0) {
+                    diag_error_codef(tc->diag, "E3114", NODE_FILE(tc, node), node->token.line, node->token.column, 0, vname, tc->enum_display_names[eidx]);
+                } else if (expected_pc != got_ac) {
+                    diag_error_codef(tc->diag, "E3113", NODE_FILE(tc, node), node->token.line, node->token.column, 0, vname, tc->enum_display_names[eidx], expected_pc, got_ac);
+                } else {
+                    /* Validate each arg type against payload type */
+                    for (int ai = 0; ai < got_ac; ai++) {
+                        EzType *arg_t = resolve_expr(tc, node->data.call.args[ai]);
+                        EzType *expected_t = tc_type_from_name(tc, tc->enum_payload_types[eidx][vidx][ai]);
+                        if (arg_t && expected_t &&
+                            arg_t->kind != TK_UNKNOWN && expected_t->kind != TK_UNKNOWN &&
+                            arg_t->kind != expected_t->kind &&
+                            !(is_int_kind(arg_t->kind) && is_int_kind(expected_t->kind))) {
+                            diag_error_codef(tc->diag, "E3001", NODE_FILE(tc, node->data.call.args[ai]),
+                                node->data.call.args[ai]->token.line, node->data.call.args[ai]->token.column, 0);
+                        }
+                    }
+                }
+                result = type_enum(ename);
+            } else {
+                result = &TYPE_UNKNOWN;
             }
         } else if (fn->kind == NODE_MEMBER_EXPR && fn->data.member.object->kind == NODE_LABEL) {
             const char *mod_raw = fn->data.member.object->data.label.value;
@@ -6197,6 +6305,14 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
         result = resolve_implicit_enum(tc, node);
         break;
 
+    case NODE_WHEN_PATTERN:
+        /* Pattern nodes are validated in the NODE_WHEN_STMT handler */
+        if (node->data.when_pattern.enum_name)
+            result = type_enum(node->data.when_pattern.enum_name);
+        else
+            result = &TYPE_UNKNOWN;
+        break;
+
     case NODE_CAST_EXPR: {
         EzType *src_t = resolve_expr(tc, node->data.cast.value);
         EzType *dst_t = type_from_name(node->data.cast.target_type);
@@ -9104,6 +9220,42 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
         for (int i = 0; i < node->data.when_stmt.case_count; i++) {
             for (int j = 0; j < node->data.when_stmt.cases[i].value_count; j++) {
                 AstNode *val_i = node->data.when_stmt.cases[i].values[j];
+                /* Handle NODE_WHEN_PATTERN: validate variant + binding count */
+                if (val_i->kind == NODE_WHEN_PATTERN) {
+                    const char *vname = val_i->data.when_pattern.variant;
+                    const char *ename = NULL;
+                    if (val_i->data.when_pattern.is_implicit) {
+                        if (when_t && when_t->kind == TK_ENUM && when_t->name)
+                            ename = when_t->name;
+                    } else {
+                        /* For explicit form Variant(x), resolve from scrutinee type */
+                        if (when_t && when_t->kind == TK_ENUM && when_t->name)
+                            ename = when_t->name;
+                    }
+                    if (ename) {
+                        val_i->data.when_pattern.enum_name = ename;
+                        int eidx = -1;
+                        for (int ei = 0; ei < tc->enum_count; ei++) {
+                            if (strcmp(tc->enum_names[ei], ename) == 0) { eidx = ei; break; }
+                        }
+                        if (eidx >= 0) {
+                            int vidx = -1;
+                            for (int vi = 0; vi < tc->enum_value_counts[eidx]; vi++) {
+                                if (strcmp(tc->enum_values[eidx][vi], vname) == 0) { vidx = vi; break; }
+                            }
+                            if (vidx < 0) {
+                                diag_error_codef(tc->diag, "E3047", NODE_FILE(tc, val_i), val_i->token.line, val_i->token.column, 0, ename, vname);
+                            } else {
+                                int expected_bc = tc->enum_payload_counts[eidx][vidx];
+                                int got_bc = val_i->data.when_pattern.binding_count;
+                                if (expected_bc != got_bc) {
+                                    diag_error_codef(tc->diag, "E3116", NODE_FILE(tc, val_i), val_i->token.line, val_i->token.column, 0, vname, expected_bc, got_bc);
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
                 EzType *case_t = resolve_expr(tc, val_i);
                 /* Check case value type matches scrutinee; skip range exprs and unknowns */
                 if (when_t && case_t &&
@@ -9143,6 +9295,33 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
             }
             Scope *case_outer = tc->current_scope;
             tc->current_scope = scope_create(case_outer);
+            /* Introduce pattern bindings into case scope */
+            for (int j = 0; j < node->data.when_stmt.cases[i].value_count; j++) {
+                AstNode *val_i = node->data.when_stmt.cases[i].values[j];
+                if (val_i->kind == NODE_WHEN_PATTERN && val_i->data.when_pattern.enum_name) {
+                    const char *ename = val_i->data.when_pattern.enum_name;
+                    const char *vname = val_i->data.when_pattern.variant;
+                    int eidx = -1;
+                    for (int ei = 0; ei < tc->enum_count; ei++) {
+                        if (strcmp(tc->enum_names[ei], ename) == 0) { eidx = ei; break; }
+                    }
+                    if (eidx >= 0) {
+                        int vidx = -1;
+                        for (int vi = 0; vi < tc->enum_value_counts[eidx]; vi++) {
+                            if (strcmp(tc->enum_values[eidx][vi], vname) == 0) { vidx = vi; break; }
+                        }
+                        if (vidx >= 0) {
+                            int bc = val_i->data.when_pattern.binding_count;
+                            int pc = tc->enum_payload_counts[eidx][vidx];
+                            int limit = bc < pc ? bc : pc;
+                            for (int bi = 0; bi < limit; bi++) {
+                                EzType *bt = tc_type_from_name(tc, tc->enum_payload_types[eidx][vidx][bi]);
+                                scope_define(tc->current_scope, val_i->data.when_pattern.bindings[bi], bt, false);
+                            }
+                        }
+                    }
+                }
+            }
             check_block(tc, node->data.when_stmt.cases[i].body);
             tc->current_scope = case_outer;
         }
@@ -9178,6 +9357,11 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                         cv->data.implicit_enum.resolved_enum) {
                         enum_name = cv->data.implicit_enum.resolved_enum;
                     }
+                    /* Infer from when pattern */
+                    if (cv->kind == NODE_WHEN_PATTERN &&
+                        cv->data.when_pattern.enum_name) {
+                        enum_name = cv->data.when_pattern.enum_name;
+                    }
                 }
             }
             if (enum_name) {
@@ -9207,6 +9391,11 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                                 /* Match .VARIANT (implicit enum selector) */
                                 if (cv->kind == NODE_IMPLICIT_ENUM &&
                                     strcmp(cv->data.implicit_enum.variant, variants[vi]) == 0) {
+                                    covered = true;
+                                }
+                                /* Match when pattern (destructuring) */
+                                if (cv->kind == NODE_WHEN_PATTERN &&
+                                    strcmp(cv->data.when_pattern.variant, variants[vi]) == 0) {
                                     covered = true;
                                 }
                                 /* Match bare integer literal (for auto-increment enums) */
@@ -9553,7 +9742,35 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
         for (int j = 0; j < vc; j++) {
             vnames[j] = stmt->data.enum_decl.values[j].name;
         }
-        register_enum(tc, stmt->data.enum_decl.name, ENUM_DISPLAY_NAME(stmt), is_str, vnames, vc);
+        /* Extract payload info for tagged enums */
+        bool has_tagged = stmt->data.enum_decl.is_tagged;
+        const char ***pt = NULL;
+        int *pc = NULL;
+        if (vc > 0) {
+            pt = xmalloc(sizeof(const char **) * vc);
+            pc = xmalloc(sizeof(int) * vc);
+            for (int j = 0; j < vc; j++) {
+                EnumVal *ev = &stmt->data.enum_decl.values[j];
+                pc[j] = ev->payload_count;
+                if (ev->payload_count > 0) {
+                    pt[j] = xmalloc(sizeof(const char *) * ev->payload_count);
+                    for (int k = 0; k < ev->payload_count; k++) {
+                        pt[j][k] = ev->payload_types[k];
+                    }
+                } else {
+                    pt[j] = NULL;
+                }
+            }
+        }
+        /* E3111: string enum with payloads */
+        if (is_str && has_tagged) {
+            diag_error_code(tc->diag, "E3111", NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0);
+        }
+        /* E3112: flags enum with payloads */
+        if (stmt->data.enum_decl.is_flags && has_tagged) {
+            diag_error_code(tc->diag, "E3112", NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0);
+        }
+        register_enum(tc, stmt->data.enum_decl.name, ENUM_DISPLAY_NAME(stmt), is_str, vnames, vc, pt, pc, has_tagged);
     }
 
     /* Pass 2b: Register structs and functions (enums already registered above) */
@@ -9925,7 +10142,9 @@ void typechecker_check(TypeChecker *tc, AstNode *program) {
                 const char *unprefixed = en + prefix_len;
                 if (!is_enum_name(tc, unprefixed)) {
                     register_enum(tc, unprefixed, unprefixed, tc->enum_is_string[ei],
-                        tc->enum_values[ei], tc->enum_value_counts[ei]);
+                        tc->enum_values[ei], tc->enum_value_counts[ei],
+                        tc->enum_payload_types[ei], tc->enum_payload_counts[ei],
+                        tc->enum_is_tagged[ei]);
                 }
             }
         }

--- a/ezc/src/typechecker/typechecker.h
+++ b/ezc/src/typechecker/typechecker.h
@@ -82,6 +82,9 @@ typedef struct {
     bool *enum_is_string; /* parallel array: true if string enum */
     const char ***enum_values; /* parallel array: variant name arrays */
     int *enum_value_counts; /* parallel array: variant counts */
+    const char ****enum_payload_types; /* [enum_idx][variant_idx] → type name array */
+    int **enum_payload_counts;         /* [enum_idx][variant_idx] → count */
+    bool *enum_is_tagged;              /* parallel to enum_names */
     int enum_count;
     int enum_cap;
 

--- a/ezc/src/util/error_codes.h
+++ b/ezc/src/util/error_codes.h
@@ -92,7 +92,8 @@
     EZ_ERROR("E2079", "syntax", "'nil' is a value, not a type; for a function that returns nothing, omit the '-> ...' clause") \
     EZ_ERROR("E2080", "syntax", "invalid character in C header path; only [A-Za-z0-9./_+-] are permitted") \
     EZ_ERROR("E2081", "syntax", "'^' is a dereference operator, not a type modifier; for a pointer return type write '^%s', not '%s^'") \
-    EZ_ERROR("E2082", "syntax", "arrays of typed func signatures are not supported; use '[func]' or '[func, N]' with '()func_name' elements instead")
+    EZ_ERROR("E2082", "syntax", "arrays of typed func signatures are not supported; use '[func]' or '[func, N]' with '()func_name' elements instead") \
+    EZ_ERROR("E2083", "syntax", "enum variant '%s' cannot have both a payload and an explicit value")
 
 /* --- E3xxx: Type Problems (Typechecker) --- */
 #define EZ_TYPE_ERRORS \
@@ -192,7 +193,13 @@
     EZ_ERROR("E3107", "types", "fmt.%s: format string has %d directive(s) but %d argument(s) were passed (too few)") \
     EZ_ERROR("E3108", "types", "fmt.%s: format string has %d directive(s) but %d argument(s) were passed (too many)") \
     EZ_ERROR("E3109", "types", "#json struct '%s' cannot have default field values; field '%s' has a default") \
-    EZ_ERROR("E3110", "types", "implicit enum selector '.%s' requires type context; use the full form 'EnumName.%s' or add a type annotation")
+    EZ_ERROR("E3110", "types", "implicit enum selector '.%s' requires type context; use the full form 'EnumName.%s' or add a type annotation") \
+    EZ_ERROR("E3111", "types", "payload types are not allowed on string enum variants") \
+    EZ_ERROR("E3112", "types", "payload types are not allowed on #flags enum variants") \
+    EZ_ERROR("E3113", "types", "variant '%s' of enum '%s' expects %d payload value(s), got %d") \
+    EZ_ERROR("E3114", "types", "variant '%s' of enum '%s' has no payload; remove the arguments") \
+    EZ_ERROR("E3115", "types", "enum '%s' is not a tagged enum; variant '%s' cannot be called") \
+    EZ_ERROR("E3116", "types", "wrong number of bindings for variant '%s'; expected %d, got %d")
 
 /* --- E4xxx: Name Problems (References) --- */
 #define EZ_REFERENCE_ERRORS \


### PR DESCRIPTION
## Summary
- Enum variants can now carry positional payload types (`Circle(float)`, `Rect(float, float)`), making the enum a tagged union
- Construction via `Shape.Circle(3.14)` or implicit `.Circle(3.14)` syntax
- Destructuring in `when/is` with bindings: `is Circle(r) { ... }` or `is .Circle(r) { ... }`
- Added error codes E2083, E3111-E3116 for payload validation (wrong arg count, string/flags constraints, binding mismatches)
- Plain enums without payloads continue to work exactly as before — no regressions

Closes #1709