### PR TITLE
feat(uuid): add UUID struct type to uuid module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ context/
 /internal/ezc/runtime/src/
 *.md
 .claude/
+
+
+# Ignore local EZ playground env
+/playground

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -2841,18 +2841,22 @@ The `HttpResponse` struct is available when either `@http` or `@server` is impor
 
 ### 9.14 UUID Module (`@uuid`)
 
+UUID is a struct type wrapping a canonical 36-character hyphenated string. All generator and parse functions return `UUID`.
+
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `generate` | `() -> string` | Generate UUID v4 without hyphens (32 chars) |
-| `generate_hyphenated` | `() -> string` | Generate UUID v4 with hyphens (36 chars) |
-| `generate_random` | `() -> string` | RFC 4122 v4 (random), hyphenated, lowercase |
-| `generate_time_ordered` | `() -> string` | RFC 9562 v7 (time-ordered), hyphenated, lowercase. Sorts by creation time |
-| `parse` | `(s string) -> string` | Validate and normalize a 36-char hyphenated UUID to lowercase. Panics on invalid input — gate with `is_valid()` for a non-panicking check |
+| `generate` | `() -> UUID` | Generate UUID v4 (hyphenated, 36 chars) |
+| `generate_hyphenated` | `() -> UUID` | Alias for `generate` |
+| `generate_random` | `() -> UUID` | RFC 4122 v4 (random), hyphenated, lowercase |
+| `generate_time_ordered` | `() -> UUID` | RFC 9562 v7 (time-ordered), hyphenated, lowercase. Sorts by creation time |
+| `generate_compact` | `(id UUID) -> string` | Strip hyphens from a UUID, returning a 32-char hex string |
+| `parse` | `(s string) -> UUID` | Validate and normalize a 36-char hyphenated UUID to lowercase. Panics on invalid input — gate with `is_valid()` for a non-panicking check |
+| `to_string` | `(id UUID) -> string` | Convert UUID to its 36-char hyphenated string representation |
 | `is_valid` | `(s string) -> bool` | Validate UUID format |
 
 | Constant | Type | Value |
 |----------|------|-------|
-| `NIL_UUID` | `string` | `"00000000-0000-0000-0000-000000000000"` |
+| `NIL_UUID` | `UUID` | All-zero UUID (`00000000-0000-0000-0000-000000000000`) |
 
 UUID randomness comes from `getentropy()` (macOS, BSDs, glibc 2.25+) with a fallback to `/dev/urandom`, suitable for security-sensitive identifiers.
 

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -271,6 +271,7 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
     if (strcmp(type_name, "Listener") == 0) return "EzSocket";
     if (strcmp(type_name, "Database") == 0) return "EzSqlite";
     if (strcmp(type_name, "Router") == 0)   return "EzRouter";
+    if (strcmp(type_name, "UUID") == 0)     return "EzUUID";
     if (strcmp(type_name, "func") == 0)  return "void *"; /* bare func; cast at call site */
     if (strncmp(type_name, "func(", 5) == 0) return "void *"; /* typed func; same C storage, signature lives in casts */
 
@@ -916,7 +917,7 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             {"O_RDONLY","io","0"},{"O_WRONLY","io","1"},{"O_RDWR","io","2"},
             {"BASE_2","strconv","2"},{"BASE_8","strconv","8"},{"BASE_10","strconv","10"},
             {"BASE_16","strconv","16"},{"BASE_36","strconv","36"},
-            {"NIL_UUID","uuid","ez_string_lit(\"00000000-0000-0000-0000-000000000000\")"},
+            {"NIL_UUID","uuid","ez_uuid_nil()"},
             {NULL,NULL,NULL}
         };
         bool emitted_const = false;
@@ -1115,6 +1116,12 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 case TK_ARRAY:  emit(cg, "%s"); break;
                 case TK_MAP:    emit(cg, "%s"); break;
                 case TK_ERROR:  emit(cg, "%s"); break;
+                case TK_STRUCT:
+                    if (t && t->name && strcmp(t->name, "UUID") == 0)
+                        emit(cg, "%s");
+                    else
+                        emit(cg, "%lld");
+                    break;
                 case TK_ENUM:
                     if (t && t->name && cg_enum_is_string(cg, t->name))
                         emit(cg, "%s");
@@ -1219,6 +1226,16 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 emit(cg, "(unsigned long long)(");
                 emit_expression(cg, part);
                 emit(cg, ")");
+                break;
+            case TK_STRUCT:
+                if (t && t->name && strcmp(t->name, "UUID") == 0) {
+                    emit_expression(cg, part);
+                    emit(cg, ".value.data");
+                } else {
+                    emit(cg, "(long long)(");
+                    emit_expression(cg, part);
+                    emit(cg, ")");
+                }
                 break;
             case TK_ENUM:
                 if (t && t->name && cg_enum_is_string(cg, t->name)) {
@@ -2138,7 +2155,7 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             /* @uuid constants */
             if (strcmp(mod, "uuid") == 0) {
                 if (strcmp(mem, "NIL_UUID") == 0) {
-                    emit(cg, "ez_string_lit(\"00000000-0000-0000-0000-000000000000\")");
+                    emit(cg, "ez_uuid_nil()");
                     break;
                 }
             }
@@ -2759,8 +2776,10 @@ static const char *resolve_print_suffix(CodeGen *cg, AstNode *arg) {
             /* Check if it's a known stdlib module function that returns string */
             if ((strcmp(obj, "strings") == 0) ||
                 (strcmp(obj, "encoding") == 0) ||
-                (strcmp(obj, "crypto") == 0) ||
-                (strcmp(obj, "uuid") == 0)) return "_str";
+                (strcmp(obj, "crypto") == 0)) return "_str";
+            if (strcmp(obj, "uuid") == 0 &&
+                (strcmp(mem, "generate_compact") == 0 ||
+                 strcmp(mem, "to_string") == 0)) return "_str";
             /* Check if it's a struct-namespaced function or instance method call */
             {
                 const char *struct_name = NULL;
@@ -3234,6 +3253,11 @@ static bool emit_builtin_call(CodeGen *cg, AstNode *node, const char *func) {
                 emit(cg, " ? ");
                 emit_expression(cg, arg);
                 emit(cg, "->message : ez_string_lit(\"nil\"))");
+            } else if (arg_t && arg_t->kind == TK_STRUCT && arg_t->name &&
+                       strcmp(arg_t->name, "UUID") == 0) {
+                emit(cg, "ez_builtin_println_str(");
+                emit_expression(cg, arg);
+                emit(cg, ".value)");
             } else {
                 const char *bi_type = resolve_bigint_type(cg, arg);
                 if (bi_type) {
@@ -3517,6 +3541,11 @@ static bool emit_builtin_call(CodeGen *cg, AstNode *node, const char *func) {
                 emit(cg, " ? ");
                 emit_expression(cg, arg);
                 emit(cg, "->message : ez_string_lit(\"nil\"))");
+            } else if (arg_t && arg_t->kind == TK_STRUCT && arg_t->name &&
+                       strcmp(arg_t->name, "UUID") == 0) {
+                emit(cg, "ez_builtin_eprintln_str(");
+                emit_expression(cg, arg);
+                emit(cg, ".value)");
             } else {
                 const char *bi_type = resolve_bigint_type(cg, arg);
                 if (bi_type) {
@@ -3543,6 +3572,11 @@ static bool emit_builtin_call(CodeGen *cg, AstNode *node, const char *func) {
             emit(cg, " ? ");
             emit_expression(cg, arg);
             emit(cg, "->message : ez_string_lit(\"nil\"))");
+        } else if (arg_t && arg_t->kind == TK_STRUCT && arg_t->name &&
+                   strcmp(arg_t->name, "UUID") == 0) {
+            emit(cg, "ez_builtin_eprint_str(");
+            emit_expression(cg, arg);
+            emit(cg, ".value)");
         } else {
             const char *bi_type = resolve_bigint_type(cg, arg);
             if (bi_type) {
@@ -3701,6 +3735,11 @@ static bool emit_builtin_call(CodeGen *cg, AstNode *node, const char *func) {
             emit(cg, " ? ");
             emit_expression(cg, arg);
             emit(cg, "->message : ez_string_lit(\"nil\"))");
+        } else if (arg_t && arg_t->kind == TK_STRUCT && arg_t->name &&
+                   strcmp(arg_t->name, "UUID") == 0) {
+            emit(cg, "ez_builtin_print_str(");
+            emit_expression(cg, arg);
+            emit(cg, ".value)");
         } else {
             const char *bi_type = resolve_bigint_type(cg, arg);
             if (bi_type) {
@@ -4029,11 +4068,13 @@ static bool emit_time_call(CodeGen *cg, AstNode *node, const char *func) {
 /* --- @uuid module --- */
 
 static bool emit_uuid_call(CodeGen *cg, AstNode *node, const char *func) {
-    if (strcmp(func, "generate_hyphenated") == 0) {
+    if (strcmp(func, "generate") == 0 || strcmp(func, "generate_hyphenated") == 0) {
         emit(cg, "ez_uuid_generate(ez_default_arena)"); return true;
     }
-    if (strcmp(func, "generate") == 0 || strcmp(func, "generate_compact") == 0) {
-        emit(cg, "ez_uuid_generate_compact(ez_default_arena)"); return true;
+    if (strcmp(func, "generate_compact") == 0) {
+        emit(cg, "ez_uuid_generate_compact(ez_default_arena, ");
+        emit_expression(cg, node->data.call.args[0]);
+        emit(cg, ")"); return true;
     }
     if (strcmp(func, "generate_random") == 0) {
         emit(cg, "ez_uuid_generate_random(ez_default_arena)"); return true;
@@ -4048,6 +4089,11 @@ static bool emit_uuid_call(CodeGen *cg, AstNode *node, const char *func) {
     }
     if (strcmp(func, "parse") == 0) {
         emit(cg, "ez_uuid_parse(ez_default_arena, ");
+        emit_expression(cg, node->data.call.args[0]);
+        emit(cg, ")"); return true;
+    }
+    if (strcmp(func, "to_string") == 0) {
+        emit(cg, "ez_uuid_to_string(");
         emit_expression(cg, node->data.call.args[0]);
         emit(cg, ")"); return true;
     }
@@ -5705,6 +5751,7 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
                 {"format","time"},{"to_iso","time"},{"date","time"},{"to_clock","time"},
                 /* @uuid */
                 {"generate_hyphenated","uuid"},{"generate","uuid"},{"is_valid","uuid"},
+                {"generate_compact","uuid"},{"to_string","uuid"},
                 {"generate_random","uuid"},{"generate_time_ordered","uuid"},{"parse","uuid"},
                 /* @bytes */
                 {"from_string","bytes"},{"from_hex","bytes"},{"from_base64","bytes"},

--- a/ezc/src/stdlib/ez_uuid.c
+++ b/ezc/src/stdlib/ez_uuid.c
@@ -45,36 +45,36 @@ static void ez_uuid_format_hyphenated(const uint8_t *bytes, char *buf) {
         bytes[12], bytes[13], bytes[14], bytes[15]);
 }
 
-EzString ez_uuid_generate(EzArena *arena) {
+EzUUID ez_uuid_generate(EzArena *arena) {
     uint8_t bytes[16];
+    EzUUID uuid;
     if (!ez_uuid_random_bytes(bytes, sizeof(bytes))) {
-        return ez_string_lit("");
+        uuid.value = ez_string_lit("");
+        return uuid;
     }
     bytes[6] = (bytes[6] & 0x0F) | 0x40; /* version 4 */
     bytes[8] = (bytes[8] & 0x3F) | 0x80; /* variant 1 (RFC 4122) */
     char buf[EZ_UUID_LEN + 1];
     ez_uuid_format_hyphenated(bytes, buf);
-    return ez_string_new(arena, buf, EZ_UUID_LEN);
+    uuid.value = ez_string_new(arena, buf, EZ_UUID_LEN);
+    return uuid;
 }
 
-EzString ez_uuid_generate_compact(EzArena *arena) {
-    uint8_t bytes[16];
-    if (!ez_uuid_random_bytes(bytes, sizeof(bytes))) {
-        return ez_string_lit("");
-    }
-    bytes[6] = (bytes[6] & 0x0F) | 0x40;
-    bytes[8] = (bytes[8] & 0x3F) | 0x80;
+EzString ez_uuid_generate_compact(EzArena *arena, EzUUID id) {
+    /* Strip hyphens from the canonical 36-char hyphenated form. */
+    if (id.value.len != EZ_UUID_LEN) return ez_string_lit("");
     char buf[EZ_UUID_COMPACT_LEN + 1];
-    snprintf(buf, sizeof(buf),
-        "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-        bytes[0], bytes[1], bytes[2], bytes[3],
-        bytes[4], bytes[5], bytes[6], bytes[7],
-        bytes[8], bytes[9], bytes[10], bytes[11],
-        bytes[12], bytes[13], bytes[14], bytes[15]);
+    int j = 0;
+    for (int i = 0; i < EZ_UUID_LEN; i++) {
+        if (id.value.data[i] != '-') {
+            buf[j++] = id.value.data[i];
+        }
+    }
+    buf[EZ_UUID_COMPACT_LEN] = '\0';
     return ez_string_new(arena, buf, EZ_UUID_COMPACT_LEN);
 }
 
-EzString ez_uuid_generate_random(EzArena *arena) {
+EzUUID ez_uuid_generate_random(EzArena *arena) {
     /* Alias for the canonical hyphenated v4 form. */
     return ez_uuid_generate(arena);
 }
@@ -86,10 +86,12 @@ EzString ez_uuid_generate_random(EzArena *arena) {
  *   bytes[8]      variant 10 (high 2 bits) + 6 random bits
  *   bytes[9..15]  56 random bits
  */
-EzString ez_uuid_generate_time_ordered(EzArena *arena) {
+EzUUID ez_uuid_generate_time_ordered(EzArena *arena) {
     uint8_t bytes[16];
+    EzUUID uuid;
     if (!ez_uuid_random_bytes(bytes, sizeof(bytes))) {
-        return ez_string_lit("");
+        uuid.value = ez_string_lit("");
+        return uuid;
     }
 
     struct timespec ts;
@@ -107,7 +109,8 @@ EzString ez_uuid_generate_time_ordered(EzArena *arena) {
 
     char buf[EZ_UUID_LEN + 1];
     ez_uuid_format_hyphenated(bytes, buf);
-    return ez_string_new(arena, buf, EZ_UUID_LEN);
+    uuid.value = ez_string_new(arena, buf, EZ_UUID_LEN);
+    return uuid;
 }
 
 bool ez_uuid_is_valid(EzString s) {
@@ -126,8 +129,8 @@ bool ez_uuid_is_valid(EzString s) {
 
 /* Strict parser: panics on invalid input. Callers that want a fallible
  * check should gate with ez_uuid_is_valid() first. Returns the input
- * normalized to lowercase. */
-EzString ez_uuid_parse(EzArena *arena, EzString s) {
+ * normalized to lowercase, wrapped in a UUID struct. */
+EzUUID ez_uuid_parse(EzArena *arena, EzString s) {
     if (!ez_uuid_is_valid(s)) {
         ez_builtin_panic_msg(ez_string_lit("uuid.parse: invalid UUID string"));
     }
@@ -137,8 +140,18 @@ EzString ez_uuid_parse(EzArena *arena, EzString s) {
         buf[i] = (c >= 'A' && c <= 'F') ? (char)(c - 'A' + 'a') : c;
     }
     buf[EZ_UUID_LEN] = '\0';
-    EzString out;
-    out.data = buf;
-    out.len = EZ_UUID_LEN;
-    return out;
+    EzUUID uuid;
+    uuid.value.data = buf;
+    uuid.value.len = EZ_UUID_LEN;
+    return uuid;
+}
+
+EzString ez_uuid_to_string(EzUUID id) {
+    return id.value;
+}
+
+EzUUID ez_uuid_nil(void) {
+    EzUUID uuid;
+    uuid.value = ez_string_lit("00000000-0000-0000-0000-000000000000");
+    return uuid;
 }

--- a/ezc/src/stdlib/ez_uuid.h
+++ b/ezc/src/stdlib/ez_uuid.h
@@ -10,11 +10,17 @@
 
 #include "../runtime/ez_runtime.h"
 
-EzString ez_uuid_generate(EzArena *arena);
-EzString ez_uuid_generate_compact(EzArena *arena);
-EzString ez_uuid_generate_random(EzArena *arena);
-EzString ez_uuid_generate_time_ordered(EzArena *arena);
+typedef struct {
+    EzString value;
+} EzUUID;
+
+EzUUID ez_uuid_generate(EzArena *arena);
+EzString ez_uuid_generate_compact(EzArena *arena, EzUUID id);
+EzUUID ez_uuid_generate_random(EzArena *arena);
+EzUUID ez_uuid_generate_time_ordered(EzArena *arena);
 bool ez_uuid_is_valid(EzString s);
-EzString ez_uuid_parse(EzArena *arena, EzString s);
+EzUUID ez_uuid_parse(EzArena *arena, EzString s);
+EzString ez_uuid_to_string(EzUUID id);
+EzUUID ez_uuid_nil(void);
 
 #endif

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -777,8 +777,8 @@ static const StdlibArgEntry stdlib_arg_table[] = {
     {"encoding", "url_encode", 1, 1}, {"encoding", "url_decode", 1, 1},
     /* uuid */
     {"uuid", "generate", 0, 0}, {"uuid", "generate_hyphenated", 0, 0},
-    {"uuid", "generate_compact", 0, 0},
-    {"uuid", "is_valid", 1, 1},
+    {"uuid", "generate_compact", 1, 1},
+    {"uuid", "is_valid", 1, 1}, {"uuid", "to_string", 1, 1},
     {"uuid", "generate_random", 0, 0}, {"uuid", "generate_time_ordered", 0, 0},
     {"uuid", "parse", 1, 1},
     /* regex */
@@ -1388,12 +1388,12 @@ static const UsingFunc _using_funcs[] = {
     {"from_float","strconv",TK_STRING},{"from_bool","strconv",TK_STRING},
     {"is_numeric","strconv",TK_BOOL},{"is_integer","strconv",TK_BOOL},
     /* uuid */
-    {"generate_hyphenated","uuid",TK_STRING},{"generate","uuid",TK_STRING},
+    {"generate_hyphenated","uuid",TK_UNKNOWN},{"generate","uuid",TK_UNKNOWN},
     {"generate_compact","uuid",TK_STRING},
-    {"generate_random","uuid",TK_STRING},
-    {"generate_time_ordered","uuid",TK_STRING},
-    {"parse","uuid",TK_STRING},
-    {"is_valid","uuid",TK_BOOL},
+    {"generate_random","uuid",TK_UNKNOWN},
+    {"generate_time_ordered","uuid",TK_UNKNOWN},
+    {"parse","uuid",TK_UNKNOWN},
+    {"is_valid","uuid",TK_BOOL},{"to_string","uuid",TK_STRING},
     /* bytes */
     {"from_string","bytes",TK_ARRAY},{"from_hex","bytes",TK_ARRAY},
     {"from_base64","bytes",TK_ARRAY},
@@ -1501,7 +1501,7 @@ static const UsingConst _using_consts[] = {
     {"O_RDONLY","io",TK_INT},{"O_WRONLY","io",TK_INT},{"O_RDWR","io",TK_INT},
     {"BASE_2","strconv",TK_INT},{"BASE_8","strconv",TK_INT},{"BASE_10","strconv",TK_INT},
     {"BASE_16","strconv",TK_INT},{"BASE_36","strconv",TK_INT},
-    {"NIL_UUID","uuid",TK_STRING},
+    {"NIL_UUID","uuid",TK_STRUCT},
     {NULL,NULL,TK_UNKNOWN}
 };
 
@@ -3151,13 +3151,15 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                 }
             } else if (strcmp(mod, "uuid") == 0) {
                 if (strcmp(mfn, "is_valid") == 0) result = &TYPE_BOOL;
-                else if (strcmp(mfn, "generate") == 0 ||
+                else if (strcmp(mfn, "generate_compact") == 0 ||
+                         strcmp(mfn, "to_string") == 0) {
+                    result = &TYPE_STRING;
+                } else if (strcmp(mfn, "generate") == 0 ||
                          strcmp(mfn, "generate_hyphenated") == 0 ||
-                         strcmp(mfn, "generate_compact") == 0 ||
                          strcmp(mfn, "generate_random") == 0 ||
                          strcmp(mfn, "generate_time_ordered") == 0 ||
                          strcmp(mfn, "parse") == 0) {
-                    result = &TYPE_STRING;
+                    result = type_struct("UUID");
                 } else {
                     emit_unknown_stdlib_fn(tc, mod, mfn, node);
                     result = &TYPE_UNKNOWN;
@@ -5827,7 +5829,7 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
             if (strcmp(obj_name, "uuid") == 0) {
                 const char *mem = node->data.member.member;
                 if (strcmp(mem, "NIL_UUID") == 0) {
-                    result = &TYPE_STRING;
+                    result = type_struct("UUID");
                     break;
                 }
             }
@@ -9289,7 +9291,8 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
          * invalid C with no EZ diagnostic. */
         static const char *reserved_stdlib_struct_names[] = {
             "Thread", "Mutex", "SpinLock", "Channel", "Socket",
-            "Listener", "Database", "Router", "HttpRequest", "HttpResponse", NULL
+            "Listener", "Database", "Router", "HttpRequest", "HttpResponse",
+            "UUID", NULL
         };
         const char *sname = STRUCT_DISPLAY_NAME(node);
         for (int ri = 0; reserved_stdlib_struct_names[ri]; ri++) {
@@ -10279,6 +10282,13 @@ void typechecker_check(TypeChecker *tc, AstNode *program) {
         req_types[4] = type_from_name("map[string:string]");
         req_types[5] = type_from_name("map[string:string]");
         register_struct(tc, "HttpRequest", "HttpRequest", req_fields, req_types, 6);
+    }
+
+    if (tc_is_imported_module(tc, "uuid")) {
+        static const char *uuid_fields[] = {"value"};
+        static EzType *uuid_types[1];
+        uuid_types[0] = &TYPE_STRING;
+        register_struct(tc, "UUID", "UUID", uuid_fields, uuid_types, 1);
     }
 
     /* Collect 'using' and 'import and use' module names */

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -9768,6 +9768,17 @@ static void validate_field_type_recursive(TypeChecker *tc, AstNode *program,
     if (is_struct_name(tc, type_name)) return;
     if (struct_name_declared(program, type_name)) return;
 
+    /* Stdlib opaque struct types are registered after user structs; accept
+     * them here so struct fields can reference them without false E4016. */
+    static const char *stdlib_struct_types[] = {
+        "Thread", "Mutex", "SpinLock", "Channel", "Socket", "Listener",
+        "Database", "Router", "HttpRequest", "HttpResponse", "UUID",
+        "Arena", "SourceLocation", NULL
+    };
+    for (int si = 0; stdlib_struct_types[si]; si++) {
+        if (strcmp(type_name, stdlib_struct_types[si]) == 0) return;
+    }
+
     char msg[EZ_MSG_BUF_SIZE];
     snprintf(msg, sizeof(msg),
         "field '%s' references undefined type '%s'",

--- a/integration-tests/pass/stdlib/uuid_c.ez
+++ b/integration-tests/pass/stdlib/uuid_c.ez
@@ -1,5 +1,5 @@
 /*
- * uuid_c.ez - Integration test for @uuid (compiler)
+ * uuid_c.ez - Integration test for uuid module (compiler)
  */
 
 import @uuid
@@ -9,18 +9,19 @@ do main() {
     mut passed int = 0
     mut failed int = 0
 
-    // generate_hyphenated returns 36-char string (8-4-4-4-12 with dashes)
-    mut id1 string = uuid.generate_hyphenated()
-    if len(id1) == 36 {
-        println("  [PASS] generate length")
+    // generate returns UUID struct
+    mut id1 UUID = uuid.generate()
+    mut s1 string = uuid.to_string(id1)
+    if len(s1) == 36 {
+        println("  [PASS] generate returns 36-char UUID")
         passed += 1
     } otherwise {
-        println("  [FAIL] generate length: expected 36, got ${len(id1)}")
+        println("  [FAIL] generate returns 36-char UUID: expected 36, got ${len(s1)}")
         failed += 1
     }
 
-    // generated UUID is valid
-    if uuid.is_valid(id1) == true {
+    // generated UUID string is valid
+    if uuid.is_valid(s1) == true {
         println("  [PASS] generate produces valid UUID")
         passed += 1
     } otherwise {
@@ -29,8 +30,9 @@ do main() {
     }
 
     // two UUIDs are different
-    mut id2 string = uuid.generate_hyphenated()
-    if id1 != id2 {
+    mut id2 UUID = uuid.generate()
+    mut s2 string = uuid.to_string(id2)
+    if s1 != s2 {
         println("  [PASS] generate unique")
         passed += 1
     } otherwise {
@@ -38,8 +40,8 @@ do main() {
         failed += 1
     }
 
-    // compact UUID is 32 chars (no dashes)
-    mut compact string = uuid.generate()
+    // generate_compact strips hyphens to 32 chars
+    mut compact string = uuid.generate_compact(id1)
     if len(compact) == 32 {
         println("  [PASS] generate_compact length")
         passed += 1
@@ -66,9 +68,10 @@ do main() {
         failed += 1
     }
 
-    // generate_random is a 36-char valid v4 UUID
-    mut v4 string = uuid.generate_random()
-    if len(v4) == 36 && uuid.is_valid(v4) {
+    // generate_random returns a valid v4 UUID
+    mut v4 UUID = uuid.generate_random()
+    mut v4s string = uuid.to_string(v4)
+    if len(v4s) == 36 && uuid.is_valid(v4s) {
         println("  [PASS] generate_random returns valid 36-char UUID")
         passed += 1
     } otherwise {
@@ -76,64 +79,79 @@ do main() {
         failed += 1
     }
     // v4 version nibble lives at character index 14
-    if to_char(v4, 14) == '4' {
+    if to_char(v4s, 14) == '4' {
         println("  [PASS] generate_random has version 4")
         passed += 1
     } otherwise {
-        println("  [FAIL] generate_random has version 4: got '${to_char(v4, 14)}'")
+        println("  [FAIL] generate_random has version 4: got '${to_char(v4s, 14)}'")
         failed += 1
     }
 
-    // generate_time_ordered is a 36-char valid v7 UUID
-    mut v7 string = uuid.generate_time_ordered()
-    if len(v7) == 36 && uuid.is_valid(v7) {
+    // generate_time_ordered returns a valid v7 UUID
+    mut v7 UUID = uuid.generate_time_ordered()
+    mut v7s string = uuid.to_string(v7)
+    if len(v7s) == 36 && uuid.is_valid(v7s) {
         println("  [PASS] generate_time_ordered returns valid 36-char UUID")
         passed += 1
     } otherwise {
         println("  [FAIL] generate_time_ordered returns valid 36-char UUID")
         failed += 1
     }
-    if to_char(v7, 14) == '7' {
+    if to_char(v7s, 14) == '7' {
         println("  [PASS] generate_time_ordered has version 7")
         passed += 1
     } otherwise {
-        println("  [FAIL] generate_time_ordered has version 7: got '${to_char(v7, 14)}'")
+        println("  [FAIL] generate_time_ordered has version 7: got '${to_char(v7s, 14)}'")
         failed += 1
     }
 
     // parse normalizes uppercase hex to lowercase
-    mut parsed_upper string = uuid.parse("550E8400-E29B-41D4-A716-446655440000")
-    if parsed_upper == "550e8400-e29b-41d4-a716-446655440000" {
+    mut parsed_upper UUID = uuid.parse("550E8400-E29B-41D4-A716-446655440000")
+    mut parsed_str string = uuid.to_string(parsed_upper)
+    if parsed_str == "550e8400-e29b-41d4-a716-446655440000" {
         println("  [PASS] parse normalizes uppercase to lowercase")
         passed += 1
     } otherwise {
-        println("  [FAIL] parse normalizes uppercase to lowercase: got '${parsed_upper}'")
+        println("  [FAIL] parse normalizes uppercase to lowercase: got '${parsed_str}'")
         failed += 1
     }
 
     // parse preserves already-canonical input
-    mut parsed_lower string = uuid.parse("550e8400-e29b-41d4-a716-446655440000")
-    if parsed_lower == "550e8400-e29b-41d4-a716-446655440000" {
+    mut parsed_lower UUID = uuid.parse("550e8400-e29b-41d4-a716-446655440000")
+    mut parsed_lower_str string = uuid.to_string(parsed_lower)
+    if parsed_lower_str == "550e8400-e29b-41d4-a716-446655440000" {
         println("  [PASS] parse preserves canonical input")
         passed += 1
     } otherwise {
-        println("  [FAIL] parse preserves canonical input: got '${parsed_lower}'")
+        println("  [FAIL] parse preserves canonical input: got '${parsed_lower_str}'")
         failed += 1
     }
 
     // NIL_UUID is the all-zero UUID
-    if uuid.NIL_UUID == "00000000-0000-0000-0000-000000000000" {
+    mut nil_str string = uuid.to_string(uuid.NIL_UUID)
+    if nil_str == "00000000-0000-0000-0000-000000000000" {
         println("  [PASS] NIL_UUID is all zeros")
         passed += 1
     } otherwise {
-        println("  [FAIL] NIL_UUID is all zeros: got '${uuid.NIL_UUID}'")
+        println("  [FAIL] NIL_UUID is all zeros: got '${nil_str}'")
         failed += 1
     }
-    if uuid.is_valid(uuid.NIL_UUID) {
+    if uuid.is_valid(nil_str) {
         println("  [PASS] NIL_UUID is a valid UUID string")
         passed += 1
     } otherwise {
         println("  [FAIL] NIL_UUID is a valid UUID string")
+        failed += 1
+    }
+
+    // to_string round-trip
+    mut rt UUID = uuid.generate()
+    mut rt_str string = uuid.to_string(rt)
+    if len(rt_str) == 36 {
+        println("  [PASS] to_string returns 36-char string")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] to_string returns 36-char string")
         failed += 1
     }
 

--- a/integration-tests/pass/stress/stdlib/stress_uuid.ez
+++ b/integration-tests/pass/stress/stdlib/stress_uuid.ez
@@ -1,38 +1,39 @@
-/* Stress test: @uuid — format validation
+/* Stress test: uuid module — format validation
  * Expected: all tests pass
  */
 
 import @uuid
 
 do main() {
-    println("=== Stress: @uuid ===")
+    println("=== Stress: uuid ===")
     mut passed int = 0
     mut failed int = 0
 
-    // generate() — 32 hex chars (no hyphens)
-    mut id string = uuid.generate()
-    if len(id) == 32 {
-        println("  [PASS] generate() returns 32 chars")
+    // generate() returns UUID with 36-char hyphenated string
+    mut id UUID = uuid.generate()
+    mut id_str string = uuid.to_string(id)
+    if len(id_str) == 36 {
+        println("  [PASS] generate() returns 36-char UUID")
         passed += 1
-    } otherwise { println("  [FAIL] generate() — len ${len(id)}") failed += 1 }
+    } otherwise { println("  [FAIL] generate() — len ${len(id_str)}") failed += 1 }
 
-    // generate_hyphenated() — 36 chars with hyphens
-    mut hid string = uuid.generate_hyphenated()
-    if len(hid) == 36 {
-        println("  [PASS] generate_hyphenated() returns 36 chars")
+    // generate_compact() strips hyphens to 32 chars
+    mut compact string = uuid.generate_compact(id)
+    if len(compact) == 32 {
+        println("  [PASS] generate_compact() returns 32 chars")
         passed += 1
-    } otherwise { println("  [FAIL] generate_hyphenated() — len ${len(hid)}") failed += 1 }
+    } otherwise { println("  [FAIL] generate_compact() — len ${len(compact)}") failed += 1 }
 
     // is_valid
-    if uuid.is_valid(hid) && !uuid.is_valid("not-a-uuid") {
+    if uuid.is_valid(id_str) && !uuid.is_valid("not-a-uuid") {
         println("  [PASS] is_valid on valid and invalid")
         passed += 1
     } otherwise { println("  [FAIL] is_valid") failed += 1 }
 
     // Two UUIDs should be different
-    mut id1 string = uuid.generate()
-    mut id2 string = uuid.generate()
-    if id1 != id2 {
+    mut id1 UUID = uuid.generate()
+    mut id2 UUID = uuid.generate()
+    if uuid.to_string(id1) != uuid.to_string(id2) {
         println("  [PASS] two UUIDs are different")
         passed += 1
     } otherwise { println("  [FAIL] UUIDs identical") failed += 1 }


### PR DESCRIPTION
## Summary

- **UUID is now a proper struct type** wrapping a canonical 36-char hyphenated string, consistent with other stdlib opaque types (Database, HttpResponse, etc.)
- Generator functions (`generate`, `generate_hyphenated`, `generate_random`, `generate_time_ordered`) and `parse` now return `UUID` instead of `string`
- `generate_compact(UUID) -> string` takes a UUID and strips hyphens (was previously a no-arg generator)
- Added `to_string(UUID) -> string` for extracting the string representation
- `NIL_UUID` is now `UUID` type (was `string`)
- `is_valid(string) -> bool` unchanged
- Fixed a bug where stdlib opaque struct types (UUID, Database, HttpResponse, etc.) were rejected as struct field types with false E4016 errors during the registration pass

Closes #1870