### PR TITLE
feat(stdlib): add `os.exec()` for subprocess execution with stderr capture

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -2790,6 +2790,22 @@ io.read_file("/etc/hosts")            // absolute path, unaffected by cwd
 | `current_os` | `() -> int` | Get current OS as an int matching the constants below (`MAC_OS`, `LINUX`, `WINDOWS`, `OTHER`) |
 | `arch` | `() -> string` | Get CPU architecture |
 
+#### Process Execution
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `exec` | `(cmd string, args [string]) -> (int, string, bool)` | Run a subprocess. Returns `(exit_code, stderr, ok)`. `ok` is `false` if the process could not be launched. stdout is inherited and passes through to the terminal; only stderr is captured. POSIX only. |
+
+```ez
+mut code, stderr, ok = os.exec("ls", {"-l", "/tmp"})
+if !ok {
+    println("failed to launch")
+}
+if ok && code != 0 {
+    println("exited with error: ${stderr}")
+}
+```
+
 #### Constants
 
 - `MAC_OS` = 0

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -5160,6 +5160,14 @@ static bool emit_os_call(CodeGen *cg, AstNode *node, const char *func) {
         emit(cg, ")");
         return true;
     }
+    if (strcmp(func, "exec") == 0) {
+        emit(cg, "ez_os_exec(ez_default_arena, ");
+        emit_expression(cg, node->data.call.args[0]);
+        emit(cg, ", ");
+        emit_expression(cg, node->data.call.args[1]);
+        emit(cg, ")");
+        return true;
+    }
     return false;
 }
 

--- a/ezc/src/stdlib/ez_os.c
+++ b/ezc/src/stdlib/ez_os.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
+#include <sys/wait.h>
+#include <errno.h>
 
 #define EZ_HOSTNAME_BUF 256
 
@@ -88,5 +90,78 @@ EzString ez_os_arch(void) {
 
 int64_t ez_os_pid(void) {
     return (int64_t)getpid();
+}
+
+EzOsExecResult ez_os_exec(EzArena *arena, EzString cmd, EzArray args) {
+    EzOsExecResult fail = {0, ez_string_lit(""), false};
+
+    /* Build null-terminated argv: argv[0] = cmd, argv[1..n] = args, argv[n+1] = NULL */
+    int argc = 1 + args.len;
+    char **argv = ez_arena_alloc(arena, sizeof(char *) * (size_t)(argc + 1));
+    argv[0] = (char *)cmd.data;
+    for (int i = 0; i < args.len; i++) {
+        EzString s = EZ_ARRAY_GET(args, EzString, i);
+        argv[1 + i] = (char *)s.data;
+    }
+    argv[argc] = NULL;
+
+    int stderr_pipe[2];
+    if (pipe(stderr_pipe) < 0) return fail;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(stderr_pipe[0]);
+        close(stderr_pipe[1]);
+        return fail;
+    }
+
+    if (pid == 0) {
+        /* Child: redirect stderr into pipe, stdout stays connected to terminal */
+        close(stderr_pipe[0]);
+        dup2(stderr_pipe[1], STDERR_FILENO);
+        close(stderr_pipe[1]);
+        execvp(cmd.data, argv);
+        /* execvp failed */
+        _exit(127);
+    }
+
+    /* Parent: read stderr from pipe */
+    close(stderr_pipe[1]);
+
+    char buf[4096];
+    size_t total = 0;
+    size_t cap = sizeof(buf);
+    char *collected = ez_arena_alloc(arena, cap);
+
+    ssize_t n;
+    while ((n = read(stderr_pipe[0], buf, sizeof(buf))) > 0) {
+        if (total + (size_t)n > cap) {
+            size_t new_cap = cap * 2 + (size_t)n;
+            char *grown = ez_arena_alloc(arena, new_cap);
+            memcpy(grown, collected, total);
+            collected = grown;
+            cap = new_cap;
+        }
+        memcpy(collected + total, buf, (size_t)n);
+        total += (size_t)n;
+    }
+    close(stderr_pipe[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    int exit_code = 0;
+    if (WIFEXITED(status)) {
+        exit_code = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        exit_code = 128 + WTERMSIG(status);
+    }
+
+    /* exit_code 127 means execvp failed (command not found / bad path) */
+    if (exit_code == 127) return fail;
+
+    EzString stderr_str = ez_string_new(arena, collected, (int32_t)total);
+    EzOsExecResult r = {(int64_t)exit_code, stderr_str, true};
+    return r;
 }
 

--- a/ezc/src/stdlib/ez_os.h
+++ b/ezc/src/stdlib/ez_os.h
@@ -124,6 +124,23 @@ int64_t ez_os_pid(void);
 /* Store argc/argv from main for os.args() */
 void ez_os_init(int argc, char **argv);
 
+/*@man exec
+ *@module os
+ *@group System
+ *@sig exec(cmd string, args [string]) -> (int, string, bool)
+ *@desc Executes the command cmd with the given args. Returns (exit_code, stderr, ok). ok is false if the process could not be launched. stdout is inherited and passes through to the terminal; only stderr is captured.
+ *@example
+ *   import @os
+ *   mut code, stderr, ok = os.exec("ls", {"-l"})
+ *   if ok && code == 0 {
+ *       println("success")
+ *   }
+ *@end
+ */
+/* os.exec(cmd, args) — run a process, capture stderr, return (exit_code, stderr, ok) */
+typedef struct { int64_t v0; EzString v1; bool v2; } EzOsExecResult;
+EzOsExecResult ez_os_exec(EzArena *arena, EzString cmd, EzArray args);
+
 /*@man MAC_OS
  *@module os
  *@group Constants

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -911,6 +911,7 @@ static const StdlibArgEntry stdlib_arg_table[] = {
     {"os", "args", 0, 0}, {"os", "current_dir", 0, 0},
     {"os", "hostname", 0, 0}, {"os", "pid", 0, 0},
     {"os", "current_os", 0, 0}, {"os", "arch", 0, 0},
+    {"os", "exec", 2, 2},
     /* random (variable args) */
     {"random", "rand_float", 0, 2}, {"random", "rand_int", 1, 2},
     {"random", "rand_bool", 0, 0}, {"random", "rand_byte", 0, 0},
@@ -1517,6 +1518,7 @@ static const UsingFunc _using_funcs[] = {
     {"set_env","os",TK_VOID},{"current_dir","os",TK_STRING},
     {"hostname","os",TK_STRING},{"arch","os",TK_STRING},
     {"current_os","os",TK_INT},{"pid","os",TK_INT},
+    {"exec","os",TK_BOOL},
     /* time */
     {"now","time",TK_INT},{"now_ms","time",TK_INT},{"now_ns","time",TK_INT},
     {"tick","time",TK_INT},{"elapsed_ms","time",TK_INT},
@@ -3737,6 +3739,8 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                     result = &TYPE_INT;
                 } else if (strcmp(mfn, "set_env") == 0) {
                     result = &TYPE_VOID;
+                } else if (strcmp(mfn, "exec") == 0) {
+                    result = &TYPE_BOOL;
                 } else {
                     emit_unknown_stdlib_fn(tc, mod, mfn, node);
                     result = &TYPE_UNKNOWN;

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -8131,6 +8131,19 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                             sym->ret_count = 2;
                         }
                     }
+                    /* os.exec returns (int, string, bool) — synthesize 3-type slots */
+                    if (strcmp(mod, "os") == 0 && strcmp(mfn, "exec") == 0) {
+                        Symbol *sym = scope_lookup_local(tc->current_scope,
+                            node->data.var_decl.name);
+                        if (sym) {
+                            EzType **rt = xmalloc(sizeof(EzType *) * 3);
+                            rt[0] = &TYPE_INT;
+                            rt[1] = &TYPE_STRING;
+                            rt[2] = &TYPE_BOOL;
+                            sym->ret_types = rt;
+                            sym->ret_count = 3;
+                        }
+                    }
                 }
                 /* User-defined module calls (mod.func); look up the prefixed
                  * function signature and propagate multi-return types so

--- a/integration-tests/pass/stdlib/os_c.ez
+++ b/integration-tests/pass/stdlib/os_c.ez
@@ -79,6 +79,46 @@ do main() {
         failed += 1
     }
 
+    // exec: success — 'true' exits 0 with no stderr
+    mut code, stderr, ok = os.exec("true", {})
+    if ok && code == 0 && len(stderr) == 0 {
+        println("  [PASS] exec success (code=0, ok=true, no stderr)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec success: code=${code} ok=${ok} stderr=${stderr}")
+        failed += 1
+    }
+
+    // exec: non-zero exit — 'false' exits 1, ok still true
+    mut code2, _, ok2 = os.exec("false", {})
+    if ok2 && code2 != 0 {
+        println("  [PASS] exec non-zero exit (code=${code2}, ok=true)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec non-zero exit: code=${code2} ok=${ok2}")
+        failed += 1
+    }
+
+    // exec: stderr capture — ls on a nonexistent path writes to stderr
+    mut code3, stderr3, ok3 = os.exec("ls", {"/nonexistent_ez_test_path_xyz"})
+    if ok3 && code3 != 0 && len(stderr3) > 0 {
+        println("  [PASS] exec stderr capture (captured ${len(stderr3)} bytes)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec stderr capture: code=${code3} ok=${ok3} stderr_len=${len(stderr3)}")
+        failed += 1
+    }
+
+    // exec: launch failure — command not found returns ok=false
+    mut code4, _, ok4 = os.exec("this_cmd_does_not_exist_ez", {})
+    if !ok4 {
+        println("  [PASS] exec launch failure (ok=false)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec launch failure: expected ok=false, got code=${code4}")
+        failed += 1
+    }
+
     println("")
     println("Results: ${passed} passed, ${failed} failed")
     if failed > 0 {


### PR DESCRIPTION
## Summary

- Implements `os.exec(cmd string, args [string]) -> (int, string, bool)` in the os module
- Returns `(exit_code, stderr, ok)` — `ok` is `false` if the process failed to launch, stdout is inherited, only stderr is captured
- Uses `pipe()` + `fork()` + `execvp()` (POSIX only — Linux and macOS)
- Fixes typechecker to synthesize 3-slot return types for `os.exec` so multi-var destructuring works correctly
- Adds 4 integration test cases to `os_c.ez`: success, non-zero exit, stderr capture, launch failure
- Documents `os.exec` in `STANDARD.md`

Closes #1447