### PR TITLE
hotfix: suppress ld warnings from cc link command

### DIFF
--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -1652,7 +1652,7 @@ int main(int argc, char **argv) {
             "cc -std=c11 %s -Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable "
             "-I'%s'/runtime -I'%s'/stdlib "
             "-o '%s' '%s' '%s' "
-            "-lm -lpthread 2>&1",
+            "-lm -lpthread -Wl,-w 2>&1",
             extra_flags,
             runtime_dir, runtime_dir,
             output_file, c_file, lib_path);
@@ -1690,7 +1690,7 @@ int main(int argc, char **argv) {
             "cc -std=c11 %s -Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable "
             "-I'%s'/runtime -I'%s'/stdlib "
             "-o '%s' '%s' %s"
-            "-lm -lpthread 2>&1",
+            "-lm -lpthread -Wl,-w 2>&1",
             extra_flags,
             runtime_dir, runtime_dir,
             output_file, c_file, srcs);


### PR DESCRIPTION
## Summary

- `ld` linker warnings (e.g. macOS version mismatch) were leaking to the terminal whenever an EZ program was compiled
- Added `-Wl,-w` to both `cc` invocation paths in `ezc/src/main.c` to suppress linker warnings at the linker level
- Only linker warnings are silenced — real C compiler errors still surface normally
- Affects both the prebuilt archive path (`has_archive`) and the compile-from-source fallback path