### PR TITLE
chore: add missing ez_strconv.c to stdlib_srcs[] fallback array in main.c (#2076)

### DIFF
--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -1706,7 +1706,7 @@ int main(int argc, char **argv) {
             "stdlib/ez_regex.c",    "stdlib/ez_server.c",   "stdlib/ez_sqlite.c",
             "stdlib/ez_strings.c",  "stdlib/ez_sync.c",     "stdlib/ez_atomic.c",
             "stdlib/ez_threads.c",
-            "stdlib/ez_time.c",     "stdlib/ez_uuid.c",
+            "stdlib/ez_time.c",     "stdlib/ez_uuid.c", "stdlib/ez_strconv.c"
         };
         char srcs[CMD_BUF_SIZE];
         int off = 0;


### PR DESCRIPTION
## Related issue

Closes #2076 

## What changed

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/Build

## Checklist

- [x] `make build` compiles with zero warnings
- [x] Commit message follows conventional format: `type(scope): description (#issue)`
- [x] No `@` before module names in any text (tags GitHub users)
