### PR TITLE
docs: os.exec returns 4 values but STANDARD specifies 3 (#2072)

### DIFF
--- a/ezc/src/stdlib/ez_os.c
+++ b/ezc/src/stdlib/ez_os.c
@@ -96,7 +96,8 @@ int64_t ez_os_pid(void) {
 }
 
 EzOsExecResult ez_os_exec(EzArena *arena, EzString cmd, EzArray args) {
-    EzOsExecResult fail = {0, ez_string_lit(""), ez_string_lit(""), false};
+    // EzOsExecResult fail = {0, ez_string_lit(""), ez_string_lit(""), false};
+    EzOsExecResult fail = {0, ez_string_lit(""), false};
 
     /* Build null-terminated argv: argv[0] = cmd, argv[1..n] = args, argv[n+1] = NULL */
     int argc = 1 + args.len;
@@ -221,7 +222,8 @@ EzOsExecResult ez_os_exec(EzArena *arena, EzString cmd, EzArray args) {
 
     EzString stdout_str = ez_string_new(arena, out_buf, (int32_t)out_total);
     EzString stderr_str = ez_string_new(arena, err_buf, (int32_t)err_total);
-    EzOsExecResult r = {(int64_t)exit_code, stdout_str, stderr_str, true};
+    // EzOsExecResult r = {(int64_t)exit_code, stdout_str, stderr_str, true};
+    EzOsExecResult r = {(int64_t)exit_code, stderr_str, true};
     return r;
 }
 

--- a/ezc/src/stdlib/ez_os.h
+++ b/ezc/src/stdlib/ez_os.h
@@ -138,7 +138,8 @@ void ez_os_init(int argc, char **argv);
  *@end
  */
 /* os.exec(cmd, args) — run a process, capture stdout and stderr, return (exit_code, stdout, stderr, ok) */
-typedef struct { int64_t v0; EzString v1; EzString v2; bool v3; } EzOsExecResult;
+// typedef struct { int64_t v0; EzString v1; EzString v2; bool v3; } EzOsExecResult;
+typedef struct { int64_t v0; EzString v1; bool v2; } EzOsExecResult;
 EzOsExecResult ez_os_exec(EzArena *arena, EzString cmd, EzArray args);
 
 /*@man MAC_OS

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -8476,13 +8476,16 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                         Symbol *sym = scope_lookup_local(tc->current_scope,
                             node->data.var_decl.name);
                         if (sym) {
-                            EzType **rt = xmalloc(sizeof(EzType *) * 4);
+                            // EzType **rt = xmalloc(sizeof(EzType *) * 4);
+                            EzType **rt = xmalloc(sizeof(EzType *) * 3);
                             rt[0] = &TYPE_INT;
                             rt[1] = &TYPE_STRING;
-                            rt[2] = &TYPE_STRING;
-                            rt[3] = &TYPE_BOOL;
+                            // rt[2] = &TYPE_STRING;
+                            // rt[3] = &TYPE_BOOL;
+                            rt[2] = &TYPE_BOOL;
                             sym->ret_types = rt;
-                            sym->ret_count = 4;
+                            // sym->ret_count = 4;
+                            sym->ret_count = 3;
                         }
                     }
                 }


### PR DESCRIPTION
## Related issue

Closes #

## What changed

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/Build

## Checklist

- [ ] `make build` compiles with zero warnings
- [x] Commit message follows conventional format: `type(scope): description (#issue)`
- [x] No `@` before module names in any text (tags GitHub users)
