### PR TITLE
bugfixes July 23, 2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,7 +1,7 @@
 # Grayscale Error Code Reference
 
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
-> Run `./scripts/generate_errors.sh` to regenerate.
+> Run `./scripts/generate_errors.gray` to regenerate.
 
 **Total: 368 codes** (250 errors, 17 warnings, 101 panics)
 
@@ -419,4 +419,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-07-23 07:52:53 UTC*
+*Generated on 2026-07-23 08:18:17 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,9 +1,9 @@
 # Grayscale Error Code Reference
 
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
-> Run `./scripts/generate_errors.gray` to regenerate.
+> Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 367 codes** (249 errors, 17 warnings, 101 panics)
+**Total: 368 codes** (250 errors, 17 warnings, 101 panics)
 
 ---
 
@@ -196,6 +196,7 @@
 | `E3127` | types | type parameter expects a struct type name, but '%s' is not a struct; only struct types can be passed as type arguments |
 | `E3128` | types | type parameter expects a struct type name, but got a non-type expression; pass a struct type name like 'MyStruct' |
 | `E3129` | safety | empty loop body; this will loop forever at runtime |
+| `E3130` | types | bare 'func' is not allowed as a struct field type |
 | `E4001` | names | this variable does not exist; check the spelling or make sure it is declared above this line |
 | `E4002` | names | this function does not exist; check the spelling or make sure it is defined |
 | `E4003` | names | variable '%s' already declared in this scope (line %d) |
@@ -418,4 +419,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-07-21 08:12:40 UTC*
+*Generated on 2026-07-23 06:37:38 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -419,4 +419,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-07-23 06:37:38 UTC*
+*Generated on 2026-07-23 07:52:53 UTC*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1834,7 +1834,7 @@ Inside the function body, call through the parameter the same way: `f(x)`.
 
 #### 7.6.3 Func References in Composite Types
 
-Bare `func` is a valid type in arrays, maps, and struct fields. Elements are untyped function pointers; the cast is reconstructed from context at each call site:
+Bare `func` is a valid type in arrays and maps. Elements are untyped function pointers; the cast is reconstructed from context at each call site:
 
 ```gray
 import @arrays
@@ -1864,7 +1864,7 @@ Typed func signatures as an array element type (e.g. `[func(int)->int]`) are not
 
 #### 7.6.4 Func Fields in Structs
 
-Struct fields can hold func references. Use a typed `func` signature for the field type to get compile-time argument checking:
+Struct fields can hold func references. A typed `func` signature is required for struct field types — bare `func` is not allowed. This ensures compile-time argument checking:
 
 ```gray
 const Wrapper struct {

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -718,7 +718,7 @@ The number of bindings in a pattern must match the variant's payload count. `#st
 
 ### 3.3 Type Inference
 
-Grayscale is a statically-typed language with full type inference. The type of every variable is known at compile time, but explicit type annotations are optional when the compiler can determine the type from the initializer.
+Grayscale is a statically-typed language with type inference. The type of every variable is known at compile time, and explicit type annotations are optional in most contexts when the compiler can determine the type from the initializer.
 
 Type inference works with:
 
@@ -729,6 +729,8 @@ Type inference works with:
 5. **Multiple return values** - Each variable's type is inferred from the corresponding return type
 
 > 💡 **Tip:** Array and map literals do **not** support type inference. You must always provide an explicit type annotation (e.g., `mut arr [int] = {1, 2, 3}`, `mut m map[string:int] = {"a": 1}`).
+
+> ⚠️ **File-scope `const` declarations** of primitive types and arrays require explicit type annotations. Type inference for `const` is only supported inside function bodies. For example, `const MAX_SIZE int = 100` is required at file scope, while `const x = 42` is valid inside a function.
 
 ```gray
 // Inferred from literals
@@ -764,9 +766,9 @@ do divide(a, b int) -> (int, int) {
 mut quotient, remainder = divide(10, 3)  // Both inferred: int
 ```
 
-Explicit type annotations are never required but can be used for clarity or documentation.
+Explicit type annotations are generally optional but can be used for clarity or documentation. The exceptions are file-scope `const` declarations of primitive types and arrays, which always require explicit type annotations.
 
-> 💡 **Tip:** You don't need to write the type if the compiler can figure it out, but adding it never hurts for readability.
+> 💡 **Tip:** You don't need to write the type if the compiler can figure it out, but adding it never hurts for readability. At file scope, `const` declarations of primitives and arrays always need the type.
 
 ### 3.4 Type Conversions
 
@@ -830,6 +832,8 @@ const PI float = 3.14159
 const MAX_SIZE int = 100
 const origin = Point{x: 0, y: 0}
 ```
+
+> ⚠️ At file scope, `const` declarations of primitive types (`int`, `float`, `string`, `bool`, `char`, `byte`) and arrays require explicit type annotations. Struct literals and enum values can still be inferred. Inside function bodies, type inference works for all `const` declarations.
 
 ### 4.3 Mutability
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.
 - `integration-tests/pass/multi-file/` — 118 multi-file import tests covering imports, aliases, structs, enums, private visibility, transitive imports, directory imports, and more.
 - `integration-tests/pass/stress/` — 43 stress tests (30 core, 13 stdlib).
-- `integration-tests/fail/errors/` — 774 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
+- `integration-tests/fail/errors/` — 777 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
 - `integration-tests/fail/multi-file/` — 40 multi-file error detection tests covering cross-module type errors, private access violations, and circular imports.
 
 **Running:**

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.
 - `integration-tests/pass/multi-file/` — 118 multi-file import tests covering imports, aliases, structs, enums, private visibility, transitive imports, directory imports, and more.
 - `integration-tests/pass/stress/` — 43 stress tests (30 core, 13 stdlib).
-- `integration-tests/fail/errors/` — 780 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
+- `integration-tests/fail/errors/` — 781 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
 - `integration-tests/fail/multi-file/` — 40 multi-file error detection tests covering cross-module type errors, private access violations, and circular imports.
 
 **Running:**

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.
 - `integration-tests/pass/multi-file/` — 118 multi-file import tests covering imports, aliases, structs, enums, private visibility, transitive imports, directory imports, and more.
 - `integration-tests/pass/stress/` — 43 stress tests (30 core, 13 stdlib).
-- `integration-tests/fail/errors/` — 777 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
+- `integration-tests/fail/errors/` — 779 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
 - `integration-tests/fail/multi-file/` — 40 multi-file error detection tests covering cross-module type errors, private access violations, and circular imports.
 
 **Running:**

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,7 +48,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 
 **Structure:**
 
-- `integration-tests/pass/core/` — 255 core language feature tests covering arrays, control flow, structs, enums, maps, pointers, named returns, type inference, builtins, C interop, bigint types, wildcards, and more.
+- `integration-tests/pass/core/` — 256 core language feature tests covering arrays, control flow, structs, enums, maps, pointers, named returns, type inference, builtins, C interop, bigint types, wildcards, and more.
 - `integration-tests/pass/stdlib/` — 68 stdlib module tests covering all 28 stdlib modules.
 - `integration-tests/pass/new/` — 8 project template tests (basic, cli, lib, multi, server_minimal, server_normal, client_minimal, client_normal).
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,7 +48,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 
 **Structure:**
 
-- `integration-tests/pass/core/` — 256 core language feature tests covering arrays, control flow, structs, enums, maps, pointers, named returns, type inference, builtins, C interop, bigint types, wildcards, and more.
+- `integration-tests/pass/core/` — 257 core language feature tests covering arrays, control flow, structs, enums, maps, pointers, named returns, type inference, builtins, C interop, bigint types, wildcards, and more.
 - `integration-tests/pass/stdlib/` — 68 stdlib module tests covering all 28 stdlib modules.
 - `integration-tests/pass/new/` — 8 project template tests (basic, cli, lib, multi, server_minimal, server_normal, client_minimal, client_normal).
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.
 - `integration-tests/pass/multi-file/` — 118 multi-file import tests covering imports, aliases, structs, enums, private visibility, transitive imports, directory imports, and more.
 - `integration-tests/pass/stress/` — 43 stress tests (30 core, 13 stdlib).
-- `integration-tests/fail/errors/` — 779 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
+- `integration-tests/fail/errors/` — 780 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
 - `integration-tests/fail/multi-file/` — 40 multi-file error detection tests covering cross-module type errors, private access violations, and circular imports.
 
 **Running:**

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,7 +48,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 
 **Structure:**
 
-- `integration-tests/pass/core/` — 252 core language feature tests covering arrays, control flow, structs, enums, maps, pointers, named returns, type inference, builtins, C interop, bigint types, wildcards, and more.
+- `integration-tests/pass/core/` — 255 core language feature tests covering arrays, control flow, structs, enums, maps, pointers, named returns, type inference, builtins, C interop, bigint types, wildcards, and more.
 - `integration-tests/pass/stdlib/` — 68 stdlib module tests covering all 28 stdlib modules.
 - `integration-tests/pass/new/` — 8 project template tests (basic, cli, lib, multi, server_minimal, server_normal, client_minimal, client_normal).
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ Integration tests compile and run `.gray` programs end-to-end through the full c
 - `integration-tests/pass/warnings/` — 24 warning detection tests covering all W-code warnings.
 - `integration-tests/pass/multi-file/` — 118 multi-file import tests covering imports, aliases, structs, enums, private visibility, transitive imports, directory imports, and more.
 - `integration-tests/pass/stress/` — 43 stress tests (30 core, 13 stdlib).
-- `integration-tests/fail/errors/` — 761 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
+- `integration-tests/fail/errors/` — 774 error detection tests covering all compiler error codes (E1xxx–E9xxx) and runtime panics.
 - `integration-tests/fail/multi-file/` — 40 multi-file error detection tests covering cross-module type errors, private access violations, and circular imports.
 
 **Running:**

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -9003,6 +9003,16 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
         /* Detect wide integer type for the when value */
         const char *when_bigint = (when_val_t && when_val_t->name && is_bigint_type(when_val_t->name))
             ? when_val_t->name : resolve_bigint_type(codegen, val);
+        /* Evaluate the match expression once into a temporary so that
+         * side-effecting expressions (function calls, increments, etc.)
+         * are not re-executed for each is-arm. */
+        static int when_tmp_ctr = 0;
+        char when_tmp[64];
+        snprintf(when_tmp, sizeof(when_tmp), "_gray_when%d", when_tmp_ctr++);
+        emit_indent(codegen);
+        emit_formatted(codegen, "__auto_type %s = ", when_tmp);
+        emit_expression(codegen, val);
+        emit(codegen, ";\n");
         for (int i = 0; i < node->data.when_stmt.case_count; i++) {
             WhenCase *wc = &node->data.when_stmt.cases[i];
             emit_indent(codegen);
@@ -9018,7 +9028,7 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                     const char *vname = wc->values[j]->data.when_pattern.variant;
                     const char *ename = wc->values[j]->data.when_pattern.enum_name;
                     if (!ename) ename = when_tagged_ename;
-                    emit_expression(codegen, val);
+                    emit(codegen, when_tmp);
                     emit_formatted(codegen, ".tag == GrayEnum_%s_TAG_%s", ename, vname);
                 } else if (when_is_tagged) {
                     /* Tagged enum, plain variant: compare .tag */
@@ -9030,10 +9040,10 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                         vname = cv->data.implicit_enum.variant;
                     }
                     if (vname) {
-                        emit_expression(codegen, val);
+                        emit(codegen, when_tmp);
                         emit_formatted(codegen, ".tag == GrayEnum_%s_TAG_%s", when_tagged_ename, vname);
                     } else {
-                        emit_expression(codegen, val);
+                        emit(codegen, when_tmp);
                         emit(codegen, ".tag == ");
                         emit_expression(codegen, cv);
                     }
@@ -9044,16 +9054,16 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                         range->data.range_expr.step->kind == NODE_PREFIX_EXPR &&
                         range->data.range_expr.step->data.prefix.op == TOK_MINUS);
                     emit(codegen, "(");
-                    emit_expression(codegen, val);
+                    emit(codegen, when_tmp);
                     emit(codegen, neg_step ? " <= " : " >= ");
                     emit_expression(codegen, range->data.range_expr.start);
                     emit(codegen, " && ");
-                    emit_expression(codegen, val);
+                    emit(codegen, when_tmp);
                     emit(codegen, neg_step ? " > " : " < ");
                     emit_expression(codegen, range->data.range_expr.end);
                     if (range->data.range_expr.step) {
                         emit(codegen, " && (");
-                        emit_expression(codegen, val);
+                        emit(codegen, when_tmp);
                         emit(codegen, " - ");
                         emit_expression(codegen, range->data.range_expr.start);
                         emit(codegen, ") % ");
@@ -9063,18 +9073,18 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                     emit(codegen, ")");
                 } else if (when_is_string) {
                     emit(codegen, "gray_string_eq(");
-                    emit_expression(codegen, val);
+                    emit(codegen, when_tmp);
                     emit(codegen, ", ");
                     emit_expression(codegen, wc->values[j]);
                     emit(codegen, ")");
                 } else if (when_bigint) {
                     emit_formatted(codegen, "%s_eq(", bigint_prefix(when_bigint));
-                    emit_expression(codegen, val);
+                    emit(codegen, when_tmp);
                     emit(codegen, ", ");
                     emit_expression(codegen, wc->values[j]);
                     emit(codegen, ")");
                 } else {
-                    emit_expression(codegen, val);
+                    emit(codegen, when_tmp);
                     emit(codegen, " == ");
                     emit_expression(codegen, wc->values[j]);
                 }
@@ -9104,7 +9114,7 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                                 emit_formatted(codegen, "%s %s = ",
                                     gray_type_to_c_codegen(codegen, ev->payload_types[bi]),
                                     pat->data.when_pattern.bindings[bi]);
-                                emit_expression(codegen, val);
+                                emit(codegen, when_tmp);
                                 emit_formatted(codegen, ".data.%s._%d;\n", vname, bi);
                             }
                         }

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -8804,13 +8804,16 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
         const char *idx_name = node->data.for_each.index_name;
         if (!idx_name) idx_name = "_gray_idx";
         bool is_map_iter = (coll_t && coll_t->kind == TK_MAP);
-        /* Used by the array branch: when the collection is a non-assignable
-         * expression (e.g. an inline literal), we materialize it into a
-         * named C temporary so that .iterating++ and GRAY_ARRAY_GET can
-         * operate on an addressable target. */
+        /* When the collection is a non-assignable expression (function
+         * call, literal, etc.) it is an rvalue in C and cannot be
+         * mutated (.iterating++) or addressed (&coll). Both the array
+         * and map branches materialize a named C temporary. */
         bool coll_needs_tmp = false;
         char arr_tmp_name[SHORT_VAR_BUF];
         arr_tmp_name[0] = '\0';
+        bool map_needs_tmp = false;
+        char map_tmp_name[SHORT_VAR_BUF];
+        map_tmp_name[0] = '\0';
 
         if (is_map_iter) {
             /* for_each on map; iterate occupied slots with internal counter */
@@ -8826,20 +8829,32 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
             }
             if (coll_t->value_type) c_val = gray_map_element_c_type(codegen, coll_t->value_type);
 
+            map_needs_tmp = (coll->kind != NODE_LABEL);
+            if (map_needs_tmp) {
+                snprintf(map_tmp_name, sizeof(map_tmp_name), "_gray_map%d", map_iter_counter - 1);
+                emit_formatted(codegen, "{ GrayMap %s = ", map_tmp_name);
+                emit_expression(codegen, coll);
+                emit(codegen, ";\n");
+                emit_indent(codegen);
+            }
+
             /* Iterate in insertion order using the order array */
             char slot_name[SHORT_VAR_BUF];
             snprintf(slot_name, sizeof(slot_name), "_gray_sl%d", map_iter_counter - 1);
             /* Guard against mutation during iteration */
-            emit_expression(codegen, coll);
+            if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+            else emit_expression(codegen, coll);
             emit(codegen, ".iterating++;\n");
             emit_indent(codegen);
             emit_formatted(codegen, "for (int32_t %s = 0; %s < ", mi_name, mi_name);
-            emit_expression(codegen, coll);
+            if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+            else emit_expression(codegen, coll);
             emit_formatted(codegen, ".order_len; %s++) {\n", mi_name);
             codegen->indent++;
             emit_indent(codegen);
             emit_formatted(codegen, "int32_t %s = ", slot_name);
-            emit_expression(codegen, coll);
+            if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+            else emit_expression(codegen, coll);
             emit_formatted(codegen, ".order[%s];\n", mi_name);
 
             if (node->data.for_each.index_name) {
@@ -8848,14 +8863,16 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                     emit_indent(codegen);
                     emit_formatted(codegen, "%s %s = *(%s *)gray_map_key_at(&",
                         c_key, sanitize_name(node->data.for_each.index_name), c_key);
-                    emit_expression(codegen, coll);
+                    if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+                    else emit_expression(codegen, coll);
                     emit_formatted(codegen, ", %s);\n", slot_name);
                 }
                 if (strcmp(node->data.for_each.var_name, "_") != 0) {
                     emit_indent(codegen);
                     emit_formatted(codegen, "%s %s = *(%s *)gray_map_value_at(&",
                         c_val, sanitize_name(node->data.for_each.var_name), c_val);
-                    emit_expression(codegen, coll);
+                    if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+                    else emit_expression(codegen, coll);
                     emit_formatted(codegen, ", %s);\n", slot_name);
                 }
             } else {
@@ -8863,7 +8880,8 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
                 emit_indent(codegen);
                 emit_formatted(codegen, "%s %s = *(%s *)gray_map_key_at(&",
                     c_key, sanitize_name(node->data.for_each.var_name), c_key);
-                emit_expression(codegen, coll);
+                if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+                else emit_expression(codegen, coll);
                 emit_formatted(codegen, ", %s);\n", slot_name);
             }
         } else if (coll_t && coll_t->kind == TK_STRING) {
@@ -8942,8 +8960,13 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
         /* Decrement map iteration guard */
         if (is_map_iter) {
             emit_indent(codegen);
-            emit_expression(codegen, coll);
+            if (map_needs_tmp) emit_formatted(codegen, "%s", map_tmp_name);
+            else emit_expression(codegen, coll);
             emit(codegen, ".iterating--;\n");
+            if (map_needs_tmp) {
+                emit_indent(codegen);
+                emit(codegen, "}\n");
+            }
         }
         /* Close extra scope for string iteration */
         if (coll_t && coll_t->kind == TK_STRING) {

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -6542,6 +6542,22 @@ static void emit_call_expression(CodeGen *codegen, AstNode *node) {
                         emit_expression(codegen, node->data.call.args[i]);
                     }
                 }
+                /* Inject default values for omitted trailing parameters */
+                {
+                    int self_offset = self_injected ? 1 : 0;
+                    int first_default = node->data.call.arg_count + self_offset;
+                    bool any_emitted = self_injected || node->data.call.arg_count > 0;
+                    for (int i = first_default; i < ns_func->data.func_decl.param_count; i++) {
+                        if (ns_func->data.func_decl.params[i].is_type_param) continue;
+                        if (any_emitted) emit(codegen, ", ");
+                        any_emitted = true;
+                        if (ns_func->data.func_decl.params[i].default_value) {
+                            emit_expression(codegen, ns_func->data.func_decl.params[i].default_value);
+                        } else {
+                            emit(codegen, "0");
+                        }
+                    }
+                }
                 emit(codegen, ")");
                 return;
             }

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -2777,6 +2777,7 @@ static AstNode *parse_when_statement(Parser *parser) {
             {
                 bool try_pattern = false;
                 bool is_implicit_pat = false;
+                bool is_explicit_enum = false;
                 Token pat_tok = parser->cur_token;
 
                 if (current_token_is(parser, TOK_IDENT) && peek_token_is(parser, TOK_LPAREN)) {
@@ -2803,6 +2804,42 @@ static AstNode *parse_when_statement(Parser *parser) {
                     if (all_idents && bind_count > 0 && current_token_is(parser, TOK_RPAREN)) {
                         try_pattern = true;
                         (void)vname;
+                    }
+                    /* Restore lexer state */
+                    parser->lexer->position = sv_pos;
+                    parser->lexer->read_position = sv_rpos;
+                    parser->lexer->ch = sv_ch;
+                    parser->lexer->line = sv_line;
+                    parser->lexer->column = sv_col;
+                    parser->cur_token  = sv_cur;
+                    parser->peek_token = sv_peek;
+                } else if (current_token_is(parser, TOK_IDENT) && peek_token_is(parser, TOK_DOT)) {
+                    /* IDENT.IDENT(IDENT,...) explicit enum pattern form */
+                    int sv_pos  = parser->lexer->position;
+                    int sv_rpos = parser->lexer->read_position;
+                    char sv_ch  = parser->lexer->ch;
+                    int sv_line = parser->lexer->line;
+                    int sv_col  = parser->lexer->column;
+                    Token sv_cur  = parser->cur_token;
+                    Token sv_peek = parser->peek_token;
+
+                    next_token(parser); /* skip first IDENT (enum name) */
+                    next_token(parser); /* skip DOT */
+                    if (current_token_is(parser, TOK_IDENT) && peek_token_is(parser, TOK_LPAREN)) {
+                        next_token(parser); /* skip second IDENT (variant) */
+                        next_token(parser); /* skip ( */
+                        bool all_idents = true;
+                        int bind_count = 0;
+                        while (!current_token_is(parser, TOK_RPAREN) && !current_token_is(parser, TOK_EOF)) {
+                            if (!current_token_is(parser, TOK_IDENT)) { all_idents = false; break; }
+                            bind_count++;
+                            next_token(parser);
+                            if (current_token_is(parser, TOK_COMMA)) next_token(parser);
+                        }
+                        if (all_idents && bind_count > 0 && current_token_is(parser, TOK_RPAREN)) {
+                            try_pattern = true;
+                            is_explicit_enum = true;
+                        }
                     }
                     /* Restore lexer state */
                     parser->lexer->position = sv_pos;
@@ -2854,11 +2891,17 @@ static AstNode *parse_when_statement(Parser *parser) {
                 if (try_pattern) {
                     /* Actually consume and build NODE_WHEN_PATTERN */
                     AstNode *pat = ast_alloc(parser->arena, NODE_WHEN_PATTERN, pat_tok);
-                    pat->data.when_pattern.enum_name = NULL;
                     pat->data.when_pattern.is_implicit = is_implicit_pat;
 
-                    if (is_implicit_pat) {
+                    if (is_explicit_enum) {
+                        pat->data.when_pattern.enum_name = arena_copy_string(parser->arena, parser->cur_token.literal);
+                        next_token(parser); /* skip enum name */
                         next_token(parser); /* skip dot */
+                    } else {
+                        pat->data.when_pattern.enum_name = NULL;
+                        if (is_implicit_pat) {
+                            next_token(parser); /* skip dot */
+                        }
                     }
                     pat->data.when_pattern.variant = arena_copy_string(parser->arena, parser->cur_token.literal);
                     next_token(parser); /* skip IDENT (variant) */
@@ -2872,6 +2915,15 @@ static AstNode *parse_when_statement(Parser *parser) {
                             const char **nb = arena_alloc(parser->arena, sizeof(const char *) * bc_cap);
                             memcpy(nb, pat->data.when_pattern.bindings, sizeof(const char *) * bc);
                             pat->data.when_pattern.bindings = nb;
+                        }
+                        /* Reject type keywords as binding names */
+                        if (is_reserved_type_name(parser->cur_token.literal)) {
+                            char msg[MSG_BUF_SIZE];
+                            snprintf(msg, sizeof(msg),
+                                "'%s' is a reserved type name and cannot be used as a binding name",
+                                parser->cur_token.literal);
+                            diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
+                                parser->file, parser->cur_token.line, parser->cur_token.column, 0);
                         }
                         pat->data.when_pattern.bindings[bc++] = arena_copy_string(parser->arena, parser->cur_token.literal);
                         next_token(parser);

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -10794,6 +10794,15 @@ static void validate_field_type_recursive(TypeChecker *checker, AstNode *program
 
     /* Leaf: must be a known primitive, enum, struct, or wildcard '?' */
     if (type_name_has_wildcard(type_name)) return;
+
+    /* Bare func: reject with guidance toward typed signature */
+    if (strcmp(type_name, "func") == 0) {
+        diagnostic_error_code_help(checker->diag, "E3130",
+            NODE_FILE(checker, stmt), stmt->token.line, stmt->token.column, 0,
+            "use a typed signature: func(params) -> return_type");
+        return;
+    }
+
     GrayType *t = typechecker_type_from_name(checker, type_name);
     if (t && t->kind != TK_STRUCT && t->kind != TK_UNKNOWN) return;
     if (is_enum_name(checker, type_name)) return;

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -9922,23 +9922,34 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             diagnostic_error_code(checker->diag, "E3129",
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
+        Scope *wh_outer = checker->current_scope;
+        Scope *wh_scope = scope_create(wh_outer);
+        checker->current_scope = wh_scope;
         checker->loop_depth++;
         check_block(checker, node->data.while_stmt.body);
         checker->loop_depth--;
+        checker->current_scope = wh_outer;
+        scope_destroy(wh_scope);
         break;
     }
 
-    case NODE_LOOP_STMT:
+    case NODE_LOOP_STMT: {
         /* E3129: empty loop body hangs forever at runtime */
         if (node->data.loop_stmt.body &&
             node->data.loop_stmt.body->data.block.count == 0) {
             diagnostic_error_code(checker->diag, "E3129",
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
+        Scope *lp_outer = checker->current_scope;
+        Scope *lp_scope = scope_create(lp_outer);
+        checker->current_scope = lp_scope;
         checker->loop_depth++;
         check_block(checker, node->data.loop_stmt.body);
         checker->loop_depth--;
+        checker->current_scope = lp_outer;
+        scope_destroy(lp_scope);
         break;
+    }
 
     case NODE_BREAK_STMT:
     case NODE_CONTINUE_STMT:

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -2126,6 +2126,33 @@ static void reject_void_in_context(TypeChecker *checker, AstNode *expr,
         NODE_FILE(checker, expr), expr->token.line, expr->token.column, 0);
 }
 
+/* E3040: reject multi-return calls in single-value positions (array
+ * elements, map values, return expressions, etc.). Shared helper to
+ * avoid duplicating the lookup logic at each call site. */
+static void reject_multi_return_in_single_position(TypeChecker *checker, AstNode *expr) {
+    if (!expr || expr->kind != NODE_CALL_EXPR) return;
+    AstNode *fn = expr->data.call.function;
+    FuncSig *sig = NULL;
+    const char *name = NULL;
+    if (fn && fn->kind == NODE_LABEL) {
+        name = fn->data.label.value;
+        sig = find_func(checker, name);
+    } else if (fn && fn->kind == NODE_MEMBER_EXPR &&
+               fn->data.member.object->kind == NODE_LABEL) {
+        const char *mod_raw = fn->data.member.object->data.label.value;
+        const char *mod = typechecker_resolve_alias(checker, mod_raw);
+        name = fn->data.member.member;
+        char prefixed[MSG_BUF_SIZE];
+        snprintf(prefixed, sizeof(prefixed), "%s_%s", mod, name);
+        sig = find_func(checker, prefixed);
+    }
+    if (sig && sig->return_count > 1) {
+        diagnostic_error_code_formatted(checker->diag, "E3040",
+            NODE_FILE(checker, expr), expr->token.line, expr->token.column, 0,
+            name, sig->return_count, name);
+    }
+}
+
 /* : emit E4005 at a stdlib call site where the function name
  * isn't recognized. Shared between every module dispatch branch that
  * has a fallthrough "unknown function" else. Without this, typing
@@ -7006,10 +7033,12 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
         }
         if (node->data.array_value.count > 0) {
             GrayType *first = resolve_expression(checker, node->data.array_value.elements[0]);
+            reject_multi_return_in_single_position(checker, node->data.array_value.elements[0]);
             result = type_array(type_name(first));
             /* Validate all elements have the same type */
             for (int i = 1; i < node->data.array_value.count; i++) {
                 GrayType *element_resolved = resolve_expression(checker, node->data.array_value.elements[i]);
+                reject_multi_return_in_single_position(checker, node->data.array_value.elements[i]);
                 if (!element_resolved || element_resolved->kind == TK_UNKNOWN || !first || first->kind == TK_UNKNOWN)
                     continue;
                 bool compatible = (element_resolved->kind == first->kind) ||
@@ -7040,6 +7069,8 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
             /* : void can't be a map key or value. */
             reject_void_in_context(checker, node->data.map_value.keys[i], kt, "map key");
             reject_void_in_context(checker, node->data.map_value.values[i], vt, "map value");
+            /* E3040: multi-return call in single-value map position */
+            reject_multi_return_in_single_position(checker, node->data.map_value.values[i]);
         }
         /* E12006: Check for duplicate keys in map literal */
         for (int i = 0; i < node->data.map_value.count; i++) {
@@ -9268,6 +9299,8 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
 
     case NODE_RETURN_STMT:
         for (int i = 0; i < node->data.return_stmt.count; i++) {
+            /* E3040: multi-return call in single-value return position */
+            reject_multi_return_in_single_position(checker, node->data.return_stmt.values[i]);
             /* Set expected_type for implicit enum resolution in return values */
             GrayType *saved_ret_expected = checker->expected_type;
             if (i < checker->current_return_count &&

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -11630,25 +11630,6 @@ void typechecker_check(TypeChecker *checker, AstNode *program) {
         }
     }
 
-    /* Pass 1.5: Pre-register all global constants and variables that have an
-     * explicit type annotation. This allows global initializers to reference
-     * any other global constant regardless of declaration order within the
-     * same file or across imported files. The def_line is intentionally left
-     * as 0 to mark these as pre-registered (not real duplicates); Pass 2
-     * overwrites each entry with the fully resolved type and real def_line. */
-    for (int i = 0; i < program->data.program.stmt_count; i++) {
-        AstNode *stmt = program->data.program.stmts[i];
-        if (stmt->kind != NODE_VAR_DECL) continue;
-        if (!stmt->data.var_decl.type_name) continue; /* inferred type — skip */
-        if (scope_lookup_local(checker->current_scope, stmt->data.var_decl.name)) continue;
-        GrayType *pre_t = type_from_name(stmt->data.var_decl.type_name);
-        if (!pre_t) continue;
-        scope_define(checker->current_scope, stmt->data.var_decl.name,
-            pre_t, stmt->data.var_decl.mutable);
-        /* Leave def_line = 0: sentinel that lets the E4003 duplicate check
-         * in check_statement distinguish pre-registration from real duplicates. */
-    }
-
     /* E2088: keyword alias consistency (while vs as_long_as, else vs otherwise) */
     check_keyword_alias_consistency(checker, program);
 

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -8906,17 +8906,69 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
         GrayType *value_t = resolve_expression(checker, node->data.assign.value);
         checker->expected_type = saved_expected;
 
-        /* E3078: compound arithmetic assigns on pointer variables
-         * (p += 1, p -= 2, etc.) are pointer arithmetic and not
-         * supported. Plain `=` (and the existing `p = nil` /
-         * `p = addr(...)` paths) stay valid. */
+        /* Compound assignment type validation: x op= y must be valid
+         * when x op y would be valid. Mirrors the checks in
+         * resolve_infix_expr() for the corresponding binary operator. */
         TokenType aop = node->data.assign.op;
-        if ((aop == TOK_PLUS_ASSIGN || aop == TOK_MINUS_ASSIGN ||
-             aop == TOK_ASTERISK_ASSIGN || aop == TOK_SLASH_ASSIGN ||
-             aop == TOK_PERCENT_ASSIGN) &&
-            target_t && target_t->kind == TK_POINTER) {
-            diagnostic_error_code(checker->diag, "E3078",
-                NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+        if (aop == TOK_PLUS_ASSIGN || aop == TOK_MINUS_ASSIGN ||
+            aop == TOK_ASTERISK_ASSIGN || aop == TOK_SLASH_ASSIGN ||
+            aop == TOK_PERCENT_ASSIGN) {
+
+            /* E3078: pointer arithmetic */
+            if (target_t && target_t->kind == TK_POINTER) {
+                diagnostic_error_code(checker->diag, "E3078",
+                    NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+            }
+
+            if (target_t && value_t &&
+                target_t->kind != TK_UNKNOWN && value_t->kind != TK_UNKNOWN) {
+
+                /* E3002: bool in arithmetic */
+                if (target_t->kind == TK_BOOL || value_t->kind == TK_BOOL) {
+                    char *msg = typechecker_format(checker,
+                        "invalid operands: cannot use '%s' with %s and %s",
+                        operator_to_string(aop), type_name(target_t), type_name(value_t));
+                    diagnostic_error_message(checker->diag, "E3002", msg,
+                        NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+                }
+
+                /* E3048: string += (concatenation) */
+                if ((target_t->kind == TK_STRING || value_t->kind == TK_STRING) &&
+                    aop == TOK_PLUS_ASSIGN) {
+                    diagnostic_error_code_help(checker->diag, "E3048",
+                        NODE_FILE(checker, node), node->token.line, node->token.column, 0,
+                        "use string interpolation \"${a}${b}\" or fmt.format() to combine strings");
+                }
+
+                /* E3002: string in non-plus arithmetic */
+                if ((target_t->kind == TK_STRING || value_t->kind == TK_STRING) &&
+                    aop != TOK_PLUS_ASSIGN) {
+                    char *msg = typechecker_format(checker,
+                        "cannot use '%s' on string type", operator_to_string(aop));
+                    diagnostic_error_message(checker->diag, "E3002", msg,
+                        NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+                }
+
+                /* E3002: modulo on float */
+                if (aop == TOK_PERCENT_ASSIGN &&
+                    (target_t->kind == TK_FLOAT || value_t->kind == TK_FLOAT)) {
+                    diagnostic_error_message(checker->diag, "E3002",
+                        "modulo (%) only works on integers, not floats",
+                        NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+                }
+
+                /* E3093: arithmetic on map, array, or struct */
+                if (target_t->kind == TK_MAP || target_t->kind == TK_ARRAY ||
+                    target_t->kind == TK_STRUCT ||
+                    value_t->kind == TK_MAP || value_t->kind == TK_ARRAY ||
+                    value_t->kind == TK_STRUCT) {
+                    GrayType *bad = (target_t->kind == TK_MAP || target_t->kind == TK_ARRAY ||
+                                     target_t->kind == TK_STRUCT) ? target_t : value_t;
+                    diagnostic_error_code_formatted(checker->diag, "E3093",
+                        NODE_FILE(checker, node), node->token.line, node->token.column, 0,
+                        operator_to_string(aop), type_display_name(checker, bad));
+                }
+            }
         }
 
         /* E6008: reject assignment to stdlib module constants (math.PI = x, etc.) */

--- a/grayc/src/util/error_codes.h
+++ b/grayc/src/util/error_codes.h
@@ -211,7 +211,8 @@
     GRAY_ERROR("E3126", "types", "array size must be greater than zero; '%s' resolves to %d") \
     GRAY_ERROR("E3127", "types", "type parameter expects a struct type name, but '%s' is not a struct; only struct types can be passed as type arguments") \
     GRAY_ERROR("E3128", "types", "type parameter expects a struct type name, but got a non-type expression; pass a struct type name like 'MyStruct'") \
-    GRAY_ERROR("E3129", "safety", "empty loop body; this will loop forever at runtime")
+    GRAY_ERROR("E3129", "safety", "empty loop body; this will loop forever at runtime") \
+    GRAY_ERROR("E3130", "types", "bare 'func' is not allowed as a struct field type")
 
 /* --- E4xxx: Name Problems (References) --- */
 #define GRAY_REFERENCE_ERRORS \

--- a/integration-tests/fail/errors/E2002_type_keyword_as_enum_binding.gray
+++ b/integration-tests/fail/errors/E2002_type_keyword_as_enum_binding.gray
@@ -1,0 +1,19 @@
+/* E2002: type keywords cannot be used as when/is binding names */
+/* expect: E2002 */
+
+const Wrapper enum {
+    Value(int)
+    Empty
+}
+
+do main() {
+    mut w = Wrapper.Value(42)
+    when w {
+        is Wrapper.Value(int) {
+            println("got: ${int}")
+        }
+        is Wrapper.Empty {
+            println("empty")
+        }
+    }
+}

--- a/integration-tests/fail/errors/E3002_compound_assign_bool.gray
+++ b/integration-tests/fail/errors/E3002_compound_assign_bool.gray
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E3002 - compound-assign-bool
+ * Expected: "invalid operands: cannot use '+=' with bool and bool"
+ */
+
+do main() {
+    mut b bool = true
+    b += true
+}

--- a/integration-tests/fail/errors/E3002_compound_assign_string.gray
+++ b/integration-tests/fail/errors/E3002_compound_assign_string.gray
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E3002 - compound-assign-string
+ * Expected: "cannot use '-=' on string type"
+ */
+
+do main() {
+    mut s string = "hello"
+    s -= "world"
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_array.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_array.gray
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3040 - multi-return-in-array
+ * Expected: "'get_pair' returns 2 values"
+ */
+
+do get_pair() -> (int, int) {
+    return 10, 20
+}
+
+do main() {
+    mut arr [int] = {get_pair()}
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_map.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_map.gray
@@ -1,0 +1,12 @@
+/*
+ * Error Test: E3040 - multi-return-in-map
+ * Expected: "'get_val' returns 2 values"
+ */
+
+do get_val() -> (int, Error) {
+    return 42, nil
+}
+
+do main() {
+    mut m map[string:int] = {"a": get_val()}
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_return.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_return.gray
@@ -1,0 +1,16 @@
+/*
+ * Error Test: E3040 - multi-return-in-return
+ * Expected: "'get_val' returns 2 values"
+ */
+
+do get_val() -> (int, Error) {
+    return 42, nil
+}
+
+do wrapper() -> int {
+    return get_val()
+}
+
+do main() {
+    println(wrapper())
+}

--- a/integration-tests/fail/errors/E3130_bare_func_struct_field.gray
+++ b/integration-tests/fail/errors/E3130_bare_func_struct_field.gray
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E3130 - bare-func-struct-field
+ * Expected: "bare 'func' is not allowed as a struct field type"
+ */
+
+const Foobar struct {
+    name string
+    callback func
+}
+
+do main() {
+    println("unreachable")
+}

--- a/integration-tests/fail/errors/E4001_global_const_forward_ref.gray
+++ b/integration-tests/fail/errors/E4001_global_const_forward_ref.gray
@@ -1,0 +1,9 @@
+/* E4001: file-scope constant forward references are rejected */
+/* expect: E4001 */
+
+const B int = A + 1
+const A int = 10
+
+do main() {
+    println("${B}")
+}

--- a/integration-tests/fail/errors/E4001_loop_scope_leak.gray
+++ b/integration-tests/fail/errors/E4001_loop_scope_leak.gray
@@ -1,0 +1,16 @@
+/*
+ * Error Test: E4001 - loop-scope-leak
+ * Expected: "undefined variable 'inner'"
+ */
+
+do main() {
+    mut count int = 0
+    loop {
+        mut inner int = 99
+        count++
+        if count >= 1 {
+            break
+        }
+    }
+    println("${inner}")
+}

--- a/integration-tests/fail/errors/E4001_while_scope_leak.gray
+++ b/integration-tests/fail/errors/E4001_while_scope_leak.gray
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E4001 - while-scope-leak
+ * Expected: "undefined variable 'inner'"
+ */
+
+do main() {
+    mut x int = 0
+    while x < 1 {
+        mut inner int = 42
+        x++
+    }
+    println("${inner}")
+}

--- a/integration-tests/pass/core/for_each_map_func_call.gray
+++ b/integration-tests/pass/core/for_each_map_func_call.gray
@@ -1,0 +1,27 @@
+/*
+ * Test: for_each over map from function call evaluates collection once
+ * Verifies that the map expression is hoisted into a temporary
+ */
+
+mut call_count int = 0
+mut passed int = 0
+mut failed int = 0
+
+do get_map() -> map[string:int] {
+    call_count++
+    mut m map[string:int] = {"a": 1, "b": 2}
+    return m
+}
+
+do main() {
+    for_each k, v in get_map() {
+        println("${k}=${v}")
+    }
+    if call_count == 1 {
+        passed++
+    } otherwise {
+        failed++
+    }
+
+    println("passed: ${passed}, failed: ${failed}")
+}

--- a/integration-tests/pass/core/struct_func_default_params.gray
+++ b/integration-tests/pass/core/struct_func_default_params.gray
@@ -1,0 +1,54 @@
+/*
+ * Test: struct function default parameters are injected in codegen
+ * Covers instance dispatch, static dispatch, and partial defaults
+ */
+
+mut passed int = 0
+mut failed int = 0
+
+const Vec struct {
+    x int
+    y int
+
+    do scale(self Vec, factor int = 2) -> Vec {
+        return Vec{x: self.x * factor, y: self.y * factor}
+    }
+}
+
+const Foo struct {
+    val int
+
+    do compute(self Foo, a int, b int = 10) -> int {
+        return self.val + a + b
+    }
+}
+
+do main() {
+    mut v = Vec{x: 3, y: 4}
+
+    // Instance dispatch, default omitted
+    mut a = v.scale()
+    if a.x == 6 { passed++ } otherwise { failed++ }
+    if a.y == 8 { passed++ } otherwise { failed++ }
+
+    // Instance dispatch, explicit value
+    mut b = v.scale(3)
+    if b.x == 9 { passed++ } otherwise { failed++ }
+    if b.y == 12 { passed++ } otherwise { failed++ }
+
+    // Static dispatch, default omitted
+    mut c = Vec.scale(v)
+    if c.x == 6 { passed++ } otherwise { failed++ }
+    if c.y == 8 { passed++ } otherwise { failed++ }
+
+    // Partial defaults - trailing default omitted
+    mut f = Foo{val: 100}
+    mut r1 = f.compute(5)
+    if r1 == 115 { passed++ } otherwise { failed++ }
+
+    // Partial defaults - all provided
+    mut r2 = f.compute(5, 20)
+    if r2 == 125 { passed++ } otherwise { failed++ }
+
+    println("passed: ${passed}, failed: ${failed}")
+}

--- a/integration-tests/pass/core/when_single_eval.gray
+++ b/integration-tests/pass/core/when_single_eval.gray
@@ -1,0 +1,29 @@
+/*
+ * Test: when statement evaluates the match expression exactly once
+ * Verifies that side-effecting expressions are not re-evaluated per arm
+ */
+
+mut counter int = 0
+mut passed int = 0
+mut failed int = 0
+
+do next_val() -> int {
+    counter++
+    return counter
+}
+
+do main() {
+    when next_val() {
+        is 10 { println("got 10") }
+        is 20 { println("got 20") }
+        is 30 { println("got 30") }
+        default { println("no match") }
+    }
+    if counter == 1 {
+        passed++
+    } otherwise {
+        failed++
+    }
+
+    println("passed: ${passed}, failed: ${failed}")
+}


### PR DESCRIPTION
This PR contains the following changes: 

## Bug Fixes:
- Reject bare `func` as struct field type (#2121)
- Validate types for compound assignment operators (#2125)
- Reject multi-return calls in array, map, and return contexts (#2114)
- Evaluate `when` match expression once into a temporary (#2126)
- Add child scopes for `while` and `loop` bodies (#2127)
- Hoist map collection into temporary for `for_each` iteration (#2128)
- Reject type keywords as enum binding names; add explicit enum pattern parsing (#2129, also fixes #2115)
- Inject default params for struct function calls (#2130)
- Reject global constant forward references (#2132)

## Test
- Add several integration test
## Docs:
- Update STANDARD.md type inference section for file-scope const rules (#2122)