### PR TITLE
Fix release tag collisions with EZ-era versions

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -17,7 +17,7 @@
     ".": {
       "release-type": "go",
       "package-name": "grayscale",
-      "include-component-in-tag": false,
+      "include-component-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- Enables `include-component-in-tag` in release-please config so tags are prefixed with `grayscale-` (e.g., `grayscale-v0.1.0`)
- Prevents collisions with existing EZ-era tags (`v0.1.0` through `v3.9.0`)

## Context

Release-please failed because `v0.1.0` already exists from the EZ era. With this change, all future Grayscale releases use distinct tags that won't conflict.