### PR TITLE
fix(cli): filter releases to grayscale-v* tags, excluding legacy EZ releases

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -53,6 +53,7 @@ const (
 	checkTimeout         = 2 * time.Second
 	maxChangelogVersions = 10        // Maximum number of versions to show in changelog
 	maxDownloadBytes     = 256 << 20 // 256 MiB upper bound on release archive size
+	releaseTagPrefix     = "grayscale-"
 )
 
 // getUpdateStatePath returns the path to the update state file
@@ -184,6 +185,7 @@ func GetVersionInfo() VersionInfo {
 // the pre-release label is stripped back to the real identifier so a local
 // dev build still orders correctly against upstream tags.
 func parseSemver(v string) (major, minor, patch int, pre string) {
+	v = strings.TrimPrefix(v, releaseTagPrefix)
 	v = strings.TrimPrefix(v, "v")
 	// Drop +build metadata
 	if i := strings.Index(v, "+"); i != -1 {
@@ -367,7 +369,16 @@ func fetchAllReleases(ctx context.Context) ([]GitHubRelease, error) {
 		return nil, err
 	}
 
-	return releases, nil
+	// Filter to only Grayscale-era releases (grayscale-v* tags) so that
+	// legacy EZ releases (v1.x–v3.x) are excluded from version discovery.
+	filtered := releases[:0]
+	for _, r := range releases {
+		if strings.HasPrefix(r.TagName, releaseTagPrefix) {
+			filtered = append(filtered, r)
+		}
+	}
+
+	return filtered, nil
 }
 
 // pickLatestPrerelease scans a release list (as returned by /releases) and
@@ -820,6 +831,7 @@ func runUpdate(confirm bool, url string, pre bool) error {
 // normalizeTag strips a single leading 'v' so user input and GitHub tag
 // names (which may or may not be prefixed) compare cleanly.
 func normalizeTag(v string) string {
+	v = strings.TrimPrefix(v, releaseTagPrefix)
 	return strings.TrimPrefix(v, "v")
 }
 

--- a/cli/update_extra_test.go
+++ b/cli/update_extra_test.go
@@ -40,19 +40,19 @@ func TestIsVersionInRange(t *testing.T) {
 
 func TestGetReleasesInRange(t *testing.T) {
 	releases := []GitHubRelease{
-		{TagName: "v3.0.0"},
-		{TagName: "v3.0.1"},
-		{TagName: "v3.0.2"},
-		{TagName: "v3.1.0"},
-		{TagName: "v2.9.9"},
+		{TagName: "grayscale-v0.1.0"},
+		{TagName: "grayscale-v0.1.1"},
+		{TagName: "grayscale-v0.1.2"},
+		{TagName: "grayscale-v0.2.0"},
+		{TagName: "grayscale-v0.0.4"},
 	}
 
-	got := getReleasesInRange(releases, "v3.0.0", "v3.0.2")
+	got := getReleasesInRange(releases, "grayscale-v0.1.0", "grayscale-v0.1.2")
 	if len(got) != 2 {
-		t.Fatalf("expected 2 releases in (v3.0.0, v3.0.2], got %d: %v", len(got), got)
+		t.Fatalf("expected 2 releases in (grayscale-v0.1.0, grayscale-v0.1.2], got %d: %v", len(got), got)
 	}
 	tags := []string{got[0].TagName, got[1].TagName}
-	for _, want := range []string{"v3.0.1", "v3.0.2"} {
+	for _, want := range []string{"grayscale-v0.1.1", "grayscale-v0.1.2"} {
 		found := false
 		for _, tag := range tags {
 			if tag == want {
@@ -66,8 +66,8 @@ func TestGetReleasesInRange(t *testing.T) {
 }
 
 func TestGetReleasesInRange_Empty(t *testing.T) {
-	releases := []GitHubRelease{{TagName: "v3.0.0"}}
-	got := getReleasesInRange(releases, "v3.0.0", "v3.0.0")
+	releases := []GitHubRelease{{TagName: "grayscale-v0.1.0"}}
+	got := getReleasesInRange(releases, "grayscale-v0.1.0", "grayscale-v0.1.0")
 	if len(got) != 0 {
 		t.Errorf("expected empty, got %v", got)
 	}
@@ -82,8 +82,8 @@ func TestPickLatestStable(t *testing.T) {
 
 	t.Run("only prereleases", func(t *testing.T) {
 		rels := []GitHubRelease{
-			{TagName: "v3.0.0-beta.1", Prerelease: true},
-			{TagName: "v3.0.0-rc.1", Prerelease: true},
+			{TagName: "grayscale-v0.2.0-beta.1", Prerelease: true},
+			{TagName: "grayscale-v0.2.0-rc.1", Prerelease: true},
 		}
 		if got := pickLatestStable(rels); got != nil {
 			t.Errorf("want nil for prerelease-only list, got %+v", got)
@@ -92,14 +92,14 @@ func TestPickLatestStable(t *testing.T) {
 
 	t.Run("picks highest stable", func(t *testing.T) {
 		rels := []GitHubRelease{
-			{TagName: "v3.0.0", Prerelease: false},
-			{TagName: "v3.1.0", Prerelease: false},
-			{TagName: "v3.2.0-beta.1", Prerelease: true},
-			{TagName: "v2.9.9", Prerelease: false},
+			{TagName: "grayscale-v0.1.0", Prerelease: false},
+			{TagName: "grayscale-v0.1.1", Prerelease: false},
+			{TagName: "grayscale-v0.2.0-beta.1", Prerelease: true},
+			{TagName: "grayscale-v0.0.4", Prerelease: false},
 		}
 		got := pickLatestStable(rels)
-		if got == nil || got.TagName != "v3.1.0" {
-			t.Errorf("want v3.1.0, got %+v", got)
+		if got == nil || got.TagName != "grayscale-v0.1.1" {
+			t.Errorf("want grayscale-v0.1.1, got %+v", got)
 		}
 	})
 }

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -31,6 +31,9 @@ func TestParseSemver(t *testing.T) {
 		// Missing components default to 0
 		{"v2.1", 2, 1, 0, ""},
 		{"v2", 2, 0, 0, ""},
+		// Release-please component prefix (grayscale-v*)
+		{"grayscale-v0.1.1", 0, 1, 1, ""},
+		{"grayscale-v0.2.0-rc.1", 0, 2, 0, "rc.1"},
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
@@ -81,6 +84,10 @@ func TestCompareSemver(t *testing.T) {
 		// Git-describe trailer must not affect ordering
 		{"v3.0.0-beta.2-4-g0cbcb58-dirty", "v3.0.0-beta.2", 0},
 		{"v3.0.0-beta.2-4-g0cbcb58", "v3.0.0-beta.1", 1},
+
+		// Release-please component prefix (grayscale-v*)
+		{"grayscale-v0.1.1", "grayscale-v0.1.0", 1},
+		{"grayscale-v0.1.0", "v0.1.0", 0}, // prefix-stripped tags compare equal
 	}
 	for _, c := range cases {
 		t.Run(c.a+"_vs_"+c.b, func(t *testing.T) {
@@ -128,8 +135,8 @@ func TestPickLatestPrerelease(t *testing.T) {
 
 	t.Run("no prereleases", func(t *testing.T) {
 		rels := []GitHubRelease{
-			{TagName: "v3.0.0", Prerelease: false},
-			{TagName: "v2.9.0", Prerelease: false},
+			{TagName: "grayscale-v0.1.0", Prerelease: false},
+			{TagName: "grayscale-v0.0.9", Prerelease: false},
 		}
 		if got := pickLatestPrerelease(rels); got != nil {
 			t.Errorf("want nil, got %+v", got)
@@ -138,26 +145,26 @@ func TestPickLatestPrerelease(t *testing.T) {
 
 	t.Run("picks highest semver prerelease", func(t *testing.T) {
 		rels := []GitHubRelease{
-			{TagName: "v3.0.0", Prerelease: false},
-			{TagName: "v3.0.0-beta.1", Prerelease: true},
-			{TagName: "v3.1.0-beta.2", Prerelease: true},
-			{TagName: "v3.0.0-beta.10", Prerelease: true},
-			{TagName: "v3.0.0-beta.2", Prerelease: true},
+			{TagName: "grayscale-v0.2.0", Prerelease: false},
+			{TagName: "grayscale-v0.2.0-beta.1", Prerelease: true},
+			{TagName: "grayscale-v0.3.0-beta.2", Prerelease: true},
+			{TagName: "grayscale-v0.2.0-beta.10", Prerelease: true},
+			{TagName: "grayscale-v0.2.0-beta.2", Prerelease: true},
 		}
 		got := pickLatestPrerelease(rels)
-		if got == nil || got.TagName != "v3.1.0-beta.2" {
-			t.Errorf("want v3.1.0-beta.2, got %+v", got)
+		if got == nil || got.TagName != "grayscale-v0.3.0-beta.2" {
+			t.Errorf("want grayscale-v0.3.0-beta.2, got %+v", got)
 		}
 	})
 
 	t.Run("ignores stable entries when picking prerelease", func(t *testing.T) {
 		rels := []GitHubRelease{
-			{TagName: "v4.0.0", Prerelease: false},
-			{TagName: "v3.0.0-beta.2", Prerelease: true},
+			{TagName: "grayscale-v1.0.0", Prerelease: false},
+			{TagName: "grayscale-v0.2.0-beta.2", Prerelease: true},
 		}
 		got := pickLatestPrerelease(rels)
-		if got == nil || got.TagName != "v3.0.0-beta.2" {
-			t.Errorf("want v3.0.0-beta.2, got %+v", got)
+		if got == nil || got.TagName != "grayscale-v0.2.0-beta.2" {
+			t.Errorf("want grayscale-v0.2.0-beta.2, got %+v", got)
 		}
 	})
 }
@@ -222,6 +229,9 @@ func TestNormalizeTag(t *testing.T) {
 		// Only one leading v is stripped — defensive
 		{"vv3.0.0", "v3.0.0"},
 		{"", ""},
+		// Release-please component prefix
+		{"grayscale-v0.1.1", "0.1.1"},
+		{"grayscale-v0.2.0-rc.1", "0.2.0-rc.1"},
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `fetchAllReleases` now filters to only `grayscale-v*` tagged releases, so legacy EZ releases (v1.x–v3.9.0) no longer appear as update targets
- `parseSemver` and `normalizeTag` strip the `grayscale-` component prefix so semver comparison works correctly with release-please tags
- Test fixtures updated to use `grayscale-v` prefixed tags

Closes #2201

