### PR TITLE
docs: Add EZ to Grayscale migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ gray update --pre        # latest pre-release Note: The latest pre-release may b
 gray install x.y.z       # pin to an exact version
 ```
 
-`gray update` checks for new versions, shows the changelog, and upgrades both the `gray` CLI and the compiler. Pass `--pre` to pick up the latest alpha, beta, or rc. Use `gray install <version>` to install an exact version by semver — downgrades and pre-release tags (e.g. `3.0.0-beta.2`) are supported.
+`gray update` checks for new versions, shows the changelog, and upgrades both the `gray` CLI and the compiler. Pass `--pre` to pick up the latest alpha, beta, or rc. Use `gray install <version>` to install an exact version by semver — downgrades and pre-release tags (e.g. `0.2.0-beta.1`) are supported.
+
+### Migrating from EZ
+
+Grayscale was previously known as **EZ**. The `ez update` command from older EZ versions cannot upgrade to Grayscale automatically. To migrate, uninstall EZ and do a fresh install of Grayscale using the instructions in the [Install](#install) section above.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a "Migrating from EZ" section to the README explaining that `ez update` cannot upgrade to Grayscale automatically
- Directs old EZ users to do a fresh install
- Updates the example semver in the Updating section to reflect Grayscale versioning