### PR TITLE
chore: prevent docs commits from triggering release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,7 +5,7 @@
     {"type": "fix", "section": "Bug Fixes", "hidden": false},
     {"type": "perf", "section": "Performance Improvements", "hidden": false},
     {"type": "revert", "section": "Reverts", "hidden": false},
-    {"type": "docs", "section": "Documentation", "hidden": false},
+    {"type": "docs", "section": "Documentation", "hidden": true},
     {"type": "chore", "section": "Miscellaneous", "hidden": true},
     {"type": "style", "section": "Styles", "hidden": true},
     {"type": "refactor", "section": "Code Refactoring", "hidden": true},


### PR DESCRIPTION
## Summary

- Sets `docs` type to `hidden: true` in release-please config so docs-only commits no longer trigger a version bump