### PR TITLE
bugfixes July-26-2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,7 +1,7 @@
 # Grayscale Error Code Reference
 
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
-> Run `./scripts/generate_errors.sh` to regenerate.
+> Run `./scripts/generate_errors.gray` to regenerate.
 
 **Total: 370 codes** (251 errors, 17 warnings, 102 panics)
 
@@ -421,4 +421,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-07-25 20:05:19 UTC*
+*Generated on 2026-07-26 03:23:28 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,7 +1,7 @@
 # Grayscale Error Code Reference
 
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
-> Run `./scripts/generate_errors.gray` to regenerate.
+> Run `./scripts/generate_errors.sh` to regenerate.
 
 **Total: 370 codes** (251 errors, 17 warnings, 102 panics)
 
@@ -189,7 +189,7 @@
 | `E3119` | types | fixed-size arrays are not allowed in function parameters; use '[%s]' instead of '%s' for parameter '%s' |
 | `E3120` | types | pointer ordering comparisons are not supported; only == and != are allowed on pointers |
 | `E3121` | types | cannot use '%s' as a condition in a when statement; allowed types are int, uint, string, char, byte, bool, float, and enum |
-| `E3122` | safety | cannot take the address of const '%s'; addr() on an immutable variable would allow mutation through the pointer |
+| `E3122` | safety | cannot write through pointer to const '%s'; the address was taken from an immutable variable |
 | `E3123` | iteration | for_each with both positions discarded accesses nothing; use 'for _ in range(0, len(collection))' to iterate by count |
 | `E3124` | types | operator '%s' is not defined for tagged enum '%s'; tagged enums carry payloads and cannot be compared with == or != |
 | `E3125` | types | '%s' is not a compile-time integer constant; array size must be a const int/uint value |
@@ -421,4 +421,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-07-25 01:14:42 UTC*
+*Generated on 2026-07-25 20:05:19 UTC*

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
 - **Readable syntax** — `for_each`, `as_long_as`(alias is `while`), `if`/`or`/`otherwise`(alias is `else`), `when`/`is`, `in`/`not_in`(alias is `!in`), `or_return`, `ensure`, `bit_and`/`bit_or`/`bit_xor`, etc.
 - **Versatility through simplicity** — Scripts, microservices, CLI tools, or projects where you want to learn systems programming fundamentals
 - **A compiler that works **for** the programmer** — Clear error messages, a built-in formatter, live reloading, and built-in language and stdlib docs via `gray man`. When questions arise, Grayscale provides the answers.
-- **Safe by default** — Automatic Scope-Based Arena Management for memory, bounds-checked arrays, overflow-checked math, nil protection, **NO** pointer arithmetic. The guardrails are on unless you explicitly take them off with the `@mem` stdlib module
 
+- **Safe by default** — Automatic Scope-Based Arena Management for memory, bounds-checked arrays, strings, and maps, overflow-checked arithmetic, division-by-zero protection, nil pointer checks, stack depth guards, no implicit narrowing, **NO** pointer arithmetic. The guardrails are on unless you explicitly take them off with the `@mem` or `@threads` stdlib modules
 ---
 
 ## The Standard Library

--- a/cli/update.go
+++ b/cli/update.go
@@ -1013,7 +1013,7 @@ func downloadAndInstall(downloadURL string) error {
 		return fmt.Errorf("permission denied. Please run as Administrator")
 	}
 	fmt.Println("Root permissions required. Running with sudo...")
-	cmd := exec.Command("sudo", os.Args[0], "update", "--confirm", downloadURL)
+	cmd := exec.Command("sudo", execPath, "update", "--confirm", downloadURL)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cli/update.go
+++ b/cli/update.go
@@ -15,6 +15,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -984,22 +985,11 @@ func getAssetName() string {
 	return name
 }
 
-// checkWritePermission checks if we can write to the executable's directory
-func checkWritePermission(path string) bool {
-	dir := filepath.Dir(path)
-	testFile := filepath.Join(dir, ".gray-update-test")
-	f, err := os.Create(testFile)
-	if err != nil {
-		return false
-	}
-	f.Close()
-	os.Remove(testFile)
-	return true
-}
-
-// downloadAndInstall downloads the archive and extracts/installs the binary
-func downloadAndInstall(url string) error {
-	// Get current executable path
+// downloadAndInstall downloads the archive and extracts/installs the binary.
+// Instead of probing write permission with a test file (TOCTOU-prone), this
+// attempts the install directly and escalates to sudo only if the actual
+// file operation fails with a permission error.
+func downloadAndInstall(downloadURL string) error {
 	execPath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to get executable path: %w", err)
@@ -1009,28 +999,31 @@ func downloadAndInstall(url string) error {
 		return fmt.Errorf("failed to resolve symlinks: %w", err)
 	}
 
-	// Check if we have write permission
-	if !checkWritePermission(execPath) {
-		// Need elevated permissions - re-exec with sudo
-		if runtime.GOOS == "windows" {
-			return fmt.Errorf("permission denied. Please run as Administrator")
-		}
-		fmt.Println("Root permissions required. Running with sudo...")
-		// Re-run the update command with sudo
-		cmd := exec.Command("sudo", os.Args[0], "update", "--confirm", url)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		err := cmd.Run()
-		if err != nil {
-			return fmt.Errorf("failed to run with sudo: %w", err)
-		}
-
-		os.Exit(0)
+	err = doInstall(downloadURL, execPath)
+	if err == nil {
+		return nil
 	}
 
-	return doInstall(url, execPath)
+	if !errors.Is(err, os.ErrPermission) {
+		return err
+	}
+
+	// Need elevated permissions
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("permission denied. Please run as Administrator")
+	}
+	fmt.Println("Root permissions required. Running with sudo...")
+	cmd := exec.Command("sudo", os.Args[0], "update", "--confirm", downloadURL)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run with sudo: %w", err)
+	}
+
+	os.Exit(0)
+	return nil // unreachable
 }
 
 const (

--- a/cli/update.go
+++ b/cli/update.go
@@ -97,7 +97,7 @@ func writeUpdateState(state *UpdateState) error {
 
 	// Ensure directory exists
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 
@@ -106,7 +106,7 @@ func writeUpdateState(state *UpdateState) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0600)
 }
 
 // shouldCheckForUpdate returns true if we should check for updates (once per day)

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -1186,24 +1186,30 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
         break;
 
     case NODE_INTERPOLATED_STRING: {
-        emit(codegen, "gray_string_format(gray_default_arena, \"");
-        /* First pass: emit format string */
-        for (int i = 0; i < node->data.interpolated_string.part_count; i++) {
+        /* Emit as chained gray_string_concat() calls instead of gray_string_format()
+         * to preserve null bytes in string values (gray_string_format uses vsnprintf
+         * which truncates at \0). gray_string_concat is null-safe (uses memcpy). */
+        int part_count = node->data.interpolated_string.part_count;
+        if (part_count == 0) {
+            emit(codegen, "gray_string_lit(\"\")");
+            break;
+        }
+        /* Emit N-1 opening gray_string_concat calls for left-associative chaining:
+         * concat(arena, concat(arena, part0, part1), part2) */
+        for (int i = 1; i < part_count; i++) {
+            emit(codegen, "gray_string_concat(gray_default_arena, ");
+        }
+        /* Emit each part as a GrayString expression */
+        for (int i = 0; i < part_count; i++) {
+            if (i > 0) emit(codegen, ", ");
             AstNode *part = node->data.interpolated_string.parts[i];
             if (part->kind == NODE_STRING_VALUE) {
-                const char *s = part->data.string_value.value;
-                while (*s) {
-                    if (*s == '%') append_string_to_buffer(&codegen->output, "%%");
-                    else if (s[0] == '\\' && s[1] == '$') { append_char_to_buffer(&codegen->output, '$'); s++; }
-                    else append_char_to_buffer(&codegen->output, *s);
-                    s++;
-                }
+                /* Literal text — reuses NODE_STRING_VALUE codegen (null-safe) */
+                emit_expression(codegen, part);
             } else {
-                /* Use type table to determine format specifier */
+                /* Expression — resolve type and emit as GrayString */
                 GrayType *part_type = codegen->type_table ? typetable_get(codegen->type_table, part) : NULL;
                 TypeKind tk = part_type ? part_type->kind : TK_UNKNOWN;
-
-                /* Fall back to AST-based inference if no type info */
                 if (tk == TK_UNKNOWN) {
                     if (codegen->wildcard_binding) {
                         GrayType *wildcard_type = type_from_name(codegen->wildcard_binding);
@@ -1214,160 +1220,104 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                     if (part->kind == NODE_FLOAT_VALUE) tk = TK_FLOAT;
                     else if (part->kind == NODE_BOOL_VALUE) tk = TK_BOOL;
                     else if (part->kind == NODE_STRING_VALUE) tk = TK_STRING;
-                    else tk = TK_INT; /* default integer kind */
+                    else tk = TK_INT;
                 }
 
-                /* Check for bigint types; format as %s (use to_string) */
-                const char *bi_interp = resolve_bigint_type(codegen, part);
-                if (bi_interp) {
-                    emit(codegen, "%s");
+                const char *bi = resolve_bigint_type(codegen, part);
+                if (bi) {
+                    emit_formatted(codegen, "%s_to_string(gray_default_arena, ", bigint_prefix(bi));
+                    emit_expression(codegen, part);
+                    emit(codegen, ")");
                 } else switch (tk) {
-                case TK_STRING: emit(codegen, "%s"); break;
-                case TK_FLOAT:  emit(codegen, "%s"); break; /* uses gray_builtin_format_float */
-                case TK_BOOL:   emit(codegen, "%s"); break;
-                case TK_CHAR:   emit(codegen, "%s"); break;
-                case TK_ARRAY:  emit(codegen, "%s"); break;
-                case TK_MAP:    emit(codegen, "%s"); break;
-                case TK_ERROR:  emit(codegen, "%s"); break;
+                case TK_STRING:
+                    emit_expression(codegen, part);
+                    break;
+                case TK_BOOL:
+                    emit(codegen, "(");
+                    emit_expression(codegen, part);
+                    emit(codegen, ") ? gray_string_lit(\"true\") : gray_string_lit(\"false\")");
+                    break;
+                case TK_FLOAT:
+                    emit(codegen, "gray_builtin_format_float(gray_default_arena, ");
+                    emit_expression(codegen, part);
+                    emit(codegen, ")");
+                    break;
+                case TK_CHAR:
+                    emit(codegen, "gray_builtin_char_to_utf8(gray_default_arena, ");
+                    emit_expression(codegen, part);
+                    emit(codegen, ")");
+                    break;
+                case TK_ARRAY: {
+                    int ek = 0;
+                    if (part_type && part_type->element_type) {
+                        GrayType *et = type_from_name(part_type->element_type);
+                        if (et->kind == TK_FLOAT) ek = 1;
+                        else if (et->kind == TK_STRING) ek = 2;
+                        else if (et->kind == TK_BOOL) ek = 3;
+                        else if (et->kind == TK_UINT) ek = 4;
+                        else if (et->kind == TK_BYTE) ek = 5;
+                        else if (et->kind == TK_CHAR) ek = 6;
+                    }
+                    emit_formatted(codegen, "({ GrayArray _interp_arr = ");
+                    emit_expression(codegen, part);
+                    emit_formatted(codegen, "; gray_builtin_array_to_string(gray_default_arena, &_interp_arr, %d); })", ek);
+                    break;
+                }
+                case TK_MAP: {
+                    int vk = 0;
+                    if (part_type && part_type->value_type) {
+                        GrayType *vt = type_from_name(part_type->value_type);
+                        if (vt->kind == TK_FLOAT) vk = 1;
+                        else if (vt->kind == TK_STRING) vk = 2;
+                        else if (vt->kind == TK_BOOL) vk = 3;
+                        else if (vt->kind == TK_UINT) vk = 4;
+                        else if (vt->kind == TK_BYTE) vk = 5;
+                        else if (vt->kind == TK_CHAR) vk = 6;
+                    }
+                    emit_formatted(codegen, "({ GrayMap _interp_map = ");
+                    emit_expression(codegen, part);
+                    emit_formatted(codegen, "; gray_builtin_map_to_string(gray_default_arena, &_interp_map, %d); })", vk);
+                    break;
+                }
+                case TK_ERROR:
+                    emit_expression(codegen, part);
+                    emit(codegen, " ? ");
+                    emit_expression(codegen, part);
+                    emit(codegen, "->message : gray_string_lit(\"nil\")");
+                    break;
+                case TK_UINT:
+                    emit(codegen, "gray_string_format(gray_default_arena, \"%llu\", (unsigned long long)(");
+                    emit_expression(codegen, part);
+                    emit(codegen, "))");
+                    break;
                 case TK_STRUCT:
-                    if (part_type && part_type->name && strcmp(part_type->name, "UUID") == 0)
-                        emit(codegen, "%s");
-                    else
-                        emit(codegen, "%lld");
+                    if (part_type && part_type->name && strcmp(part_type->name, "UUID") == 0) {
+                        emit_expression(codegen, part);
+                        emit(codegen, ".value");
+                    } else {
+                        emit(codegen, "gray_string_format(gray_default_arena, \"%lld\", (long long)(");
+                        emit_expression(codegen, part);
+                        emit(codegen, "))");
+                    }
                     break;
                 case TK_ENUM:
-                    if (part_type && part_type->name && codegen_enum_is_string(codegen, part_type->name))
-                        emit(codegen, "%s");
-                    else
-                        emit(codegen, "%lld");
+                    if (part_type && part_type->name && codegen_enum_is_string(codegen, part_type->name)) {
+                        emit_expression(codegen, part);
+                    } else {
+                        emit(codegen, "gray_string_format(gray_default_arena, \"%lld\", (long long)(");
+                        emit_expression(codegen, part);
+                        emit(codegen, "))");
+                    }
                     break;
-                case TK_UINT:   emit(codegen, "%llu"); break;
-                default:        emit(codegen, "%lld"); break;
+                default:
+                    emit(codegen, "gray_string_format(gray_default_arena, \"%lld\", (long long)(");
+                    emit_expression(codegen, part);
+                    emit(codegen, "))");
+                    break;
                 }
             }
+            if (i > 0) emit(codegen, ")");
         }
-        emit(codegen, "\"");
-        /* Second pass: emit arguments */
-        for (int i = 0; i < node->data.interpolated_string.part_count; i++) {
-            AstNode *part = node->data.interpolated_string.parts[i];
-            if (part->kind == NODE_STRING_VALUE) continue;
-            emit(codegen, ", ");
-
-            GrayType *part_type = codegen->type_table ? typetable_get(codegen->type_table, part) : NULL;
-            TypeKind tk = part_type ? part_type->kind : TK_UNKNOWN;
-            if (tk == TK_UNKNOWN) {
-                if (codegen->wildcard_binding) {
-                    GrayType *wildcard_type = type_from_name(codegen->wildcard_binding);
-                    if (wildcard_type) { tk = wildcard_type->kind; part_type = wildcard_type; }
-                }
-            }
-            if (tk == TK_UNKNOWN) {
-                if (part->kind == NODE_FLOAT_VALUE) tk = TK_FLOAT;
-                else if (part->kind == NODE_BOOL_VALUE) tk = TK_BOOL;
-                else if (part->kind == NODE_STRING_VALUE) tk = TK_STRING;
-                else tk = TK_INT; /* default integer kind */
-            }
-
-            /* Check for bigint types; use to_string */
-            const char *bi_arg = resolve_bigint_type(codegen, part);
-            if (bi_arg) {
-                emit_formatted(codegen, "%s_to_string(gray_default_arena, ", bigint_prefix(bi_arg));
-                emit_expression(codegen, part);
-                emit(codegen, ").data");
-            } else switch (tk) {
-            case TK_STRING:
-                emit_expression(codegen, part);
-                emit(codegen, ".data");
-                break;
-            case TK_BOOL:
-                emit(codegen, "(");
-                emit_expression(codegen, part);
-                emit(codegen, ") ? \"true\" : \"false\"");
-                break;
-            case TK_FLOAT:
-                emit(codegen, "gray_builtin_format_float(gray_default_arena, ");
-                emit_expression(codegen, part);
-                emit(codegen, ").data");
-                break;
-            case TK_CHAR:
-                emit(codegen, "gray_builtin_char_to_utf8(gray_default_arena, ");
-                emit_expression(codegen, part);
-                emit(codegen, ").data");
-                break;
-            case TK_ARRAY: {
-                /* Determine element kind: 0=int, 1=float, 2=string, 3=bool, 4=uint, 5=byte, 6=char */
-                int ek = 0;
-                if (part_type && part_type->element_type) {
-                    GrayType *et = type_from_name(part_type->element_type);
-                    if (et->kind == TK_FLOAT) ek = 1;
-                    else if (et->kind == TK_STRING) ek = 2;
-                    else if (et->kind == TK_BOOL) ek = 3;
-                    else if (et->kind == TK_UINT) ek = 4;
-                    else if (et->kind == TK_BYTE) ek = 5;
-                    else if (et->kind == TK_CHAR) ek = 6;
-                }
-                emit_formatted(codegen, "({ GrayArray _interp_arr = ");
-                emit_expression(codegen, part);
-                emit_formatted(codegen, "; gray_builtin_array_to_string(gray_default_arena, &_interp_arr, %d); }).data", ek);
-                break;
-            }
-            case TK_MAP: {
-                /* Determine value kind: 0=int, 1=float, 2=string, 3=bool, 4=uint, 5=byte, 6=char */
-                int vk = 0;
-                if (part_type && part_type->value_type) {
-                    GrayType *vt = type_from_name(part_type->value_type);
-                    if (vt->kind == TK_FLOAT) vk = 1;
-                    else if (vt->kind == TK_STRING) vk = 2;
-                    else if (vt->kind == TK_BOOL) vk = 3;
-                    else if (vt->kind == TK_UINT) vk = 4;
-                    else if (vt->kind == TK_BYTE) vk = 5;
-                    else if (vt->kind == TK_CHAR) vk = 6;
-                }
-                emit_formatted(codegen, "({ GrayMap _interp_map = ");
-                emit_expression(codegen, part);
-                emit_formatted(codegen, "; gray_builtin_map_to_string(gray_default_arena, &_interp_map, %d); }).data", vk);
-                break;
-            }
-            case TK_ERROR:
-                /* Print error message */
-                emit_expression(codegen, part);
-                emit(codegen, " ? ");
-                emit_expression(codegen, part);
-                emit(codegen, "->message.data : \"nil\"");
-                break;
-            case TK_UINT:
-                emit(codegen, "(unsigned long long)(");
-                emit_expression(codegen, part);
-                emit(codegen, ")");
-                break;
-            case TK_STRUCT:
-                if (part_type && part_type->name && strcmp(part_type->name, "UUID") == 0) {
-                    emit_expression(codegen, part);
-                    emit(codegen, ".value.data");
-                } else {
-                    emit(codegen, "(long long)(");
-                    emit_expression(codegen, part);
-                    emit(codegen, ")");
-                }
-                break;
-            case TK_ENUM:
-                if (part_type && part_type->name && codegen_enum_is_string(codegen, part_type->name)) {
-                    emit_expression(codegen, part);
-                    emit(codegen, ".data");
-                } else {
-                    emit(codegen, "(long long)(");
-                    emit_expression(codegen, part);
-                    emit(codegen, ")");
-                }
-                break;
-            default:
-                emit(codegen, "(long long)(");
-                emit_expression(codegen, part);
-                emit(codegen, ")");
-                break;
-            }
-        }
-        emit(codegen, ")");
         break;
     }
 

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -211,6 +211,65 @@ static const char *sized_check_func(TokenType op, bool is_unsigned) {
     return NULL;
 }
 
+/* Emit an overflow-checked compound assignment for a pointer-based target
+ * whose C reference string is ref_str (e.g. "*_dp", "_dp->field").
+ * Handles +=, -=, *= on sized and plain integer types.
+ * Returns true if a checked form was emitted, false otherwise. */
+static bool emit_checked_ptr_compound(CodeGen *codegen, AstNode *node,
+                                      const char *ref_str) {
+    TokenType aop = node->data.assign.op;
+    if (aop != TOK_PLUS_ASSIGN && aop != TOK_MINUS_ASSIGN &&
+        aop != TOK_ASTERISK_ASSIGN)
+        return false;
+
+    GrayType *tgt_t = codegen->type_table
+        ? typetable_get(codegen->type_table, node->data.assign.target) : NULL;
+    if (!tgt_t) return false;
+
+    const char *sn = tgt_t->name;
+
+    /* Sized integers (i8/i16/i32/u8/u16/u32): gray_(u)sized_*_check */
+    const char *smin = NULL, *smax = NULL;
+    bool su = false;
+    if (sn) sized_int_bounds(sn, &smin, &smax, &su);
+    if (smax) {
+        const char *fn = sized_check_func(aop, su);
+        if (!fn) return false;
+        emit_formatted(codegen, "%s = %s(%s, ", ref_str, fn, ref_str);
+        emit_expression(codegen, node->data.assign.value);
+        if (su)
+            emit_formatted(codegen, ", %s, \"%s\", \"%s\", %d)",
+                           smax, sn, codegen->file, node->token.line);
+        else
+            emit_formatted(codegen, ", %s, %s, \"%s\", \"%s\", %d)",
+                           smin, smax, sn, codegen->file, node->token.line);
+        return true;
+    }
+
+    /* Plain int/uint (i64/u64): gray_(u)*_check */
+    bool tgt_is_int = (tgt_t->kind == TK_INT || tgt_t->kind == TK_UINT ||
+                       tgt_t->kind == TK_BYTE);
+    if (!tgt_is_int) return false;
+
+    bool unsigned_op = (tgt_t->kind == TK_UINT || tgt_t->kind == TK_BYTE);
+    const char *fn = NULL;
+    if (unsigned_op) {
+        if (aop == TOK_PLUS_ASSIGN) fn = "gray_uadd_check";
+        else if (aop == TOK_MINUS_ASSIGN) fn = "gray_usub_check";
+        else if (aop == TOK_ASTERISK_ASSIGN) fn = "gray_umul_check";
+    } else {
+        if (aop == TOK_PLUS_ASSIGN) fn = "gray_add_check";
+        else if (aop == TOK_MINUS_ASSIGN) fn = "gray_sub_check";
+        else if (aop == TOK_ASTERISK_ASSIGN) fn = "gray_mul_check";
+    }
+    if (!fn) return false;
+
+    emit_formatted(codegen, "%s = %s(%s, ", ref_str, fn, ref_str);
+    emit_expression(codegen, node->data.assign.value);
+    emit_formatted(codegen, ", \"%s\", %d)", codegen->file, node->token.line);
+    return true;
+}
+
 static const char *sanitize_name(const char *name) {
     if (!name || !is_c_keyword(name)) return name;
     static char bufs[4][MSG_BUF_SIZE];
@@ -7644,7 +7703,12 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
                               ? ptr_t->element_type : NULL;
         emit(codegen, "{ __auto_type _dp = ");
         emit_expression(codegen, ptr_node);
-        emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } *_dp", codegen->file, node->token.line);
+        emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } ", codegen->file, node->token.line);
+        if (!bi_elem && emit_checked_ptr_compound(codegen, node, "*_dp")) {
+            emit(codegen, "; }\n");
+            return;
+        }
+        emit(codegen, "*_dp");
         emit_formatted(codegen, " %s ", operator_to_c_string(node->data.assign.op));
         if (bi_elem) {
             emit_bigint_operand(codegen, node->data.assign.value,
@@ -7663,7 +7727,14 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
         const char *field = node->data.assign.target->data.member.member;
         emit(codegen, "{ __auto_type _dp = ");
         emit_expression(codegen, ptr);
-        emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } _dp->%s", codegen->file, node->token.line, field);
+        emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } ", codegen->file, node->token.line);
+        char _ref2[MSG_BUF_SIZE];
+        snprintf(_ref2, sizeof(_ref2), "_dp->%s", field);
+        if (emit_checked_ptr_compound(codegen, node, _ref2)) {
+            emit(codegen, "; }\n");
+            return;
+        }
+        emit(codegen, _ref2);
         emit_formatted(codegen, " %s ", operator_to_c_string(node->data.assign.op));
         emit_expression(codegen, node->data.assign.value);
         emit(codegen, "; }\n");
@@ -7690,12 +7761,19 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
         if (ptr_root && depth > 1) {
             emit(codegen, "{ __auto_type _dp = ");
             emit_expression(codegen, ptr_root);
-            emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } _dp->", codegen->file, node->token.line);
-            /* Emit chain in reverse: chain[depth-1] is closest to root */
-            for (int i = depth - 1; i >= 0; i--) {
-                emit(codegen, sanitize_name(chain[i]));
-                if (i > 0) emit(codegen, ".");
+            emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } ", codegen->file, node->token.line);
+            /* Build the field reference string for the chain */
+            char _ref3[MSG_BUF_SIZE];
+            int _pos = snprintf(_ref3, sizeof(_ref3), "_dp->");
+            for (int i = depth - 1; i >= 0 && _pos < (int)sizeof(_ref3); i--) {
+                _pos += snprintf(_ref3 + _pos, sizeof(_ref3) - _pos, "%s%s",
+                                 sanitize_name(chain[i]), i > 0 ? "." : "");
             }
+            if (emit_checked_ptr_compound(codegen, node, _ref3)) {
+                emit(codegen, "; }\n");
+                return;
+            }
+            emit(codegen, _ref3);
             emit_formatted(codegen, " %s ", operator_to_c_string(node->data.assign.op));
             emit_expression(codegen, node->data.assign.value);
             emit(codegen, "; }\n");
@@ -7741,7 +7819,14 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
             }
             emit(codegen, "{ __auto_type _dp = ");
             emit_expression(codegen, obj);
-            emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } _dp->%s", codegen->file, node->token.line, sanitize_name(field));
+            emit_formatted(codegen, "; if (!_dp) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } ", codegen->file, node->token.line);
+            char _ref4[MSG_BUF_SIZE];
+            snprintf(_ref4, sizeof(_ref4), "_dp->%s", sanitize_name(field));
+            if (emit_checked_ptr_compound(codegen, node, _ref4)) {
+                emit(codegen, "; }\n");
+                return;
+            }
+            emit(codegen, _ref4);
             emit_formatted(codegen, " %s ", operator_to_c_string(node->data.assign.op));
             emit_expression(codegen, node->data.assign.value);
             emit(codegen, "; }\n");

--- a/grayc/src/main.c
+++ b/grayc/src/main.c
@@ -1698,6 +1698,7 @@ int main(int argc, char **argv) {
         snprintf(cmd, sizeof(cmd),
             "cc -std=c11 %s -Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable "
             "-Wno-tautological-compare -Wno-infinite-recursion "
+            "-Wno-incompatible-pointer-types-discards-qualifiers "
             "-isystem '%s'/runtime -isystem '%s'/stdlib "
             "-o '%s' '%s' '%s' "
             "-lm -lpthread -Wl,-w 2>&1",
@@ -1737,6 +1738,7 @@ int main(int argc, char **argv) {
         snprintf(cmd, sizeof(cmd),
             "cc -std=c11 %s -Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable "
             "-Wno-tautological-compare -Wno-infinite-recursion "
+            "-Wno-incompatible-pointer-types-discards-qualifiers "
             "-isystem '%s'/runtime -isystem '%s'/stdlib "
             "-o '%s' '%s' %s"
             "-lm -lpthread -Wl,-w 2>&1",

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -567,6 +567,15 @@ static AstNode *parse_interpolated_string(Parser *parser, const char *raw) {
                 if (brace_depth > 0) s++;
             }
 
+            /* Guard against unbounded interpolation expressions */
+            size_t expr_len = (size_t)(s - expr_start);
+            if (expr_len > 65536) {
+                diagnostic_error_message(parser->diag, "E2001",
+                    arena_copy_string(parser->arena, "string interpolation expression is too large (max 64KB)"),
+                    parser->file, parser->cur_token.line, parser->cur_token.column, 0);
+                return NULL;
+            }
+
             /* Parse the expression text */
             if (count >= cap) {
                 cap *= 2;

--- a/grayc/src/stdlib/http.c
+++ b/grayc/src/stdlib/http.c
@@ -209,9 +209,22 @@ static GrayHttpResponse do_request(GrayArena *arena, const char *method,
             GrayString *k = (GrayString *)gray_map_key_at(custom_headers, slot);
             GrayString *v = (GrayString *)gray_map_value_at(custom_headers, slot);
             if (!k || !v) continue;
-            int n = snprintf(header + header_length, sizeof(header) - (size_t)header_length,
+            int remaining = (int)(sizeof(header)) - header_length;
+            if (remaining <= 0) {
+                gray_net_close(sock);
+                const char *detail = "request headers too large";
+                err_resp.body = gray_string_new(arena, detail, (int32_t)strlen(detail));
+                return err_resp;
+            }
+            int n = snprintf(header + header_length, (size_t)remaining,
                 "%.*s: %.*s\r\n", (int)k->len, k->data, (int)v->len, v->data);
-            if (n > 0) header_length += n;
+            if (n < 0 || n >= remaining) {
+                gray_net_close(sock);
+                const char *detail = "request headers too large";
+                err_resp.body = gray_string_new(arena, detail, (int32_t)strlen(detail));
+                return err_resp;
+            }
+            header_length += n;
         }
     }
 

--- a/grayc/src/stdlib/regex.c
+++ b/grayc/src/stdlib/regex.c
@@ -15,7 +15,6 @@
 
 #define GRAY_REGEX_PAT_BUF        4096
 #define GRAY_REGEX_TXT_BUF        8192
-#define GRAY_REGEX_RESULT_BUF     16384
 
 /* Helper: compile pattern into a null-terminated C string and regex_t.
  * Returns 0 on success, non-zero on error. Caller must regfree on success. */
@@ -115,25 +114,44 @@ GrayString gray_regex_replace(GrayArena *arena, GrayString pattern, GrayString t
 
     char repl_buf[GRAY_REGEX_PAT_BUF];
     to_cstr(replacement, repl_buf, sizeof(repl_buf));
+    int repl_len = (int)strlen(repl_buf);
 
-    /* Build result by replacing all matches */
-    char result[GRAY_REGEX_RESULT_BUF];
-    int pos = 0;
+    /* First pass: compute exact output size */
+    size_t out_size = 0;
+    int match_count = 0;
     const char *cursor = txt_buf;
     regmatch_t match;
 
-    while (regexec(&re, cursor, 1, &match, 0) == 0 && pos < (int)sizeof(result) - GRAY_REGEX_PAT_BUF) {
-        /* Copy text before match */
+    while (regexec(&re, cursor, 1, &match, 0) == 0) {
+        out_size += (size_t)match.rm_so;
+        out_size += (size_t)repl_len;
+        cursor += match.rm_eo;
+        match_count++;
+        if (match.rm_eo == 0) {
+            if (*cursor) { out_size++; cursor++; }
+            else break;
+        }
+    }
+    out_size += strlen(cursor);
+
+    if (match_count == 0) {
+        regfree(&re);
+        return text;
+    }
+
+    /* Second pass: build result into arena-allocated buffer */
+    char *result = (char *)gray_arena_alloc(arena, out_size + 1);
+    int pos = 0;
+    cursor = txt_buf;
+
+    while (regexec(&re, cursor, 1, &match, 0) == 0) {
         int pre_len = (int)match.rm_so;
         memcpy(result + pos, cursor, (size_t)pre_len);
         pos += pre_len;
 
-        /* Copy replacement */
-        int repl_len = (int)strlen(repl_buf);
         memcpy(result + pos, repl_buf, (size_t)repl_len);
         pos += repl_len;
 
-        /* Advance past match */
         cursor += match.rm_eo;
         if (match.rm_eo == 0) {
             if (*cursor) result[pos++] = *cursor++;
@@ -141,13 +159,13 @@ GrayString gray_regex_replace(GrayArena *arena, GrayString pattern, GrayString t
         }
     }
 
-    /* Copy remaining text */
     int remaining = (int)strlen(cursor);
     memcpy(result + pos, cursor, (size_t)remaining);
     pos += remaining;
+    result[pos] = '\0';
 
     regfree(&re);
-    return gray_string_new(arena, result, (int32_t)pos);
+    return (GrayString){ result, (int32_t)pos };
 }
 
 GrayArray gray_regex_split(GrayArena *arena, GrayString pattern, GrayString text) {

--- a/grayc/src/typechecker/scope.h
+++ b/grayc/src/typechecker/scope.h
@@ -18,6 +18,7 @@ typedef struct {
     const char *declared_type; /* original declared type name (e.g., "uint", "i8") */
     bool mutable;
     bool is_ref;         /* true if created via ref() — transparent reference */
+    bool const_source;   /* true if pointer was taken from a const variable via addr() */
     bool used;           /* true if variable was read */
     int def_line;        /* line where variable was defined */
     int def_column;      /* column where variable was defined */

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -6385,11 +6385,14 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
                     "++ and -- require a variable; you cannot increment a literal or expression",
                     NODE_FILE(checker, node), node->token.line, node->token.column, 0);
             }
-            /* ++ and -- only valid on mutable numeric types */
-            if (node->data.postfix.left->kind == NODE_LABEL) {
-                Symbol *sym = scope_lookup(checker->current_scope, node->data.postfix.left->data.label.value);
-                if (sym && !sym->mutable) {
-                    diagnostic_error_code_formatted(checker->diag, "E3005", NODE_FILE(checker, node), node->token.line, node->token.column, 0, node->data.postfix.left->data.label.value);
+            /* ++ and -- only valid on mutable numeric types.
+             * Walk nested member/index chains so that e.g. p.x++ is caught. */
+            {
+                const char *root = assignment_target_root_name(node->data.postfix.left);
+                if (root) {
+                    Symbol *sym = scope_lookup(checker->current_scope, root);
+                    if (sym && !sym->mutable && !(sym->type && sym->type->kind == TK_POINTER))
+                        diagnostic_error_code_formatted(checker->diag, "E3005", NODE_FILE(checker, node), node->token.line, node->token.column, 0, root);
                 }
             }
             if (left_t->kind != TK_UNKNOWN && !type_is_integer(left_t)) {
@@ -8498,20 +8501,19 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
 
-        /* Check for assignment to const variable (direct, index, or field) */
+        /* Check for assignment to const variable (direct, index, or field).
+         * Uses assignment_target_root_name() to walk arbitrarily nested
+         * member/index chains so that e.g. o.inner.value = 999 is caught. */
         const char *const_name = NULL;
-        if (target->kind == NODE_LABEL) {
-            Symbol *sym = scope_lookup(checker->current_scope, target->data.label.value);
-            if (sym && !sym->mutable) const_name = target->data.label.value;
-        } else if (target->kind == NODE_INDEX_EXPR && target->data.index_expr.left->kind == NODE_LABEL) {
-            Symbol *sym = scope_lookup(checker->current_scope, target->data.index_expr.left->data.label.value);
-            if (sym && !sym->mutable) const_name = target->data.index_expr.left->data.label.value;
-        } else if (target->kind == NODE_MEMBER_EXPR && target->data.member.object->kind == NODE_LABEL) {
-            Symbol *sym = scope_lookup(checker->current_scope, target->data.member.object->data.label.value);
-            /* p.field on a pointer parameter auto-derefs to p^.field — the
-             * pointer itself is not being modified, so don't flag it as const. */
-            if (sym && !sym->mutable && !(sym->type && sym->type->kind == TK_POINTER))
-                const_name = target->data.member.object->data.label.value;
+        {
+            const char *root = assignment_target_root_name(target);
+            if (root) {
+                Symbol *sym = scope_lookup(checker->current_scope, root);
+                /* p.field on a pointer parameter auto-derefs to p^.field — the
+                 * pointer itself is not being modified, so don't flag it. */
+                if (sym && !sym->mutable && !(sym->type && sym->type->kind == TK_POINTER))
+                    const_name = root;
+            }
         }
         if (const_name) {
             diagnostic_error_code_formatted(checker->diag, "E3005", NODE_FILE(checker, node), node->token.line, node->token.column, 0, const_name);

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -3424,16 +3424,6 @@ static GrayType *resolve_builtin_call(TypeChecker *checker, AstNode *node, const
                 "addr() requires a variable, field, or index expression; cannot take address of a literal or expression",
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
-        /* E3122: addr() of a const variable would allow mutation
-         * through the resulting pointer, bypassing immutability. */
-        const char *root = assignment_target_root_name(arg);
-        if (root) {
-            Symbol *sym = scope_lookup(checker->current_scope, root);
-            if (sym && !sym->mutable) {
-                diagnostic_error_code_formatted(checker->diag, "E3122", NODE_FILE(checker, node),
-                    node->token.line, node->token.column, 0, root);
-            }
-        }
         GrayType *arg_t = resolve_expression(checker, arg);
         result = type_pointer(type_name(arg_t));
     } else if (strcmp(function_name, "ref") == 0 && node->data.call.arg_count == 1) {
@@ -8208,6 +8198,21 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                         }
                     }
                 }
+                /* Mark const_source when addr() takes a const variable,
+                 * so writes through the resulting pointer are caught. */
+                if (fn->kind == NODE_LABEL && strcmp(fn->data.label.value, "addr") == 0 &&
+                    node->data.var_decl.value->data.call.arg_count == 1) {
+                    AstNode *src = node->data.var_decl.value->data.call.args[0];
+                    const char *root = assignment_target_root_name(src);
+                    if (root) {
+                        Symbol *src_sym = scope_lookup(checker->current_scope, root);
+                        if (src_sym && !src_sym->mutable) {
+                            Symbol *sym = scope_lookup_local(checker->current_scope,
+                                node->data.var_decl.name);
+                            if (sym) sym->const_source = true;
+                        }
+                    }
+                }
                 /* Store multi-return types for temp variables from calls.
                  * For generic functions, substitute the wildcard binding
                  * so destructured slots get concrete types instead of
@@ -8511,6 +8516,33 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
         if (const_name) {
             diagnostic_error_code_formatted(checker->diag, "E3005", NODE_FILE(checker, node), node->token.line, node->token.column, 0, const_name);
         }
+
+        /* E3122: cannot write through a pointer that was taken from a const
+         * variable via addr().  Covers p^ = v, p^.field = v, and compound
+         * assignments (p^ += v). */
+        if (target->kind == NODE_POSTFIX_EXPR &&
+            target->data.postfix.op == TOK_CARET &&
+            target->data.postfix.left->kind == NODE_LABEL) {
+            Symbol *sym = scope_lookup(checker->current_scope,
+                target->data.postfix.left->data.label.value);
+            if (sym && sym->const_source) {
+                diagnostic_error_code_formatted(checker->diag, "E3122",
+                    NODE_FILE(checker, node), node->token.line, node->token.column, 0,
+                    target->data.postfix.left->data.label.value);
+            }
+        } else if (target->kind == NODE_MEMBER_EXPR &&
+                   target->data.member.object->kind == NODE_POSTFIX_EXPR &&
+                   target->data.member.object->data.postfix.op == TOK_CARET &&
+                   target->data.member.object->data.postfix.left->kind == NODE_LABEL) {
+            Symbol *sym = scope_lookup(checker->current_scope,
+                target->data.member.object->data.postfix.left->data.label.value);
+            if (sym && sym->const_source) {
+                diagnostic_error_code_formatted(checker->diag, "E3122",
+                    NODE_FILE(checker, node), node->token.line, node->token.column, 0,
+                    target->data.member.object->data.postfix.left->data.label.value);
+            }
+        }
+
         /* E3004: string index assignment is not supported; strings are immutable
          * sequences — individual characters cannot be modified by index.
          * This fires regardless of the assigned value's type. */

--- a/grayc/src/util/error_codes.h
+++ b/grayc/src/util/error_codes.h
@@ -205,7 +205,7 @@
     GRAY_ERROR("E3119", "types", "fixed-size arrays are not allowed in function parameters; use '[%s]' instead of '%s' for parameter '%s'") \
     GRAY_ERROR("E3120", "types", "pointer ordering comparisons are not supported; only == and != are allowed on pointers") \
     GRAY_ERROR("E3121", "types", "cannot use '%s' as a condition in a when statement; allowed types are int, uint, string, char, byte, bool, float, and enum") \
-    GRAY_ERROR("E3122", "safety", "cannot take the address of const '%s'; addr() on an immutable variable would allow mutation through the pointer") \
+    GRAY_ERROR("E3122", "safety", "cannot write through pointer to const '%s'; the address was taken from an immutable variable") \
     GRAY_ERROR("E3123", "iteration", "for_each with both positions discarded accesses nothing; use 'for _ in range(0, len(collection))' to iterate by count") \
     GRAY_ERROR("E3124", "types", "operator '%s' is not defined for tagged enum '%s'; tagged enums carry payloads and cannot be compared with == or !=") \
     GRAY_ERROR("E3125", "types", "'%s' is not a compile-time integer constant; array size must be a const int/uint value") \

--- a/grayc/tests/test_codegen.c
+++ b/grayc/tests/test_codegen.c
@@ -1002,7 +1002,7 @@ static void test_e2e_divide_by_zero(void) {
         "}";
 
     FILE *file = fopen(gray_file, "w");
-    if (!file) { _test_fail++; printf("  FAIL %s: cannot write\n", __func__); return; }
+    ASSERT(file != NULL);
     fputs(src, file);
     fclose(file);
 
@@ -1010,9 +1010,7 @@ static void test_e2e_divide_by_zero(void) {
     snprintf(command, sizeof(command), "./grayc %s -o %s >/dev/null 2>&1", gray_file, binary_file);
     if (system(command) != 0) {
         unlink(gray_file);
-        _test_fail++;
-        printf("  FAIL %s: compile failed\n", __func__);
-        return;
+        ASSERT(0 && "compile failed");
     }
 
     char run_cmd[256];
@@ -1027,13 +1025,7 @@ static void test_e2e_divide_by_zero(void) {
     unlink(gray_file);
     unlink(binary_file);
 
-    if (strstr(output, "division by zero")) {
-        _test_pass++;
-        printf("  PASS %s\n", __func__);
-    } else {
-        _test_fail++;
-        printf("  FAIL %s: expected 'division by zero' in output\n", __func__);
-    }
+    ASSERT(strstr(output, "division by zero") != NULL);
 }
 
 /* ===== Sized Integer Types ===== */

--- a/integration-tests/fail/errors/E3005_nested_compound_assign.gray
+++ b/integration-tests/fail/errors/E3005_nested_compound_assign.gray
@@ -1,0 +1,17 @@
+/*
+ * Error Test: E3005 - compound assignment on nested const member
+ * Expected: "cannot modify constant; declare with 'mut' to make it mutable"
+ */
+
+const Inner struct {
+    value int
+}
+
+const Outer struct {
+    inner Inner
+}
+
+do main() {
+    const o = Outer{inner: Inner{value: 42}}
+    o.inner.value += 10  // ERROR: cannot modify const 'o' through compound assignment
+}

--- a/integration-tests/fail/errors/E3005_nested_member_assign.gray
+++ b/integration-tests/fail/errors/E3005_nested_member_assign.gray
@@ -1,0 +1,17 @@
+/*
+ * Error Test: E3005 - nested member assignment on const variable
+ * Expected: "cannot modify constant; declare with 'mut' to make it mutable"
+ */
+
+const Inner struct {
+    value int
+}
+
+const Outer struct {
+    inner Inner
+}
+
+do main() {
+    const o = Outer{inner: Inner{value: 42}}
+    o.inner.value = 999  // ERROR: cannot modify const 'o' through nested access
+}

--- a/integration-tests/fail/errors/E3005_postfix_member.gray
+++ b/integration-tests/fail/errors/E3005_postfix_member.gray
@@ -1,0 +1,14 @@
+/*
+ * Error Test: E3005 - postfix increment on const struct field
+ * Expected: "cannot modify constant; declare with 'mut' to make it mutable"
+ */
+
+const Point struct {
+    x int
+    y int
+}
+
+do main() {
+    const p = Point{x: 1, y: 2}
+    p.x++  // ERROR: cannot increment field of const 'p'
+}

--- a/integration-tests/fail/errors/E3122_addr_const_int.gray
+++ b/integration-tests/fail/errors/E3122_addr_const_int.gray
@@ -1,5 +1,0 @@
-/* Error Test: E3122 - addr() on const int */
-do main() {
-    const x int = 5
-    mut p ^int = addr(x)
-}

--- a/integration-tests/fail/errors/E3122_addr_const_string.gray
+++ b/integration-tests/fail/errors/E3122_addr_const_string.gray
@@ -1,5 +1,0 @@
-/* Error Test: E3122 - addr() on const string */
-do main() {
-    const s string = "hello"
-    mut p ^string = addr(s)
-}

--- a/integration-tests/fail/errors/E3122_addr_const_struct_field.gray
+++ b/integration-tests/fail/errors/E3122_addr_const_struct_field.gray
@@ -1,9 +1,0 @@
-/* Error Test: E3122 - addr() on field of const struct */
-const Point struct {
-    x int
-    y int
-}
-do main() {
-    const p Point = Point{x: 1, y: 2}
-    mut px ^int = addr(p.x)
-}

--- a/integration-tests/fail/errors/E3122_compound_assign_through_const_ptr.gray
+++ b/integration-tests/fail/errors/E3122_compound_assign_through_const_ptr.gray
@@ -1,0 +1,6 @@
+/* Error Test: E3122 - cannot compound-assign through pointer to const */
+do main() {
+    const x int = 5
+    mut p ^int = addr(x)
+    p^ += 1
+}

--- a/integration-tests/fail/errors/E3122_write_field_through_const_ptr.gray
+++ b/integration-tests/fail/errors/E3122_write_field_through_const_ptr.gray
@@ -1,0 +1,10 @@
+/* Error Test: E3122 - cannot write field through pointer to const struct */
+const Point struct {
+    x int
+    y int
+}
+do main() {
+    const pt Point = Point{x: 1, y: 2}
+    mut p ^Point = addr(pt)
+    p^.x = 99
+}

--- a/integration-tests/fail/errors/E3122_write_through_const_ptr.gray
+++ b/integration-tests/fail/errors/E3122_write_through_const_ptr.gray
@@ -1,0 +1,6 @@
+/* Error Test: E3122 - cannot write through pointer to const */
+do main() {
+    const x int = 5
+    mut p ^int = addr(x)
+    p^ = 99
+}

--- a/integration-tests/pass/core/addr_const_read.gray
+++ b/integration-tests/pass/core/addr_const_read.gray
@@ -1,0 +1,58 @@
+/*
+ * addr_const_read.gray - Taking addr() of a const and reading through
+ * the pointer is safe and allowed.
+ */
+
+const Point struct {
+    x int
+    y int
+}
+
+do main() {
+    println("=== addr(const) read-only ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: addr() of const int, read through pointer
+    const val int = 42
+    mut p ^int = addr(val)
+    if p^ == 42 {
+        println("  [PASS] read const int through pointer")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] read const int through pointer")
+        failed += 1
+    }
+
+    // Test 2: addr() of const string, read through pointer
+    const s string = "hello"
+    mut ps ^string = addr(s)
+    if ps^ == "hello" {
+        println("  [PASS] read const string through pointer")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] read const string through pointer")
+        failed += 1
+    }
+
+    // Test 3: addr() of const struct, read field through pointer
+    const pt Point = Point { x: 10, y: 20 }
+    mut pp ^Point = addr(pt)
+    if pp^.x == 10 && pp^.y == 20 {
+        println("  [PASS] read const struct fields through pointer")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] read const struct fields through pointer")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/interpolation_null_bytes.gray
+++ b/integration-tests/pass/core/interpolation_null_bytes.gray
@@ -1,0 +1,87 @@
+/*
+ * interpolation_null_bytes.gray - String interpolation preserves null bytes
+ *
+ * Verifies that interpolating strings containing \0 does not truncate
+ * at the null byte. The old gray_string_format approach used vsnprintf
+ * which stops at \0; the concat-based approach uses memcpy with .len.
+ */
+
+do main() {
+    println("=== Interpolation Null Bytes Test ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: single string with embedded null byte
+    mut a string = "ab\x00cd"
+    mut s1 string = "${a}"
+    if len(s1) == 5 {
+        println("  [PASS] single interpolation preserves null byte")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] single interp: expected len 5, got ${len(s1)}")
+        failed += 1
+    }
+
+    // Test 2: two null-bearing strings via interpolation
+    mut b string = "ef\x00gh"
+    mut s2 string = "${a}${b}"
+    if len(s2) == 10 {
+        println("  [PASS] two null-bearing strings concatenated")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] two null strings: expected len 10, got ${len(s2)}")
+        failed += 1
+    }
+
+    // Test 3: null-bearing string with literal text
+    mut s3 string = "start-${a}-end"
+    if len(s3) == 15 {
+        println("  [PASS] null string with surrounding literal text")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] with literals: expected len 15, got ${len(s3)}")
+        failed += 1
+    }
+
+    // Test 4: null-bearing string mixed with integer
+    mut n int = 42
+    mut s4 string = "${a}=${n}"
+    if len(s4) == 8 {
+        println("  [PASS] null string mixed with integer")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] mixed int: expected len 8, got ${len(s4)}")
+        failed += 1
+    }
+
+    // Test 5: multiple null bytes in one string
+    mut c string = "\x00\x00\x00"
+    mut s5 string = "${c}"
+    if len(s5) == 3 {
+        println("  [PASS] multiple null bytes preserved")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] multi null: expected len 3, got ${len(s5)}")
+        failed += 1
+    }
+
+    // Test 6: null-bearing string with bool interpolation
+    mut flag bool = true
+    mut s6 string = "${a}-${flag}"
+    if len(s6) == 10 {
+        println("  [PASS] null string with bool interpolation")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] with bool: expected len 10, got ${len(s6)}")
+        failed += 1
+    }
+
+    // Summary
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/internal/driver/grayc.go
+++ b/internal/driver/grayc.go
@@ -28,6 +28,7 @@ import (
 func Find() (string, error) {
 	// 1. Explicit override
 	if p := os.Getenv("GRAY_COMPILER_PATH"); p != "" && statFile(p) {
+		fmt.Fprintf(os.Stderr, "note: using compiler from GRAY_COMPILER_PATH=%s\n", p)
 		return p, nil
 	}
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -253,6 +253,7 @@ for dir in "$TEST_DIR"/fail/multi-file/*/; do
 done
 
 # Summary
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
 echo ""
 echo "========================================"
 echo "  Test Summary"
@@ -260,6 +261,7 @@ echo "========================================"
 echo ""
 printf "  ${GREEN}Passed:${NC}  $PASS_COUNT\n"
 printf "  ${RED}Failed:${NC}  $FAIL_COUNT\n"
+printf "  Total:   $TOTAL\n"
 echo ""
 
 if [ $FAIL_COUNT -eq 0 ]; then


### PR DESCRIPTION
This PR contains the following changes:

## Bug Fixes
- fix(codegen): use `gray_string_concat` for string interpolation to preserve null bytes (#2195)
- fix(codegen): emit overflow checks for compound assignment through pointers
- fix(typechecker): catch const mutation through nested access and postfix ops
- fix(parser): enforce 64KB limit on string interpolation expressions (#2177)
- fix(tests): correct e2e test count double-counting in test_e2e_divide_by_zero

## Security Improvments
- security(stdlib): replace fixed buffer with arena allocation in regex.replace (#2167)
- security(stdlib): fix header buffer overflow in http do_request (#2173)
- security(cli): restrict update state file permissions to owner-only (#2176)
- security(cli): use resolved executable path in sudo re-exec (#2165)
- security(cli): eliminate TOCTOU race in self-update permission check (#2170)
- security(cli): log notice when GRAY_COMPILER_PATH overrides compiler lookup

## Tests
- Add several new integration tests

