### PR TITLE
fix: emit implicit enum selectors in struct field defaults

### DIFF
--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -1684,7 +1684,10 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                 if (!specified) {
                     if (node->data.struct_value.count > 0 || field_index > 0) emit(codegen, ", ");
                     emit_formatted(codegen, ".%s = ", sanitize_name(sf->name));
+                    const char *saved = codegen->current_var_type;
+                    codegen->current_var_type = sf->type_name;
                     emit_expression(codegen, sf->default_value);
+                    codegen->current_var_type = saved;
                 }
             }
         }
@@ -2854,6 +2857,10 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
 
     case NODE_IMPLICIT_ENUM: {
         const char *ename = node->data.implicit_enum.resolved_enum;
+        if (!ename && codegen->current_var_type &&
+            codegen_is_enum(codegen, codegen->current_var_type)) {
+            ename = codegen->current_var_type;
+        }
         const char *variant = node->data.implicit_enum.variant;
         if (ename) {
             if (codegen_enum_is_tagged(codegen, ename)) {

--- a/integration-tests/pass/core/implicit_enum_struct_default.gray
+++ b/integration-tests/pass/core/implicit_enum_struct_default.gray
@@ -1,0 +1,67 @@
+/*
+ * Pass Test: Implicit enum selectors in struct field defaults
+ * Verifies omitted defaults, explicit-selector parity, overrides, and
+ * non-enum defaults.
+ */
+
+const Status enum {
+    UNKNOWN
+    PENDING
+    DONE
+}
+
+const ImplicitTask struct {
+    status Status = .PENDING
+    retries int = 3
+}
+
+const ExplicitTask struct {
+    status Status = Status.PENDING
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    mut implicit = ImplicitTask{}
+    if implicit.status == Status.PENDING {
+        println("  [PASS] omitted field uses implicit enum default")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] omitted field did not use implicit enum default")
+        failed += 1
+    }
+
+    mut explicit = ExplicitTask{}
+    if explicit.status == implicit.status {
+        println("  [PASS] implicit and explicit enum defaults match")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] implicit and explicit enum defaults differ")
+        failed += 1
+    }
+
+    if implicit.retries == 3 {
+        println("  [PASS] non-enum default is preserved")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] non-enum default was not preserved")
+        failed += 1
+    }
+
+    mut overridden = ImplicitTask{status: .DONE, retries: 9}
+    if overridden.status == Status.DONE && overridden.retries == 9 {
+        println("  [PASS] explicit fields override defaults")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] explicit fields did not override defaults")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Update the existing struct-default initializer path in `grayc/src/codegen/codegen.c` so it emits an implicit enum selector using the field's declared enum type as context. Reuse the production expression/codegen behavior that already handles implicit enum selectors in struct literal fields and other contextually typed positions, keeping explicit enum selectors and non-enum defaults unchanged. Add a focused passing integration program that declares an enum-typed field with an implicit-selector default, constructs the struct without overriding that field, and verifies the resulting value; include an explicit-selector default or override in the same test as a parity guard.

The typechecker accepts an implicit enum selector such as `.PENDING` as the default value of an enum-typed struct field, but the code generator emits no C expression for that default. Constructing the struct with the field omitted therefore produces an initializer like `.status = }` and leaks a C compiler error. The equivalent explicit selector, `Status.PENDING`, works, and implicit selectors already work in other expression contexts. There are no assignees, competing pull requests, comments claiming the work, or closed prior attempts in the supplied issue bundle.

Closes #2223

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Tests
- [ ] Documentation
- [ ] CI/Build

## Breaking changes

None.

## Checklist

- [ ] `make build` compiles with zero warnings
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] No `@` before module names in any text (it tags GitHub users)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.

### If adding user-facing stdlib/builtin/type

- [ ] C implementation in `grayc/src/stdlib/<module>.h` and `.c` (with `@man` block)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Typechecker wired: return type, `stdlib_arg_table[]`, `stdlib_arg_type_table[]`, `_using_funcs[]`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Codegen wired: `emit_<module>_call()`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `STANDARD.md` updated
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `./scripts/generate_stdlib_man.sh` run and output committed
  Not run: no test command resolved in this workspace, so nothing was executed to pass.

AI was used for assistance.
