### PR TITLE
fix(typechecker): validate arrays.map callback return type matches element type (#2240)

### DIFF
--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -2622,6 +2622,15 @@ static GrayType *resolve_stdlib_call(TypeChecker *checker, AstNode *node, const 
                                     diagnostic_error_code_formatted(checker->diag, "E9004",
                                         NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
                                         mfn, msg);
+                                } else if (elem_tn && cb_fs->return_count >= 1 &&
+                                           cb_fs->return_types[0] &&
+                                           strcmp(type_name(cb_fs->return_types[0]), elem_tn) != 0) {
+                                    char *msg = typechecker_format(checker,
+                                        "map callback must return the same type as the array element type (%s), got '%s'",
+                                        elem_tn, type_name(cb_fs->return_types[0]));
+                                    diagnostic_error_code_formatted(checker->diag, "E9004",
+                                        NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
+                                        mfn, msg);
                                 }
                             } else if (strcmp(mfn, "filter") == 0 ||
                                        strcmp(mfn, "any") == 0 ||

--- a/integration-tests/fail/errors/E9004_map_callback_return_type.gray
+++ b/integration-tests/fail/errors/E9004_map_callback_return_type.gray
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E9004 - arrays.map() callback return type mismatch
+ * Expected: E9004 error (map callback must return the same type as the array element type)
+ */
+
+import @arrays
+
+do to_str(n int) -> string {
+    return "n${n}"
+}
+
+do main() {
+    mut nums [int] = {1, 2, 3}
+    mut strs = arrays.map(nums, ()to_str)
+}


### PR DESCRIPTION
Fixes #2240

`arrays.map()` was missing validation that the callback's return type matches the input array's element type. When a callback returned a different type (e.g., `string` from an `int` array), the typechecker accepted it and codegen produced code that reinterpreted the return value's bits as the input element type, resulting in garbage data at runtime.

Added an `else if` clause to the existing map callback validation chain that checks `cb_fs->return_types[0]` against the array's element type, emitting E9004 on mismatch. This mirrors the existing return type validation that `filter`/`any`/`all` already have for `bool`.