### PR TITLE
fix(typechecker): validate arrays.reduce callback return type matches accumulator (#2241)

### DIFF
--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -2672,6 +2672,23 @@ static GrayType *resolve_stdlib_call(TypeChecker *checker, AstNode *node, const 
                                     diagnostic_error_code_formatted(checker->diag, "E9004",
                                         NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
                                         mfn, msg);
+                                } else if (cb_fs->return_count >= 1 && cb_fs->return_types[0] &&
+                                           node->data.call.arg_count > 1) {
+                                    AstNode *init_arg = node->data.call.args[1];
+                                    GrayType *init_t = typetable_get(checker->type_table, init_arg);
+                                    if (!init_t) init_t = resolve_expression(checker, init_arg);
+                                    if (init_t) {
+                                        const char *init_tn = type_name(init_t);
+                                        const char *ret_tn = type_name(cb_fs->return_types[0]);
+                                        if (init_tn && ret_tn && strcmp(ret_tn, init_tn) != 0) {
+                                            char *msg = typechecker_format(checker,
+                                                "reduce callback must return the same type as the accumulator (%s)",
+                                                init_tn);
+                                            diagnostic_error_code_formatted(checker->diag, "E9004",
+                                                NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
+                                                mfn, msg);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/integration-tests/fail/errors/E9004_arrays_reduce_wrong_return.gray
+++ b/integration-tests/fail/errors/E9004_arrays_reduce_wrong_return.gray
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E9004 - arrays.reduce() callback must return same type as accumulator
+ * Expected: E9004 error
+ */
+
+import @arrays
+
+do bad_reducer(acc int, x int) -> string { return "nope" }
+
+do main() {
+    mut nums [int] = {1, 2, 3}
+    mut result = arrays.reduce(nums, 0, ()bad_reducer)
+}


### PR DESCRIPTION
Fixes #2241

`arrays.reduce()` was missing validation that the reducer callback's return type matches the accumulator type. When a callback returned a different type (e.g., `string` instead of `int`), the typechecker accepted it and codegen produced code that reinterpreted the return value's bits as the accumulator type, resulting in garbage data at runtime.

Added an `else if` branch in the existing reduce callback validation (E9004) that resolves the initial value's type and compares it against the callback's return type, emitting E9004 on mismatch.

Added fail test `E9004_arrays_reduce_wrong_return.gray`.