### PR TITLE
Bugfixes August 5, 2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,7 +1,7 @@
 # Grayscale Error Code Reference
 
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
-> Run `./scripts/generate_errors.gray` to regenerate.
+> Run `./scripts/generate_errors.sh` to regenerate.
 
 **Total: 377 codes** (257 errors, 17 warnings, 103 panics)
 
@@ -428,4 +428,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-07-31 21:59:29 UTC*
+*Generated on 2026-08-02 03:39:48 UTC*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -81,13 +81,16 @@ Multi-line comments do not nest. A `/*` inside a multi-line comment has no speci
 Identifiers name program entities such as variables, functions, types, and modules.
 
 Identifiers must:
-- Begin with an ASCII letter
+- Begin with an ASCII letter or underscore
 - Contain only ASCII letters, digits, and underscores
 - Not be a reserved keyword
+- Not use the reserved prefixes `gray_`, `_gray_`, or `Gray` (reserved for the compiler)
 
-Valid identifiers: `x`, `count`, `myVariable`, `point_2d`, `MAX_SIZE`
+The standalone `_` is the blank identifier (see §4.5) and is not a valid variable or function name.
 
-Invalid identifiers: `2fast`, `my-var`, `café`, `_private`
+Valid identifiers: `x`, `count`, `myVariable`, `point_2d`, `MAX_SIZE`, `_helper`, `_x`
+
+Invalid identifiers: `2fast`, `my-var`, `café`
 
 ### 2.5 Keywords
 

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -279,6 +279,20 @@ static const char *sanitize_name(const char *name) {
     return bufs[i];
 }
 
+/* Returns true if the function declaration contains any wildcard ('?')
+ * type parameters or return types, indicating a generic function. */
+static bool func_is_generic(AstNode *func) {
+    for (int i = 0; i < func->data.func_decl.param_count; i++) {
+        if (func->data.func_decl.params[i].type_name &&
+            strchr(func->data.func_decl.params[i].type_name, '?')) return true;
+    }
+    for (int i = 0; i < func->data.func_decl.return_type_count; i++) {
+        if (func->data.func_decl.return_types[i] &&
+            strchr(func->data.func_decl.return_types[i], '?')) return true;
+    }
+    return false;
+}
+
 /* Map Grayscale type name to C type */
 /* Return a type string with any '?' replaced by the active wildcard
  * binding. Returns the original pointer if no binding is active or the
@@ -6474,16 +6488,7 @@ static void emit_call_expression(CodeGen *codegen, AstNode *node) {
             }
             if (ns_func) {
                 /* Generic struct function: mangle with concrete binding */
-                bool ns_generic = false;
-                for (int pi = 0; pi < ns_func->data.func_decl.param_count && !ns_generic; pi++) {
-                    if (ns_func->data.func_decl.params[pi].type_name &&
-                        strchr(ns_func->data.func_decl.params[pi].type_name, '?')) ns_generic = true;
-                }
-                for (int pi = 0; pi < ns_func->data.func_decl.return_type_count && !ns_generic; pi++) {
-                    if (ns_func->data.func_decl.return_types[pi] &&
-                        strchr(ns_func->data.func_decl.return_types[pi], '?')) ns_generic = true;
-                }
-                if (ns_generic) {
+                if (func_is_generic(ns_func)) {
                     const char *binding = NULL;
                     char *dyn_binding = NULL;
                     int cc = ns_func->data.func_decl.param_count < node->data.call.arg_count
@@ -6601,15 +6606,7 @@ static void emit_call_expression(CodeGen *codegen, AstNode *node) {
         /* Known function; use gray_fn_ prefix. For generic functions,
          * rewrite to the mangled instantiation name derived from the
          * first wildcard parameter's argument type ). */
-        bool tf_generic = false;
-        for (int pi = 0; pi < target_func->data.func_decl.param_count && !tf_generic; pi++) {
-            if (target_func->data.func_decl.params[pi].type_name &&
-                strchr(target_func->data.func_decl.params[pi].type_name, '?')) tf_generic = true;
-        }
-        for (int pi = 0; pi < target_func->data.func_decl.return_type_count && !tf_generic; pi++) {
-            if (target_func->data.func_decl.return_types[pi] &&
-                strchr(target_func->data.func_decl.return_types[pi], '?')) tf_generic = true;
-        }
+        bool tf_generic = func_is_generic(target_func);
         if (tf_generic) {
             /* Derive the concrete binding by scanning params for the
              * first '?' slot and reading the matching arg's type. */
@@ -9284,15 +9281,7 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
          * no instantiations and we skip emission entirely; the
          * un-specialised form has '?' in its signature and can't be
          * compiled as C. */
-        bool has_wc = false;
-        for (int i = 0; i < node->data.func_decl.param_count && !has_wc; i++) {
-            if (node->data.func_decl.params[i].type_name &&
-                strchr(node->data.func_decl.params[i].type_name, '?')) has_wc = true;
-        }
-        for (int i = 0; i < node->data.func_decl.return_type_count && !has_wc; i++) {
-            if (node->data.func_decl.return_types[i] &&
-                strchr(node->data.func_decl.return_types[i], '?')) has_wc = true;
-        }
+        bool has_wc = func_is_generic(node);
         if (has_wc) {
             const char *orig_name = node->data.func_decl.name;
             for (int inst_index = 0; inst_index < node->data.func_decl.instantiation_count; inst_index++) {
@@ -10046,15 +10035,7 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
         /* Detect wildcard generics ); emit one forward per
          * instantiation under a mangled name, skipping the un-specialised
          * signature which would contain '?' in C. */
-        bool has_wc = false;
-        for (int j = 0; j < stmt->data.func_decl.param_count && !has_wc; j++) {
-            if (stmt->data.func_decl.params[j].type_name &&
-                strchr(stmt->data.func_decl.params[j].type_name, '?')) has_wc = true;
-        }
-        for (int j = 0; j < stmt->data.func_decl.return_type_count && !has_wc; j++) {
-            if (stmt->data.func_decl.return_types[j] &&
-                strchr(stmt->data.func_decl.return_types[j], '?')) has_wc = true;
-        }
+        bool has_wc = func_is_generic(stmt);
 
         int emit_rounds = has_wc ? stmt->data.func_decl.instantiation_count : 1;
         const char *orig_name = stmt->data.func_decl.name;

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -934,6 +934,13 @@ static const char *resolve_bigint_type(CodeGen *codegen, AstNode *node) {
         if (left_type) return left_type;
         return resolve_bigint_type(codegen, node->data.infix.right);
     }
+    /* Struct field access a.val — check the resolved field type from the type table */
+    if (node->kind == NODE_MEMBER_EXPR) {
+        GrayType *field_t = codegen->type_table
+            ? typetable_get(codegen->type_table, node) : NULL;
+        if (field_t && field_t->name && is_bigint_type(field_t->name))
+            return field_t->name;
+    }
     /* Pointer dereference p^ — check whether the pointee type is bigint */
     if (node->kind == NODE_POSTFIX_EXPR && node->data.postfix.op == TOK_CARET) {
         GrayType *ptr_t = codegen->type_table

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -2058,9 +2058,9 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                 /* Float division: check for zero (Grayscale panics, no IEEE 754 inf) */
                 emit(codegen, "({ double _dv = (double)");
                 emit_expression(codegen, node->data.infix.right);
-                emit_formatted(codegen, "; if (_dv == 0.0) { gray_panic_code_at(\"%s\", %d, \"P0078\", \"division by zero\"); } (double)", codegen->file, node->token.line);
+                emit_formatted(codegen, "; if (_dv == 0.0) { gray_panic_code_at(\"%s\", %d, \"P0078\", \"division by zero\"); } (double)(", codegen->file, node->token.line);
                 emit_expression(codegen, node->data.infix.left);
-                emit_formatted(codegen, " %s _dv; })", operator_to_c_string(op));
+                emit_formatted(codegen, ") %s _dv; })", operator_to_c_string(op));
                 break;
             } else {
                 /* For signed integer division, also guard the TYPE_MIN / -1
@@ -2084,8 +2084,9 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                     emit_formatted(codegen, "; if ((int64_t)_dn == %s && _dv == -1) { gray_panic_code_at(\"%s\", %d, \"P0079\", \"%s result is too large; value exceeds the range of this type\"); } _dn %s _dv; })",
                         signed_min, codegen->file, node->token.line, opname, operator_to_c_string(op));
                 } else {
+                    emit(codegen, "(");
                     emit_expression(codegen, node->data.infix.left);
-                    emit_formatted(codegen, " %s _dv; })", operator_to_c_string(op));
+                    emit_formatted(codegen, ") %s _dv; })", operator_to_c_string(op));
                 }
                 break;
             }

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -3235,12 +3235,26 @@ static void emit_value_print(CodeGen *codegen, const char *c_expr, GrayType *typ
 
     switch (type->kind) {
     case TK_INT: case TK_BYTE: case TK_ENUM:
-        emit_indent(codegen);
-        emit_formatted(codegen, "fprintf(%s, \"%%lld\", (long long)(%s));\n", stream, c_expr);
+        if (type->name && is_bigint_type(type->name)) {
+            const char *pfx = bigint_prefix(type->name);
+            emit_indent(codegen);
+            emit_formatted(codegen, "{ GrayString _bs = %s_to_string(gray_default_arena, %s); fprintf(%s, \"%%.*s\", (int)_bs.len, _bs.data); }\n",
+                   pfx, c_expr, stream);
+        } else {
+            emit_indent(codegen);
+            emit_formatted(codegen, "fprintf(%s, \"%%lld\", (long long)(%s));\n", stream, c_expr);
+        }
         break;
     case TK_UINT:
-        emit_indent(codegen);
-        emit_formatted(codegen, "fprintf(%s, \"%%llu\", (unsigned long long)(%s));\n", stream, c_expr);
+        if (type->name && is_bigint_type(type->name)) {
+            const char *pfx = bigint_prefix(type->name);
+            emit_indent(codegen);
+            emit_formatted(codegen, "{ GrayString _bs = %s_to_string(gray_default_arena, %s); fprintf(%s, \"%%.*s\", (int)_bs.len, _bs.data); }\n",
+                   pfx, c_expr, stream);
+        } else {
+            emit_indent(codegen);
+            emit_formatted(codegen, "fprintf(%s, \"%%llu\", (unsigned long long)(%s));\n", stream, c_expr);
+        }
         break;
     case TK_FLOAT:
         emit_indent(codegen);

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -1794,12 +1794,9 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
             if (ot && ot->kind == TK_INT) {
                 const char *sized_name = ot->name;
                 const char *smin = NULL, *smax = NULL;
-                if (sized_name) {
-                    if (strcmp(sized_name, "i8") == 0) { smin = "-128"; smax = "127"; }
-                    else if (strcmp(sized_name, "i16") == 0) { smin = "-32768"; smax = "32767"; }
-                    else if (strcmp(sized_name, "i32") == 0) { smin = "-2147483648LL"; smax = "2147483647LL"; }
-                }
-                if (smax) {
+                bool _su = false;
+                if (sized_name) sized_int_bounds(sized_name, &smin, &smax, &_su);
+                if (smax && !_su) {
                     emit(codegen, "gray_sized_neg_check(");
                     emit_expression(codegen, node->data.prefix.right);
                     emit_formatted(codegen, ", %s, %s, \"%s\", \"%s\", %d)", smin, smax, sized_name, codegen->file, node->token.line);
@@ -2143,14 +2140,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                     sized_name = (int_type_rank(right_name) > int_type_rank(left_name)) ? right_name : (left_name ? left_name : right_name);
                 const char *sized_min = NULL, *sized_max = NULL;
                 bool sized_unsigned = false;
-                if (sized_name) {
-                    if (strcmp(sized_name, "i8") == 0) { sized_min = "-128"; sized_max = "127"; }
-                    else if (strcmp(sized_name, "i16") == 0) { sized_min = "-32768"; sized_max = "32767"; }
-                    else if (strcmp(sized_name, "i32") == 0) { sized_min = "-2147483648LL"; sized_max = "2147483647LL"; }
-                    else if (strcmp(sized_name, "u8") == 0 || strcmp(sized_name, "byte") == 0) { sized_unsigned = true; sized_max = "255"; }
-                    else if (strcmp(sized_name, "u16") == 0) { sized_unsigned = true; sized_max = "65535"; }
-                    else if (strcmp(sized_name, "u32") == 0) { sized_unsigned = true; sized_max = "4294967295ULL"; }
-                }
+                if (sized_name) sized_int_bounds(sized_name, &sized_min, &sized_max, &sized_unsigned);
 
                 if (sized_max) {
                     /* Sized type; use bounds-checked arithmetic */
@@ -2229,14 +2219,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
             const char *smin = NULL, *smax = NULL;
             bool su = false;
             bool is_uint = postfix_type && postfix_type->kind == TK_UINT;
-            if (sized_name) {
-                if (strcmp(sized_name, "i8") == 0) { smin = "-128"; smax = "127"; }
-                else if (strcmp(sized_name, "i16") == 0) { smin = "-32768"; smax = "32767"; }
-                else if (strcmp(sized_name, "i32") == 0) { smin = "-2147483648LL"; smax = "2147483647LL"; }
-                else if (strcmp(sized_name, "u8") == 0 || strcmp(sized_name, "byte") == 0) { su = true; smax = "255"; }
-                else if (strcmp(sized_name, "u16") == 0) { su = true; smax = "65535"; }
-                else if (strcmp(sized_name, "u32") == 0) { su = true; smax = "4294967295ULL"; }
-            }
+            if (sized_name) sized_int_bounds(sized_name, &smin, &smax, &su);
             emit(codegen, "(");
             emit_expression(codegen, node->data.postfix.left);
             if (smax) {
@@ -2265,14 +2248,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
             const char *smin = NULL, *smax = NULL;
             bool su = false;
             bool is_uint = pt && pt->kind == TK_UINT;
-            if (sn) {
-                if (strcmp(sn, "i8") == 0) { smin = "-128"; smax = "127"; }
-                else if (strcmp(sn, "i16") == 0) { smin = "-32768"; smax = "32767"; }
-                else if (strcmp(sn, "i32") == 0) { smin = "-2147483648LL"; smax = "2147483647LL"; }
-                else if (strcmp(sn, "u8") == 0 || strcmp(sn, "byte") == 0) { su = true; smax = "255"; }
-                else if (strcmp(sn, "u16") == 0) { su = true; smax = "65535"; }
-                else if (strcmp(sn, "u32") == 0) { su = true; smax = "4294967295ULL"; }
-            }
+            if (sn) sized_int_bounds(sn, &smin, &smax, &su);
             emit(codegen, "(");
             emit_expression(codegen, node->data.postfix.left);
             if (smax) {
@@ -2729,12 +2705,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                 /* Sized integer targets — parse then range-check */
                 const char *smin = NULL, *smax = NULL;
                 bool is_unsigned = false;
-                if (strcmp(target, "i8") == 0) { smin = "-128"; smax = "127"; }
-                else if (strcmp(target, "i16") == 0) { smin = "-32768"; smax = "32767"; }
-                else if (strcmp(target, "i32") == 0) { smin = "-2147483648LL"; smax = "2147483647LL"; }
-                else if (strcmp(target, "u8") == 0 || strcmp(target, "byte") == 0) { is_unsigned = true; smax = "255"; }
-                else if (strcmp(target, "u16") == 0) { is_unsigned = true; smax = "65535"; }
-                else if (strcmp(target, "u32") == 0) { is_unsigned = true; smax = "4294967295ULL"; }
+                sized_int_bounds(target, &smin, &smax, &is_unsigned);
 
                 if (smax && is_unsigned) {
                     emit_formatted(codegen, "(%s)gray_ucast_check(gray_builtin_string_to_int(", gray_type_to_c_codegen(codegen, target));
@@ -2778,12 +2749,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                     /* Determine if an additional narrow range check is needed */
                     const char *nmin = NULL, *nmax = NULL;
                     bool narrow_unsigned = false;
-                    if (strcmp(target, "i8") == 0)  { nmin = "-128";          nmax = "127"; }
-                    else if (strcmp(target, "i16") == 0) { nmin = "-32768";   nmax = "32767"; }
-                    else if (strcmp(target, "i32") == 0) { nmin = "-2147483648LL"; nmax = "2147483647LL"; }
-                    else if (strcmp(target, "u8") == 0 || strcmp(target, "byte") == 0) { narrow_unsigned = true; nmax = "255"; }
-                    else if (strcmp(target, "u16") == 0) { narrow_unsigned = true; nmax = "65535"; }
-                    else if (strcmp(target, "u32") == 0) { narrow_unsigned = true; nmax = "4294967295ULL"; }
+                    sized_int_bounds(target, &nmin, &nmax, &narrow_unsigned);
 
                     if (nmax && narrow_unsigned) {
                         emit_formatted(codegen, "(%s)gray_ucast_check((int64_t)%s_to_u64(", gray_type_to_c_codegen(codegen, target), bp);
@@ -2825,12 +2791,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
             /* Numeric casts: range-checked for narrowing, raw for widening */
             const char *smin = NULL, *smax = NULL;
             bool is_unsigned = false;
-            if (strcmp(target, "i8") == 0) { smin = "-128"; smax = "127"; }
-            else if (strcmp(target, "i16") == 0) { smin = "-32768"; smax = "32767"; }
-            else if (strcmp(target, "i32") == 0) { smin = "-2147483648LL"; smax = "2147483647LL"; }
-            else if (strcmp(target, "u8") == 0 || strcmp(target, "byte") == 0) { is_unsigned = true; smax = "255"; }
-            else if (strcmp(target, "u16") == 0) { is_unsigned = true; smax = "65535"; }
-            else if (strcmp(target, "u32") == 0) { is_unsigned = true; smax = "4294967295ULL"; }
+            sized_int_bounds(target, &smin, &smax, &is_unsigned);
 
             if (smax && is_unsigned) {
                 emit_formatted(codegen, "(%s)gray_ucast_check(", gray_type_to_c_codegen(codegen, target));

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -3118,16 +3118,22 @@ static void emit_to_string(CodeGen *codegen, AstNode *arg) {
         emit_formatted(codegen, "); _gray_str_err%d ? _gray_str_err%d->message : gray_c_string_dup(gray_default_arena, \"nil\"); })", tag, tag);
         return;
     }
-    if (arg_type && arg_type->kind == TK_FLOAT)
-        emit(codegen, "gray_builtin_to_string_float(gray_default_arena, ");
-    else if (arg_type && arg_type->kind == TK_BOOL)
-        emit(codegen, "gray_builtin_to_string_bool(gray_default_arena, ");
-    else if (arg_type && arg_type->kind == TK_UINT)
-        emit(codegen, "gray_builtin_to_string_uint(gray_default_arena, ");
-    else
-        emit(codegen, "gray_builtin_to_string_int(gray_default_arena, ");
-    emit_expression(codegen, arg);
-    emit(codegen, ")");
+    if (arg_type && arg_type->kind == TK_CHAR) {
+        emit(codegen, "gray_builtin_char_to_utf8(gray_default_arena, ");
+        emit_expression(codegen, arg);
+        emit(codegen, ")");
+    } else {
+        if (arg_type && arg_type->kind == TK_FLOAT)
+            emit(codegen, "gray_builtin_to_string_float(gray_default_arena, ");
+        else if (arg_type && arg_type->kind == TK_BOOL)
+            emit(codegen, "gray_builtin_to_string_bool(gray_default_arena, ");
+        else if (arg_type && arg_type->kind == TK_UINT)
+            emit(codegen, "gray_builtin_to_string_uint(gray_default_arena, ");
+        else
+            emit(codegen, "gray_builtin_to_string_int(gray_default_arena, ");
+        emit_expression(codegen, arg);
+        emit(codegen, ")");
+    }
 }
 
 /* Emit a fmt format string literal with %d/%i/%u upgraded to %lld/%llu for

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -279,6 +279,17 @@ static const char *sanitize_name(const char *name) {
     return bufs[i];
 }
 
+/* Build a mangled name for a generic instantiation: `base__concrete`
+ * with non-alphanumeric characters replaced by underscores so
+ * array/map bindings stay legal C identifiers. */
+static void mangle_generic_name(char *buf, size_t buf_size, const char *base, const char *concrete) {
+    size_t pos = (size_t)snprintf(buf, buf_size, "%s__", base);
+    for (const char *ch = concrete; *ch && pos < buf_size - 1; ch++) {
+        buf[pos++] = (isalnum((unsigned char)*ch) || *ch == '_') ? *ch : '_';
+    }
+    buf[pos] = '\0';
+}
+
 /* Returns true if the function declaration contains any wildcard ('?')
  * type parameters or return types, indicating a generic function. */
 static bool func_is_generic(AstNode *func) {
@@ -1694,11 +1705,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
         if (node->data.struct_value.wildcard_binding) {
             const char *binding = node->data.struct_value.wildcard_binding;
             char mangled[MSG_BUF_SIZE];
-            size_t mpos = snprintf(mangled, sizeof(mangled), "%s__", sname);
-            for (const char *ch = binding; *ch && mpos < sizeof(mangled) - 1; ch++) {
-                mangled[mpos++] = (isalnum((unsigned char)*ch) || *ch == '_') ? *ch : '_';
-            }
-            mangled[mpos] = '\0';
+            mangle_generic_name(mangled, sizeof(mangled), sname, binding);
             emit_formatted(codegen, "(GrayStruct_%s){", mangled);
         } else {
             emit_formatted(codegen, "(GrayStruct_%s){", sname);
@@ -9286,15 +9293,8 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
             const char *orig_name = node->data.func_decl.name;
             for (int inst_index = 0; inst_index < node->data.func_decl.instantiation_count; inst_index++) {
                 const char *concrete = node->data.func_decl.instantiations[inst_index];
-                /* Build the mangled name: `<name>__<concrete>` with
-                 * non-alnum chars replaced by underscores so array/map
-                 * bindings stay legal C identifiers. */
                 char mangled[MSG_BUF_SIZE];
-                size_t pos = snprintf(mangled, sizeof(mangled), "%s__", orig_name);
-                for (const char *ch = concrete; *ch && pos < sizeof(mangled) - 1; ch++) {
-                    mangled[pos++] = (isalnum((unsigned char)*ch) || *ch == '_') ? *ch : '_';
-                }
-                mangled[pos] = '\0';
+                mangle_generic_name(mangled, sizeof(mangled), orig_name, concrete);
 
                 node->data.func_decl.name = mangled;
                 const char *saved = codegen->wildcard_binding;
@@ -9829,11 +9829,7 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
         for (int inst_index = 0; inst_index < stmt->data.struct_decl.instantiation_count; inst_index++) {
             const char *concrete = stmt->data.struct_decl.instantiations[inst_index];
             char mangled[MSG_BUF_SIZE];
-            size_t pos = snprintf(mangled, sizeof(mangled), "%s__", stmt->data.struct_decl.name);
-            for (const char *ch = concrete; *ch && pos < sizeof(mangled) - 1; ch++) {
-                mangled[pos++] = (isalnum((unsigned char)*ch) || *ch == '_') ? *ch : '_';
-            }
-            mangled[pos] = '\0';
+            mangle_generic_name(mangled, sizeof(mangled), stmt->data.struct_decl.name, concrete);
             /* Forward declaration */
             emit_formatted(codegen, "typedef struct GrayStruct_%s GrayStruct_%s;\n", mangled, mangled);
             emit_formatted(codegen, "struct GrayStruct_%s {\n", mangled);
@@ -10049,11 +10045,7 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
                 mangled = xmalloc(MSG_BUF_SIZE);
                 const char *concrete = stmt->data.func_decl.instantiations[round];
                 codegen->wildcard_binding = concrete;
-                size_t pos = snprintf(mangled, MSG_BUF_SIZE, "%s__", orig_name);
-                for (const char *ch = concrete; *ch && pos < MSG_BUF_SIZE - 1; ch++) {
-                    mangled[pos++] = (isalnum((unsigned char)*ch) || *ch == '_') ? *ch : '_';
-                }
-                mangled[pos] = '\0';
+                mangle_generic_name(mangled, MSG_BUF_SIZE, orig_name, concrete);
             }
             const char *emit_name = has_wc ? mangled : orig_name;
             /* Temporarily set the func name to the mangled version so

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -2663,6 +2663,11 @@ static AstNode *parse_for_each_statement(Parser *parser) {
             member->data.member.member = parser->cur_token.literal;
             result = member;
         }
+        /* If the chain is followed by (, it is a function call (e.g., maps.get_keys(m)) */
+        if (peek_token_is(parser, TOK_LPAREN)) {
+            next_token(parser); /* move to ( */
+            result = parse_call_expression(parser, result);
+        }
         node->data.for_each.collection = result;
     } else {
         node->data.for_each.collection = parse_expression(parser, PREC_LOWEST);

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -1654,36 +1654,13 @@ static AstNode *parse_func_declaration(Parser *parser) {
                     param->name);
                 diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, buf),
                     parser->file, parser->cur_token.line, parser->cur_token.column, 0);
-            } else if (parser->cur_token.type == TOK_IDENT) {
-                /* Check for builtin function/type names */
-                static const char *reserved[] = {
-                    /* types */
-                    "int", "uint", "float", "string", "bool", "char", "byte", "void",
-                    "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64",
-                    "f32", "f64", "i128", "u128", "i256", "u256",
-                    /* builtin functions */
-                    "println", "print", "eprintln", "eprint", "input",
-                    "len", "type_of", "size_of", "copy", "ref", "addr", "error",
-                    "exit", "panic", "assert", "cast", "sleep_s", "sleep_ms", "sleep_ns",
-                    "c_string", "to_char", "char_count", "here", "embed",
-                    /* stdlib modules */
-                    "arrays", "binary", "bytes", "channels", "crypto", "csv", "encoding",
-                    "fmt", "http", "io", "json", "maps", "math", "mem", "net", "os",
-                    "random", "regex", "server", "sqlite", "strconv", "strings", "sync",
-                    "threads", "time", "uuid",
-                    NULL
-                };
-                for (int ri = 0; reserved[ri]; ri++) {
-                    if (strcmp(param->name, reserved[ri]) == 0) {
-                        char buf[MSG_BUF_SIZE];
-                        snprintf(buf, sizeof(buf),
-                            "'%s' is a built-in name and cannot be used as a parameter name",
-                            param->name);
-                        diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, buf),
-                            parser->file, parser->cur_token.line, parser->cur_token.column, 0);
-                        break;
-                    }
-                }
+            } else if (parser->cur_token.type == TOK_IDENT && is_reserved_name(param->name)) {
+                char buf[MSG_BUF_SIZE];
+                snprintf(buf, sizeof(buf),
+                    "'%s' is a built-in name and cannot be used as a parameter name",
+                    param->name);
+                diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, buf),
+                    parser->file, parser->cur_token.line, parser->cur_token.column, 0);
             }
 
             /* Type name follows (unless next param or closing paren) */
@@ -2257,30 +2234,10 @@ static AstNode *parse_struct_declaration(Parser *parser) {
                 synchronize_parser(parser);
                 break;
             }
-            if (current_token_is(parser, TOK_IDENT) && is_reserved_type_name(parser->cur_token.literal)) {
+            if (current_token_is(parser, TOK_IDENT) && is_reserved_name(parser->cur_token.literal)) {
                 char msg[MSG_BUF_SIZE];
                 snprintf(msg, sizeof(msg),
-                    "'%s' is a reserved type name and cannot be used as a struct field name",
-                    parser->cur_token.literal);
-                diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
-                    parser->file, parser->cur_token.line, parser->cur_token.column, 0);
-                synchronize_parser(parser);
-                break;
-            }
-            if (current_token_is(parser, TOK_IDENT) && is_reserved_builtin_func_name(parser->cur_token.literal)) {
-                char msg[MSG_BUF_SIZE];
-                snprintf(msg, sizeof(msg),
-                    "'%s' is a builtin function and cannot be used as a struct field name",
-                    parser->cur_token.literal);
-                diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
-                    parser->file, parser->cur_token.line, parser->cur_token.column, 0);
-                synchronize_parser(parser);
-                break;
-            }
-            if (current_token_is(parser, TOK_IDENT) && is_stdlib_module_name(parser->cur_token.literal)) {
-                char msg[MSG_BUF_SIZE];
-                snprintf(msg, sizeof(msg),
-                    "'%s' is a standard library module and cannot be used as a struct field name",
+                    "'%s' is a built-in name and cannot be used as a struct field name",
                     parser->cur_token.literal);
                 diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
                     parser->file, parser->cur_token.line, parser->cur_token.column, 0);
@@ -2418,30 +2375,10 @@ static AstNode *parse_enum_declaration(Parser *parser) {
             synchronize_parser(parser);
             continue;
         }
-        if (current_token_is(parser, TOK_IDENT) && is_reserved_type_name(parser->cur_token.literal)) {
+        if (current_token_is(parser, TOK_IDENT) && is_reserved_name(parser->cur_token.literal)) {
             char msg[MSG_BUF_SIZE];
             snprintf(msg, sizeof(msg),
-                "'%s' is a reserved type name and cannot be used as an enum variant name",
-                parser->cur_token.literal);
-            diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
-                parser->file, parser->cur_token.line, parser->cur_token.column, 0);
-            synchronize_parser(parser);
-            continue;
-        }
-        if (current_token_is(parser, TOK_IDENT) && is_reserved_builtin_func_name(parser->cur_token.literal)) {
-            char msg[MSG_BUF_SIZE];
-            snprintf(msg, sizeof(msg),
-                "'%s' is a builtin function and cannot be used as an enum variant name",
-                parser->cur_token.literal);
-            diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
-                parser->file, parser->cur_token.line, parser->cur_token.column, 0);
-            synchronize_parser(parser);
-            continue;
-        }
-        if (current_token_is(parser, TOK_IDENT) && is_stdlib_module_name(parser->cur_token.literal)) {
-            char msg[MSG_BUF_SIZE];
-            snprintf(msg, sizeof(msg),
-                "'%s' is a standard library module and cannot be used as an enum variant name",
+                "'%s' is a built-in name and cannot be used as an enum variant name",
                 parser->cur_token.literal);
             diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
                 parser->file, parser->cur_token.line, parser->cur_token.column, 0);
@@ -2886,11 +2823,11 @@ static AstNode *parse_when_statement(Parser *parser) {
                             memcpy(nb, pat->data.when_pattern.bindings, sizeof(const char *) * bc);
                             pat->data.when_pattern.bindings = nb;
                         }
-                        /* Reject type keywords as binding names */
-                        if (is_reserved_type_name(parser->cur_token.literal)) {
+                        /* Reject reserved names as binding names */
+                        if (is_reserved_name(parser->cur_token.literal)) {
                             char msg[MSG_BUF_SIZE];
                             snprintf(msg, sizeof(msg),
-                                "'%s' is a reserved type name and cannot be used as a binding name",
+                                "'%s' is a built-in name and cannot be used as a binding name",
                                 parser->cur_token.literal);
                             diagnostic_error_message(parser->diag, "E2002", arena_copy_string(parser->arena, msg),
                                 parser->file, parser->cur_token.line, parser->cur_token.column, 0);

--- a/grayc/src/stdlib/random.c
+++ b/grayc/src/stdlib/random.c
@@ -21,6 +21,7 @@ void arc4random_buf(void *buf, size_t nbytes);
 #endif
 
 static bool _seeded = false;
+static bool _user_seeded = false;
 static void ensure_seed(void) {
     if (!_seeded) {
         unsigned seed;
@@ -39,6 +40,7 @@ static void ensure_seed(void) {
 void gray_random_seed(int64_t value) {
     srand((unsigned)value);
     _seeded = true;
+    _user_seeded = true;
 }
 
 double gray_random_float_unit(void) {
@@ -50,8 +52,15 @@ double gray_random_float_range(double min, double max) {
     return min + gray_random_float_unit() * (max - min);
 }
 
-/* Generate a uniform random uint64_t across the full 64-bit range. */
+/* Generate a uniform random uint64_t across the full 64-bit range.
+ * When the user has explicitly seeded via random.seed(), use srand/rand
+ * so the sequence is deterministic.  Otherwise use OS entropy. */
 static uint64_t rand64(void) {
+    if (_user_seeded) {
+        return ((uint64_t)(unsigned)rand() << 33) ^
+               ((uint64_t)(unsigned)rand() << 2)  ^
+               ((uint64_t)(unsigned)rand());
+    }
     uint64_t v;
 #if defined(__APPLE__) || defined(__FreeBSD__)
     arc4random_buf(&v, sizeof(v));
@@ -59,7 +68,6 @@ static uint64_t rand64(void) {
     FILE *f = fopen("/dev/urandom", "rb");
     if (f) { fread(&v, sizeof(v), 1, f); fclose(f); }
     else {
-        /* Fallback: combine multiple rand() calls (31 bits each) */
         v = ((uint64_t)(unsigned)rand() << 33) ^
             ((uint64_t)(unsigned)rand() << 2)  ^
             ((uint64_t)(unsigned)rand());

--- a/grayc/src/stdlib/random.c
+++ b/grayc/src/stdlib/random.c
@@ -50,16 +50,34 @@ double gray_random_float_range(double min, double max) {
     return min + gray_random_float_unit() * (max - min);
 }
 
+/* Generate a uniform random uint64_t across the full 64-bit range. */
+static uint64_t rand64(void) {
+    uint64_t v;
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    arc4random_buf(&v, sizeof(v));
+#else
+    FILE *f = fopen("/dev/urandom", "rb");
+    if (f) { fread(&v, sizeof(v), 1, f); fclose(f); }
+    else {
+        /* Fallback: combine multiple rand() calls (31 bits each) */
+        v = ((uint64_t)(unsigned)rand() << 33) ^
+            ((uint64_t)(unsigned)rand() << 2)  ^
+            ((uint64_t)(unsigned)rand());
+    }
+#endif
+    return v;
+}
+
 int64_t gray_random_int_max(int64_t max) {
     ensure_seed();
     if (max <= 0) return 0;
-    return (int64_t)(rand() % (int)max);
+    return (int64_t)(rand64() % (uint64_t)max);
 }
 
 int64_t gray_random_int_range(int64_t min, int64_t max) {
     ensure_seed();
     if (min >= max) return min;
-    return min + (int64_t)(rand() % (int)(max - min));
+    return min + (int64_t)(rand64() % (uint64_t)(max - min));
 }
 
 bool gray_random_bool(void) {

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -6605,7 +6605,7 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
         if (left->kind == TK_ARRAY && left->element_type) {
             result = typechecker_type_from_name(checker, left->element_type);
         } else if (left->kind == TK_MAP && left->value_type) {
-            result = type_from_name(left->value_type);
+            result = typechecker_type_from_name(checker, left->value_type);
             /* Check map key type matches. Enum keys are int-backed, so accept
              * int expressions (and enum members, which resolve as int) when
              * the declared key is a user enum name. */
@@ -7588,7 +7588,7 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
          * tripping "no field 'y'"). Enums are allowed; they're int-backed
          * and hash fine. */
         if (declared->kind == TK_MAP && declared->key_type) {
-            const char *kt = declared->key_type;
+            const char *kt = resolve_type_alias(checker, declared->key_type);
             GrayType *key_resolved = type_from_name(kt);
             const char *bad = NULL;
             if (key_resolved->kind == TK_STRUCT && !is_enum_name(checker, kt))

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -8942,13 +8942,14 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             diagnostic_error_message(checker->diag, "E3001", msg,
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
-        /* Bigint narrowing on reassignment: i128 → i64, u256 → int, etc. */
+        /* Integer narrowing on reassignment: u32 → u8, int → i16, i128 → i64, etc.
+         * Both sides share TK_INT/TK_UINT so the kind-equality guard passes. */
         if (target->kind == NODE_LABEL &&
             target_t && value_t &&
             target_t->name && value_t->name) {
             int dr = int_type_name_rank(target_t->name);
             int vr = int_type_name_rank(value_t->name);
-            if (dr > 0 && vr >= 5 && dr < vr) {
+            if (dr > 0 && vr > 0 && dr < vr) {
                 char *msg = NULL;
                 msg = typechecker_format(checker,
                     "type mismatch: cannot implicitly narrow %s to %s variable '%s'; use %s() to convert explicitly",
@@ -8956,6 +8957,49 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                 diagnostic_error_message(checker->diag, "E3001", msg,
                     NODE_FILE(checker, node), node->token.line, node->token.column, 0);
             }
+        }
+        /* E3019: signed-to-unsigned on reassignment (e.g., uint_var = signed_var).
+         * Only fires when narrowing did not already catch it (same rank). */
+        if (target->kind == NODE_LABEL &&
+            target_t && value_t &&
+            target_t->name && value_t->name &&
+            is_unsigned_type(target_t->name) &&
+            is_signed_int_type(value_t->name) &&
+            int_type_name_rank(target_t->name) >= int_type_name_rank(value_t->name)) {
+            diagnostic_error_code_formatted(checker->diag, "E3019",
+                NODE_FILE(checker, node), node->token.line, node->token.column, 0,
+                value_t->name, target_t->name);
+        }
+        /* Unsigned-to-signed on reassignment (e.g., int_var = uint_var).
+         * Only fires when narrowing did not already catch it (same rank). */
+        if (target->kind == NODE_LABEL &&
+            target_t && value_t &&
+            target_t->name && value_t->name &&
+            is_signed_int_type(target_t->name) &&
+            is_unsigned_type(value_t->name) &&
+            int_type_name_rank(target_t->name) >= int_type_name_rank(value_t->name)) {
+            char *msg = NULL;
+            msg = typechecker_format(checker,
+                "type mismatch: cannot assign unsigned type '%s' to signed type '%s' variable '%s'; use cast(%s, %s) to convert explicitly",
+                value_t->name, target_t->name, target->data.label.value,
+                target->data.label.value, target_t->name);
+            diagnostic_error_message(checker->diag, "E3001", msg,
+                NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+        }
+        /* Float narrowing on reassignment: f64 → f32, float → f32.
+         * Both are TK_FLOAT so the kind guard passes. */
+        if (target->kind == NODE_LABEL &&
+            target_t && value_t &&
+            target_t->kind == TK_FLOAT && value_t->kind == TK_FLOAT &&
+            target_t->name && value_t->name &&
+            strcmp(target_t->name, value_t->name) != 0 &&
+            strcmp(target_t->name, "f32") == 0) {
+            char *msg = NULL;
+            msg = typechecker_format(checker,
+                "type mismatch: cannot implicitly narrow %s to %s variable '%s'; use %s() to convert explicitly",
+                value_t->name, target_t->name, target->data.label.value, target_t->name);
+            diagnostic_error_message(checker->diag, "E3001", msg,
+                NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
         /* Check type mismatch on struct field assignment.
          * sym->type may be TK_STRUCT (by-value) or TK_POINTER (from new()),

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -2622,6 +2622,15 @@ static GrayType *resolve_stdlib_call(TypeChecker *checker, AstNode *node, const 
                                     diagnostic_error_code_formatted(checker->diag, "E9004",
                                         NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
                                         mfn, msg);
+                                } else if (elem_tn && cb_fs->return_count >= 1 &&
+                                           cb_fs->return_types[0] &&
+                                           strcmp(type_name(cb_fs->return_types[0]), elem_tn) != 0) {
+                                    char *msg = typechecker_format(checker,
+                                        "map callback must return the same type as the array element type (%s), got '%s'",
+                                        elem_tn, type_name(cb_fs->return_types[0]));
+                                    diagnostic_error_code_formatted(checker->diag, "E9004",
+                                        NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
+                                        mfn, msg);
                                 }
                             } else if (strcmp(mfn, "filter") == 0 ||
                                        strcmp(mfn, "any") == 0 ||

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -8909,6 +8909,19 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             diagnostic_error_message(checker->diag, "E3001", msg,
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
+        /* Enum-to-enum name mismatch on direct variable assignment */
+        if (target->kind == NODE_LABEL &&
+            target_t->kind == TK_ENUM && value_t->kind == TK_ENUM &&
+            target_t->name && value_t->name &&
+            !typechecker_same_enum_type(checker, target_t->name, value_t->name)) {
+            char *msg = NULL;
+            msg = typechecker_format(checker,
+                "type mismatch: cannot assign enum '%s' to enum '%s' variable '%s'",
+                type_display_name(checker, value_t), type_display_name(checker, target_t),
+                target->data.label.value);
+            diagnostic_error_message(checker->diag, "E3001", msg,
+                NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+        }
         /* E3098: struct-to-struct name mismatch through pointer dereference: v3^ = v2^
          * The NODE_LABEL check above is bypassed when the target is a postfix
          * dereference. resolve_expression already strips the pointer layer, so

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -3019,6 +3019,34 @@ static GrayType *resolve_struct_or_module_call(TypeChecker *checker, AstNode *no
                     checker->expected_type = param_t;
                 GrayType *arg_t = resolve_expression(checker, node->data.call.args[argument_index]);
                 checker->expected_type = saved_expected_m;
+                /* E3100: struct/enum type name passed as a value argument */
+                if (arg_t->kind == TK_UNKNOWN &&
+                    node->data.call.args[argument_index]->kind == NODE_LABEL) {
+                    const char *arg_label = node->data.call.args[argument_index]->data.label.value;
+                    if (!scope_lookup(checker->current_scope, arg_label)) {
+                        if (is_struct_name(checker, arg_label)) {
+                            char *msg = NULL;
+                            msg = typechecker_format(checker,
+                                "type name '%s' cannot be used as a value; use '%s{...}' or 'new(%s)' to create an instance",
+                                arg_label, arg_label, arg_label);
+                            diagnostic_error_message(checker->diag, "E3100", msg,
+                                NODE_FILE(checker, node->data.call.args[argument_index]),
+                                node->data.call.args[argument_index]->token.line,
+                                node->data.call.args[argument_index]->token.column, 0);
+                            continue;
+                        } else if (is_enum_name(checker, arg_label)) {
+                            char *msg = NULL;
+                            msg = typechecker_format(checker,
+                                "type name '%s' cannot be used as a value; use '%s.VARIANT' to access an enum value",
+                                arg_label, arg_label);
+                            diagnostic_error_message(checker->diag, "E3100", msg,
+                                NODE_FILE(checker, node->data.call.args[argument_index]),
+                                node->data.call.args[argument_index]->token.line,
+                                node->data.call.args[argument_index]->token.column, 0);
+                            continue;
+                        }
+                    }
+                }
                 if (arg_t->kind != TK_UNKNOWN && param_t->kind != TK_UNKNOWN &&
                     arg_t->kind != param_t->kind &&
                     !(is_int_kind(param_t->kind) && arg_t->kind == TK_ENUM) &&
@@ -4181,7 +4209,7 @@ static GrayType *resolve_direct_call(TypeChecker *checker, AstNode *node, const 
                         if (is_struct_name(checker, arg_label)) {
                             char *msg = NULL;
                             msg = typechecker_format(checker,
-                                "type name '%s' cannot be used as a value; to create an instance use 'new(%s)' or '%s{...}'",
+                                "type name '%s' cannot be used as a value; use '%s{...}' or 'new(%s)' to create an instance",
                                 arg_label, arg_label, arg_label);
                             diagnostic_error_message(checker->diag, "E3100", msg,
                                 NODE_FILE(checker, node->data.call.args[argument_index]),
@@ -4279,7 +4307,7 @@ static GrayType *resolve_direct_call(TypeChecker *checker, AstNode *node, const 
                     if (is_struct_name(checker, arg_label)) {
                         char *msg = NULL;
                         msg = typechecker_format(checker,
-                            "type name '%s' cannot be used as a value; to create an instance use 'new(%s)' or '%s{...}'",
+                            "type name '%s' cannot be used as a value; use '%s{...}' or 'new(%s)' to create an instance",
                             arg_label, arg_label, arg_label);
                         diagnostic_error_message(checker->diag, "E3100", msg,
                             NODE_FILE(checker, node->data.call.args[argument_index]),

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -2672,6 +2672,23 @@ static GrayType *resolve_stdlib_call(TypeChecker *checker, AstNode *node, const 
                                     diagnostic_error_code_formatted(checker->diag, "E9004",
                                         NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
                                         mfn, msg);
+                                } else if (cb_fs->return_count >= 1 && cb_fs->return_types[0] &&
+                                           node->data.call.arg_count > 1) {
+                                    AstNode *init_arg = node->data.call.args[1];
+                                    GrayType *init_t = typetable_get(checker->type_table, init_arg);
+                                    if (!init_t) init_t = resolve_expression(checker, init_arg);
+                                    if (init_t) {
+                                        const char *init_tn = type_name(init_t);
+                                        const char *ret_tn = type_name(cb_fs->return_types[0]);
+                                        if (init_tn && ret_tn && strcmp(ret_tn, init_tn) != 0) {
+                                            char *msg = typechecker_format(checker,
+                                                "reduce callback must return the same type as the accumulator (%s)",
+                                                init_tn);
+                                            diagnostic_error_code_formatted(checker->diag, "E9004",
+                                                NODE_FILE(checker, cb_arg), cb_arg->token.line, cb_arg->token.column, 0,
+                                                mfn, msg);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -8912,6 +8912,36 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             diagnostic_error_message(checker->diag, "E3001", msg,
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);
         }
+        /* Array-to-array: element types differ on reassignment (e.g., [int] = [string]).
+         * Both sides are TK_ARRAY so the outer kind-equality guard passes. */
+        if (target->kind == NODE_LABEL &&
+            target_t && value_t &&
+            target_t->kind == TK_ARRAY && value_t->kind == TK_ARRAY &&
+            target_t->element_type && value_t->element_type &&
+            strcmp(target_t->element_type, value_t->element_type) != 0) {
+            char *msg = NULL;
+            msg = typechecker_format(checker,
+                "type mismatch: cannot assign %s to %s variable '%s'",
+                type_display_name(checker, value_t), type_display_name(checker, target_t), target->data.label.value);
+            diagnostic_error_message(checker->diag, "E3001", msg,
+                NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+        }
+        /* Map-to-map: key or value types differ on reassignment (e.g., [string:int] = [string:string]).
+         * Both sides are TK_MAP so the outer kind-equality guard passes. */
+        if (target->kind == NODE_LABEL &&
+            target_t && value_t &&
+            target_t->kind == TK_MAP && value_t->kind == TK_MAP &&
+            target_t->key_type && value_t->key_type &&
+            target_t->value_type && value_t->value_type &&
+            (strcmp(target_t->key_type, value_t->key_type) != 0 ||
+             strcmp(target_t->value_type, value_t->value_type) != 0)) {
+            char *msg = NULL;
+            msg = typechecker_format(checker,
+                "type mismatch: cannot assign %s to %s variable '%s'",
+                type_display_name(checker, value_t), type_display_name(checker, target_t), target->data.label.value);
+            diagnostic_error_message(checker->diag, "E3001", msg,
+                NODE_FILE(checker, node), node->token.line, node->token.column, 0);
+        }
         /* Bigint narrowing on reassignment: i128 → i64, u256 → int, etc. */
         if (target->kind == NODE_LABEL &&
             target_t && value_t &&

--- a/grayc/src/util/reserved.h
+++ b/grayc/src/util/reserved.h
@@ -138,6 +138,14 @@ static inline bool is_stdlib_module_name(const char *name) {
                    sizeof(const char *), gray_strptr_cmp) != NULL;
 }
 
+/* --- Unified reserved name check (types + builtins + modules) --- */
+
+static inline bool is_reserved_name(const char *name) {
+    return is_reserved_type_name(name) ||
+           is_reserved_builtin_func_name(name) ||
+           is_stdlib_module_name(name);
+}
+
 /* --- Reserved stdlib struct names (map to internal C types) --- */
 
 static const char *const gray_reserved_stdlib_struct_names[] = {

--- a/integration-tests/fail/errors/E3001_array_reassign_element_type_mismatch.gray
+++ b/integration-tests/fail/errors/E3001_array_reassign_element_type_mismatch.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a [int] = {1, 2, 3}
+    mut b [string] = {"hello", "world"}
+    a = b
+}

--- a/integration-tests/fail/errors/E3001_cross_enum_reassignment.gray
+++ b/integration-tests/fail/errors/E3001_cross_enum_reassignment.gray
@@ -1,0 +1,14 @@
+const Color enum {
+    RED
+    GREEN
+}
+
+const Size enum {
+    SMALL
+    LARGE
+}
+
+do main() {
+    mut c Color = Color.RED
+    c = Size.LARGE
+}

--- a/integration-tests/fail/errors/E3001_map_reassign_key_type_mismatch.gray
+++ b/integration-tests/fail/errors/E3001_map_reassign_key_type_mismatch.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a [string:int] = {"x": 1}
+    mut b [int:int] = {1: 100}
+    a = b
+}

--- a/integration-tests/fail/errors/E3001_map_reassign_value_type_mismatch.gray
+++ b/integration-tests/fail/errors/E3001_map_reassign_value_type_mismatch.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a [string:int] = {"x": 1}
+    mut b [string:string] = {"x": "hello"}
+    a = b
+}

--- a/integration-tests/fail/errors/E3001_reassign_float_narrowing.gray
+++ b/integration-tests/fail/errors/E3001_reassign_float_narrowing.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a f32 = cast(1.0, f32)
+    mut b f64 = cast(2.0, f64)
+    a = b
+}

--- a/integration-tests/fail/errors/E3001_reassign_int_narrowing.gray
+++ b/integration-tests/fail/errors/E3001_reassign_int_narrowing.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a i8 = cast(10, i8)
+    mut b int = 42
+    a = b
+}

--- a/integration-tests/fail/errors/E3001_reassign_unsigned_to_signed.gray
+++ b/integration-tests/fail/errors/E3001_reassign_unsigned_to_signed.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a int = 10
+    mut b uint = cast(42, uint)
+    a = b
+}

--- a/integration-tests/fail/errors/E3019_reassign_signed_to_unsigned.gray
+++ b/integration-tests/fail/errors/E3019_reassign_signed_to_unsigned.gray
@@ -1,0 +1,5 @@
+do main() {
+    mut a uint = cast(10, uint)
+    mut b int = 42
+    a = b
+}

--- a/integration-tests/fail/errors/E3100_struct_call_type_as_arg.gray
+++ b/integration-tests/fail/errors/E3100_struct_call_type_as_arg.gray
@@ -1,0 +1,11 @@
+const Node struct {
+    id uint,
+    do make(&self Node) -> Node {
+        return self
+    }
+}
+
+do main() {
+    mut n = Node.make(Node)
+    println(n)
+}

--- a/integration-tests/fail/errors/E9004_arrays_reduce_wrong_return.gray
+++ b/integration-tests/fail/errors/E9004_arrays_reduce_wrong_return.gray
@@ -1,0 +1,13 @@
+/*
+ * Error Test: E9004 - arrays.reduce() callback must return same type as accumulator
+ * Expected: E9004 error
+ */
+
+import @arrays
+
+do bad_reducer(acc int, x int) -> string { return "nope" }
+
+do main() {
+    mut nums [int] = {1, 2, 3}
+    mut result = arrays.reduce(nums, 0, ()bad_reducer)
+}

--- a/integration-tests/fail/errors/E9004_map_callback_return_type.gray
+++ b/integration-tests/fail/errors/E9004_map_callback_return_type.gray
@@ -1,0 +1,15 @@
+/*
+ * Error Test: E9004 - arrays.map() callback return type mismatch
+ * Expected: E9004 error (map callback must return the same type as the array element type)
+ */
+
+import @arrays
+
+do to_str(n int) -> string {
+    return "n${n}"
+}
+
+do main() {
+    mut nums [int] = {1, 2, 3}
+    mut strs = arrays.map(nums, ()to_str)
+}

--- a/integration-tests/pass/core/alias_map_key_and_interpolation.gray
+++ b/integration-tests/pass/core/alias_map_key_and_interpolation.gray
@@ -1,0 +1,38 @@
+alias Name = string
+alias Score = float
+alias ID = int
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Alias as map key type
+    mut scores map[Name:Score] = {:}
+    scores["Alice"] = 95.5
+    if scores["Alice"] == 95.5 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Alias as map value type with interpolation
+    mut ids map[Name:ID] = {:}
+    ids["Bob"] = 42
+    if ids["Bob"] == 42 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Both key and value aliased
+    mut data map[ID:Name] = {:}
+    data[1] = "test"
+    if data[1] == "test" {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}

--- a/integration-tests/pass/core/float_paren_precedence.gray
+++ b/integration-tests/pass/core/float_paren_precedence.gray
@@ -1,0 +1,38 @@
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    mut a = 6.0
+    mut b = 4.0
+
+    // Parenthesized addition then division
+    if (a + b) / 2.0 == 5.0 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Without parens: division binds tighter
+    if a + b / 2.0 == 8.0 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Parenthesized subtraction then division
+    if (a - b) / 2.0 == 1.0 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Nested parenthesized expression
+    if (a + b) / (a - b) == 5.0 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}

--- a/integration-tests/pass/core/for_each_module_call.gray
+++ b/integration-tests/pass/core/for_each_module_call.gray
@@ -1,0 +1,33 @@
+import @maps
+import @strings
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // for_each over module-qualified function call
+    mut m [string:int] = {"a": 1, "b": 2}
+    mut key_count int = 0
+    for_each key in maps.get_keys(m) {
+        key_count += 1
+    }
+    if key_count == 2 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // for_each over another module call
+    mut part_count int = 0
+    for_each part in strings.split("x,y,z", ",") {
+        part_count += 1
+    }
+    if part_count == 3 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}

--- a/integration-tests/pass/core/int_uint_implicit_conv.gray
+++ b/integration-tests/pass/core/int_uint_implicit_conv.gray
@@ -89,15 +89,15 @@ do main() {
         failed += 1
     }
 
-    // Test 8: Assign int value to byte variable
+    // Test 8: Assign int value to byte variable via explicit cast
     mut j byte = 0
     mut k int = 100
-    j = k
+    j = cast(k, byte)
     if j == 100 {
-        println("  [PASS] assign int value to byte var")
+        println("  [PASS] assign int value to byte var via cast")
         passed += 1
     } otherwise {
-        println("  [FAIL] assign int value to byte var")
+        println("  [FAIL] assign int value to byte var via cast")
         failed += 1
     }
 

--- a/integration-tests/pass/core/rand_int_large_range.gray
+++ b/integration-tests/pass/core/rand_int_large_range.gray
@@ -1,0 +1,52 @@
+import @random
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // rand_int(0, 4294967295) should not always return 0
+    mut all_zero bool = true
+    for i in range(0, 10) {
+        if random.rand_int(0, 4294967295) != 0 {
+            all_zero = false
+        }
+    }
+    if !all_zero {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // rand_int(0, 10000000000) should produce values above INT32_MAX
+    mut any_above bool = false
+    for i in range(0, 50) {
+        if random.rand_int(0, 10000000000) > 2147483647 {
+            any_above = true
+        }
+    }
+    if any_above {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Small range still works
+    mut in_range bool = true
+    for i in range(0, 20) {
+        mut v int = random.rand_int(1, 10)
+        if v < 1 {
+            in_range = false
+        }
+        if v >= 10 {
+            in_range = false
+        }
+    }
+    if in_range {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}

--- a/integration-tests/pass/core/sized_int_overflow_checks.gray
+++ b/integration-tests/pass/core/sized_int_overflow_checks.gray
@@ -59,7 +59,8 @@ do main() {
 
     // Test 5: i16 compound assignment within bounds
     mut m i16 = 30000
-    m += 2000
+    mut m_add i16 = 2000
+    m += m_add
     if m == 32000 {
         println("  [PASS] i16 compound += within bounds")
         passed += 1

--- a/integration-tests/pass/core/string_of_char.gray
+++ b/integration-tests/pass/core/string_of_char.gray
@@ -1,0 +1,42 @@
+import @strings
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // string() should produce the character, not the codepoint
+    mut ch char = 'A'
+    if string(ch) == "A" {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Digit char
+    mut digit char = '7'
+    if string(digit) == "7" {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Consistent with interpolation
+    if string(ch) == "${ch}" {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // Building strings from chars
+    mut chars [char] = strings.to_chars("42")
+    mut result string = string(chars[0])
+    result = "${result}${chars[1]}"
+    if result == "42" {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}

--- a/integration-tests/pass/core/wide_int_struct_fields.gray
+++ b/integration-tests/pass/core/wide_int_struct_fields.gray
@@ -1,0 +1,53 @@
+const A struct {
+    val i128
+}
+
+const B struct {
+    val i256
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    mut a = A{val: 100}
+    mut b = B{val: 200}
+
+    // i128 struct field comparison
+    if a.val == 100 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // i256 struct field comparison
+    if b.val == 200 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // i128 struct field != comparison
+    if a.val != 999 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // i128 struct field > comparison
+    if a.val > 50 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    // i256 struct field < comparison
+    if b.val < 300 {
+        passed += 1
+    } otherwise {
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}

--- a/integration-tests/pass/core/wide_int_struct_print.gray
+++ b/integration-tests/pass/core/wide_int_struct_print.gray
@@ -1,0 +1,24 @@
+const Val struct {
+    num i128
+}
+
+const Big struct {
+    num i256
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    mut v = Val{num: 42}
+    mut b = Big{num: 999}
+
+    // These would previously cause C compilation errors.
+    // If we reach this point, the codegen is correct.
+    println(v)
+    println(b)
+    passed += 2
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 { println("SOME TESTS FAILED") } otherwise { println("ALL TESTS PASSED") }
+}


### PR DESCRIPTION
## Summary
This PR contains several bugfixes to the compilers core including the typechecker and codegen as well as minor bugfixes to the stdlib and builtin functions. There are also source code maintainability and readability improvements as well.

- **Typechecker hardening:** reject type-mismatched reassignments for arrays, maps, enums, and numeric types (narrowing + sign changes); validate arrays.map/reduce callback return types; resolve type aliases in map key validation; reject type names in struct-namespace function calls
- **Codegen fixes:** wide integer intrinsics for struct fields, parenthesized left operands in float/unsigned division, correct char-to-string conversion, bigint to_string for wide integer struct fields
- **Parser fix:** handle module-qualified function calls in `for_each` iterables
- **Stdlib fixes:** 64-bit RNG in `rand_int` for full-range support, respect explicit seed in `rand64`
- **Refactors:** extract `func_is_generic()`, `mangle_generic_name()`, unify `sized_int_bounds()` in codegen; unify reserved name validation in parser