### PR TITLE
fix(stdlib): add parameterized query API to sqlite module (#1690)

### DIFF
--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -4863,7 +4863,8 @@ static bool emit_json_call(CodeGen *codegen, AstNode *node, const char *func) {
 
 static bool emit_sqlite_call(CodeGen *codegen, AstNode *node, const char *func) {
     bool is_fallible = (strcmp(func, "open") == 0 || strcmp(func, "exec") == 0 ||
-        strcmp(func, "query") == 0);
+        strcmp(func, "query") == 0 || strcmp(func, "exec_params") == 0 ||
+        strcmp(func, "query_params") == 0);
     bool is_multi_var = is_result_temporary(codegen->current_var_name);
     if (strcmp(func, "open") == 0) {
         emit_formatted(codegen, "gray_sqlite_open%s(gray_default_arena, ", (is_fallible && is_multi_var) ? "_result" : "");
@@ -4889,11 +4890,35 @@ static bool emit_sqlite_call(CodeGen *codegen, AstNode *node, const char *func) 
         emit(codegen, ")");
         return true;
     }
+    if (strcmp(func, "exec_params") == 0) {
+        if (is_multi_var) {
+            emit(codegen, "gray_sqlite_exec_params_result(gray_default_arena, ");
+        } else {
+            emit(codegen, "gray_sqlite_exec_params(");
+        }
+        emit_expression(codegen, node->data.call.args[0]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[1]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[2]);
+        emit(codegen, ")");
+        return true;
+    }
     if (strcmp(func, "query") == 0) {
         emit_formatted(codegen, "gray_sqlite_query%s(gray_default_arena, ", is_multi_var ? "_result" : "");
         emit_expression(codegen, node->data.call.args[0]);
         emit(codegen, ", ");
         emit_expression(codegen, node->data.call.args[1]);
+        emit(codegen, ")");
+        return true;
+    }
+    if (strcmp(func, "query_params") == 0) {
+        emit_formatted(codegen, "gray_sqlite_query_params%s(gray_default_arena, ", is_multi_var ? "_result" : "");
+        emit_expression(codegen, node->data.call.args[0]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[1]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[2]);
         emit(codegen, ")");
         return true;
     }
@@ -6101,7 +6126,7 @@ static void emit_call_expression(CodeGen *codegen, AstNode *node) {
                 {"parse","csv"},{"read_file","csv"},{"headers","csv"},
                 {"write_file","csv"},{"format","csv"},{"encode","csv"},
                 /* @sqlite */
-                {"open","sqlite"},{"close","sqlite"},{"exec","sqlite"},{"query","sqlite"},
+                {"open","sqlite"},{"close","sqlite"},{"exec","sqlite"},{"exec_params","sqlite"},{"query","sqlite"},{"query_params","sqlite"},
                 /* @threads */
                 {"spawn","threads"},{"join","threads"},{"get_id","threads"},
                 {"detach","threads"},{"is_alive","threads"},{"current","threads"},

--- a/grayc/src/stdlib/sqlite.c
+++ b/grayc/src/stdlib/sqlite.c
@@ -41,6 +41,63 @@ bool gray_sqlite_exec(GraySqlite *db, GrayString sql) {
     return return_code == SQLITE_OK;
 }
 
+/* Bind all parameters from a [string] array to a prepared statement. */
+static int bind_string_params(sqlite3_stmt *stmt, GrayArray params) {
+    for (int32_t i = 0; i < params.len; i++) {
+        GrayString *s = (GrayString *)((char *)params.data + i * params.elem_size);
+        int rc = sqlite3_bind_text(stmt, i + 1, s->data, s->len, SQLITE_STATIC);
+        if (rc != SQLITE_OK) return rc;
+    }
+    return SQLITE_OK;
+}
+
+bool gray_sqlite_exec_params(GraySqlite *db, GrayString sql, GrayArray params) {
+    if (!db || !db->handle) return false;
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) return false;
+    rc = bind_string_params(stmt, params);
+    if (rc != SQLITE_OK) { sqlite3_finalize(stmt); return false; }
+    rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE;
+}
+
+GrayArray gray_sqlite_query_params(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params) {
+    GrayArray rows = gray_array_new(arena, sizeof(GrayMap), 8);
+    if (!db || !db->handle) return rows;
+
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) return rows;
+
+    rc = bind_string_params(stmt, params);
+    if (rc != SQLITE_OK) { sqlite3_finalize(stmt); return rows; }
+
+    int col_count = sqlite3_column_count(stmt);
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        GrayMap row = gray_map_new(arena, sizeof(GrayString), sizeof(GrayString), col_count * 2);
+        for (int i = 0; i < col_count; i++) {
+            const char *col_name = sqlite3_column_name(stmt, i);
+            GrayString key = gray_string_new(arena, col_name, (int32_t)strlen(col_name));
+
+            const char *val_text = (const char *)sqlite3_column_text(stmt, i);
+            GrayString val;
+            if (val_text) {
+                val = gray_string_new(arena, val_text, (int32_t)strlen(val_text));
+            } else {
+                val = gray_string_lit("");
+            }
+            GRAY_MAP_SET(arena, &row, &key, &val);
+        }
+        GRAY_ARRAY_PUSH(arena, &rows, &row);
+    }
+
+    sqlite3_finalize(stmt);
+    return rows;
+}
+
 GrayArray gray_sqlite_query(GrayArena *arena, GraySqlite *db, GrayString sql) {
     GrayArray rows = gray_array_new(arena, sizeof(GrayMap), 8);
     if (!db || !db->handle) return rows;
@@ -111,6 +168,42 @@ GrayResult_bool gray_sqlite_exec_result(GrayArena *arena, GraySqlite *db, GraySt
     return r;
 }
 
+GrayResult_bool gray_sqlite_exec_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params) {
+    GrayResult_bool r;
+    if (!db || !db->handle) {
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "database handle is nil"));
+        return r;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) {
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "exec_params failed: %s", errmsg ? errmsg : "unknown error"));
+        return r;
+    }
+    rc = bind_string_params(stmt, params);
+    if (rc != SQLITE_OK) {
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        sqlite3_finalize(stmt);
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "exec_params bind failed: %s", errmsg ? errmsg : "unknown error"));
+        return r;
+    }
+    rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE) {
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "exec_params failed: %s", errmsg ? errmsg : "unknown error"));
+    } else {
+        r.v0 = true;
+        r.v1 = NULL;
+    }
+    return r;
+}
+
 GrayResult_array gray_sqlite_query_result(GrayArena *arena, GraySqlite *db, GrayString sql) {
     GrayResult_array r;
     if (!db || !db->handle) {
@@ -128,6 +221,27 @@ GrayResult_array gray_sqlite_query_result(GrayArena *arena, GraySqlite *db, Gray
     }
     sqlite3_finalize(stmt);
     r.v0 = gray_sqlite_query(arena, db, sql);
+    r.v1 = NULL;
+    return r;
+}
+
+GrayResult_array gray_sqlite_query_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params) {
+    GrayResult_array r;
+    if (!db || !db->handle) {
+        r.v0 = gray_array_new(arena, sizeof(GrayMap), 0);
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "database handle is nil"));
+        return r;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) {
+        r.v0 = gray_array_new(arena, sizeof(GrayMap), 0);
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "query_params failed: %s", errmsg ? errmsg : "unknown error"));
+        return r;
+    }
+    sqlite3_finalize(stmt);
+    r.v0 = gray_sqlite_query_params(arena, db, sql, params);
     r.v1 = NULL;
     return r;
 }

--- a/grayc/src/stdlib/sqlite.h
+++ b/grayc/src/stdlib/sqlite.h
@@ -44,7 +44,7 @@
  *@module sqlite
  *@group Queries
  *@sig exec(db Database, sql string) -> (bool, Error)
- *@desc Executes a SQL statement that does not return rows (CREATE, INSERT, UPDATE, DELETE, etc.). Returns true on success. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; parameterized queries with placeholders are not supported.
+ *@desc Executes a SQL statement that does not return rows (CREATE, INSERT, UPDATE, DELETE, etc.). Returns true on success. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; use exec_params for parameterized queries.
  *@example
  *   import @sqlite
  *   mut db, _ = sqlite.open("myapp.db")
@@ -54,15 +54,44 @@
  *@end
  */
 
+/*@man exec_params
+ *@module sqlite
+ *@group Queries
+ *@sig exec_params(db Database, sql string, params [string]) -> (bool, Error)
+ *@desc Executes a parameterized SQL statement that does not return rows. Use ? placeholders in the SQL string and pass values in the params array. Prevents SQL injection by binding parameters safely. Always use destructuring — single-variable assignment is a compile error.
+ *@example
+ *   import @sqlite
+ *   mut db, _ = sqlite.open("myapp.db")
+ *   mut ok, err = sqlite.exec_params(db, "INSERT INTO users (name, age) VALUES (?, ?)", {"Alice", "30"})
+ *   if err != nil { println("exec failed: ${err}") }
+ *@end
+ */
+
 /*@man query
  *@module sqlite
  *@group Queries
  *@sig query(db Database, sql string) -> ([map[string:string]], Error)
- *@desc Executes a SQL SELECT statement and returns the result rows. Each row is a map of column name to string value. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; parameterized queries with placeholders are not supported.
+ *@desc Executes a SQL SELECT statement and returns the result rows. Each row is a map of column name to string value. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; use query_params for parameterized queries.
  *@example
  *   import @sqlite
  *   mut db, _ = sqlite.open("myapp.db")
  *   mut rows, err = sqlite.query(db, "SELECT * FROM users")
+ *   if err != nil { println("query failed: ${err}") }
+ *   for_each row in rows {
+ *       println(row)
+ *   }
+ *@end
+ */
+
+/*@man query_params
+ *@module sqlite
+ *@group Queries
+ *@sig query_params(db Database, sql string, params [string]) -> ([map[string:string]], Error)
+ *@desc Executes a parameterized SQL SELECT statement and returns the result rows. Use ? placeholders in the SQL string and pass values in the params array. Prevents SQL injection by binding parameters safely. Always use destructuring — single-variable assignment is a compile error.
+ *@example
+ *   import @sqlite
+ *   mut db, _ = sqlite.open("myapp.db")
+ *   mut rows, err = sqlite.query_params(db, "SELECT * FROM users WHERE name = ?", {"Alice"})
  *   if err != nil { println("query failed: ${err}") }
  *   for_each row in rows {
  *       println(row)
@@ -83,14 +112,22 @@ void gray_sqlite_close(GraySqlite *db);
 /* sqlite.exec(db, sql) — execute statement, return success */
 bool gray_sqlite_exec(GraySqlite *db, GrayString sql);
 
+/* sqlite.exec_params(db, sql, params) — execute parameterized statement */
+bool gray_sqlite_exec_params(GraySqlite *db, GrayString sql, GrayArray params);
+
 /* sqlite.query(db, sql) — execute query, return array of maps */
 GrayArray gray_sqlite_query(GrayArena *arena, GraySqlite *db, GrayString sql);
+
+/* sqlite.query_params(db, sql, params) — execute parameterized query */
+GrayArray gray_sqlite_query_params(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params);
 
 /* _result variants */
 typedef struct { GraySqlite *v0; GrayError *v1; } GrayResult_sqlite;
 
 GrayResult_sqlite gray_sqlite_open_result(GrayArena *arena, GrayString path);
 GrayResult_bool gray_sqlite_exec_result(GrayArena *arena, GraySqlite *db, GrayString sql);
+GrayResult_bool gray_sqlite_exec_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params);
 GrayResult_array gray_sqlite_query_result(GrayArena *arena, GraySqlite *db, GrayString sql);
+GrayResult_array gray_sqlite_query_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params);
 
 #endif

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -1182,10 +1182,12 @@ static const StdlibFuncMeta stdlib_func_meta[] = {
     {"server", "text",       2, 2, false, FT_NONE, 1, {{1, ARG_STRING}}, "HttpResponse"},
     {"server", "use",        2, 2, false, FT_NONE, 0, {{0}},"void"},
     /* sqlite */
-    {"sqlite", "close", 1, 1,  false, FT_NONE,            0, {{0}},"void"},
-    {"sqlite", "exec",  2, 99, true,  FT_BOOL,            0, {{0}},"bool"},
-    {"sqlite", "open",  1, 1,  true,  FT_STRUCT_DATABASE,  1, {{0, ARG_STRING}}, "Database"},
-    {"sqlite", "query", 2, 99, true,  FT_ARRAY_MAP,       0, {{0}},"[map]"},
+    {"sqlite", "close",        1, 1,  false, FT_NONE,            0, {{0}},"void"},
+    {"sqlite", "exec",         2, 99, true,  FT_BOOL,            0, {{0}},"bool"},
+    {"sqlite", "exec_params",  3, 3,  true,  FT_BOOL,            1, {{2, ARG_ARRAY}}, "bool"},
+    {"sqlite", "open",         1, 1,  true,  FT_STRUCT_DATABASE,  1, {{0, ARG_STRING}}, "Database"},
+    {"sqlite", "query",        2, 99, true,  FT_ARRAY_MAP,       0, {{0}},"[map]"},
+    {"sqlite", "query_params", 3, 3,  true,  FT_ARRAY_MAP,       1, {{2, ARG_ARRAY}}, "[map]"},
     /* strconv */
     {"strconv", "from_bool",  1, 1, false, FT_NONE,  1, {{0, ARG_BOOL}}, "string"},
     {"strconv", "from_float", 1, 1, false, FT_NONE,  1, {{0, ARG_FLOAT}}, "string"},

--- a/integration-tests/pass/stdlib/sqlite_params.gray
+++ b/integration-tests/pass/stdlib/sqlite_params.gray
@@ -1,0 +1,98 @@
+/*
+ * sqlite_params.gray - Integration test for parameterized queries
+ */
+
+import @sqlite
+
+do main() {
+    println("=== SQLite Parameterized Query Test ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    mut db, _ = sqlite.open(":memory:")
+    mut _, _ = sqlite.exec(db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age TEXT)")
+
+    // exec_params: insert with parameterized values
+    mut ok, err = sqlite.exec_params(db, "INSERT INTO users (id, name, age) VALUES (?, ?, ?)", {"1", "Alice", "30"})
+    if ok {
+        println("  [PASS] exec_params INSERT")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec_params INSERT: ${err}")
+        failed += 1
+    }
+
+    // exec_params: insert value containing SQL metacharacters
+    mut ok2, err2 = sqlite.exec_params(db, "INSERT INTO users (id, name, age) VALUES (?, ?, ?)", {"2", "O'Brien; DROP TABLE users; --", "25"})
+    if ok2 {
+        println("  [PASS] exec_params with SQL metacharacters")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec_params with SQL metacharacters: ${err2}")
+        failed += 1
+    }
+
+    // query_params: retrieve by name
+    mut rows, qerr = sqlite.query_params(db, "SELECT * FROM users WHERE name = ?", {"Alice"})
+    if qerr != nil {
+        println("  [FAIL] query_params: ${qerr}")
+        failed += 1
+    } otherwise {
+        if len(rows) == 1 {
+            println("  [PASS] query_params returns 1 row for Alice")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] query_params: expected 1 row, got ${len(rows)}")
+            failed += 1
+        }
+    }
+
+    // query_params: SQL injection attempt returns no rows
+    mut rows2, qerr2 = sqlite.query_params(db, "SELECT * FROM users WHERE name = ?", {"' OR '1'='1"})
+    if qerr2 != nil {
+        println("  [FAIL] query_params injection test: ${qerr2}")
+        failed += 1
+    } otherwise {
+        if len(rows2) == 0 {
+            println("  [PASS] query_params safely handles injection attempt")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] query_params injection: expected 0 rows, got ${len(rows2)}")
+            failed += 1
+        }
+    }
+
+    // query_params: integer parameter bound as text works via SQLite type affinity
+    mut rows3, qerr3 = sqlite.query_params(db, "SELECT * FROM users WHERE id = ?", {"1"})
+    if qerr3 != nil {
+        println("  [FAIL] query_params integer bind: ${qerr3}")
+        failed += 1
+    } otherwise {
+        if len(rows3) == 1 {
+            println("  [PASS] query_params integer parameter binding")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] query_params integer bind: expected 1 row, got ${len(rows3)}")
+            failed += 1
+        }
+    }
+
+    // verify the metacharacter row survived (table not dropped)
+    mut rows4, _ = sqlite.query(db, "SELECT * FROM users")
+    if len(rows4) == 2 {
+        println("  [PASS] table intact after metacharacter insert")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] expected 2 total rows, got ${len(rows4)}")
+        failed += 1
+    }
+
+    sqlite.close(db)
+
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        panic("Some tests failed!")
+    }
+    println("ALL TESTS PASSED")
+}


### PR DESCRIPTION
Fixes #1690

## Summary

- Add `sqlite.exec_params(db, sql, params)` and `sqlite.query_params(db, sql, params)` functions that accept a SQL string with `?` placeholders and a `[string]` params array
- Parameters are bound via `sqlite3_bind_text` to prevent SQL injection — SQLite handles type affinity internally
- Wired through all four compiler stages: stdlib implementation, typechecker registration, and codegen emission
- Added integration test verifying parameterized inserts, queries, SQL injection prevention (metacharacters like `'`, `;`, `--`), and integer parameter binding

## Test plan

- [x] `sqlite_params.gray` integration test passes (6/6 assertions)
- [x] SQL metacharacter values inserted safely without table corruption
- [x] Injection attempt `' OR '1'='1` returns 0 rows (not full table dump)
- [x] Integer parameters bound as text work correctly via SQLite type affinity
- [x] `make build` compiles clean