### PR TITLE
fix(typechecker): resolve implicit enum selectors in struct field defaults (#2223)

### DIFF
--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -11131,6 +11131,14 @@ static void register_declarations(TypeChecker *checker, AstNode *program) {
                         break;
                     }
                 }
+                /* Resolve implicit enum selectors in field default values */
+                if (stmt->data.struct_decl.fields[j].default_value) {
+                    GrayType *saved_expected = checker->expected_type;
+                    if (ftypes[j] && ftypes[j]->kind == TK_ENUM && ftypes[j]->name)
+                        checker->expected_type = ftypes[j];
+                    resolve_expression(checker, stmt->data.struct_decl.fields[j].default_value);
+                    checker->expected_type = saved_expected;
+                }
             }
             /* E2037/E2038: reserved name check for structs */
             const char *sn = STRUCT_DISPLAY_NAME(stmt);

--- a/integration-tests/pass/core/implicit_enum_struct_field_default.gray
+++ b/integration-tests/pass/core/implicit_enum_struct_field_default.gray
@@ -1,0 +1,79 @@
+/*
+ * Pass Test: Implicit enum selector in struct field default values
+ * Tests that .VARIANT syntax works in struct field defaults.
+ */
+
+const Status enum {
+    PENDING
+    ACTIVE
+    DONE
+}
+
+const Task struct {
+    status Status = .PENDING
+}
+
+const Job struct {
+    state Status = .ACTIVE
+    name string = "untitled"
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: implicit enum default used via empty literal
+    mut t = Task{}
+    if t.status == Status.PENDING {
+        println("  [PASS] Task{}.status == PENDING")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Task{}.status: expected PENDING")
+        failed += 1
+    }
+
+    // Test 2: implicit enum default used via new()
+    mut t2 = new(Task)
+    if t2^.status == Status.PENDING {
+        println("  [PASS] new(Task).status == PENDING")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] new(Task).status: expected PENDING")
+        failed += 1
+    }
+
+    // Test 3: override implicit enum default
+    mut t3 = Task{status: .DONE}
+    if t3.status == Status.DONE {
+        println("  [PASS] Task{status: .DONE}.status == DONE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Task{status: .DONE}: expected DONE")
+        failed += 1
+    }
+
+    // Test 4: second field with implicit enum default
+    mut j = Job{}
+    if j.state == Status.ACTIVE {
+        println("  [PASS] Job{}.state == ACTIVE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Job{}.state: expected ACTIVE")
+        failed += 1
+    }
+
+    if j.name == "untitled" {
+        println("  [PASS] Job{}.name == \"untitled\"")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Job{}.name: expected \"untitled\"")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}


### PR DESCRIPTION
Fixes #2223

Implicit enum selectors (`.VARIANT`) in struct field defaults were accepted by the typechecker but never resolved, causing codegen to emit an empty C expression. The fix sets `expected_type` before resolving struct field default values during declaration registration — the same pattern already used for function parameter defaults.

**Root cause:** `resolve_implicit_enum()` requires `checker->expected_type` to be set to the target enum type. This was done for function parameter defaults but not for struct field defaults.

**Change:** In the struct registration loop (pass 2b), after computing each field's type, resolve the field's default value expression with `expected_type` set to the field type. This writes `resolved_enum` onto the `NODE_IMPLICIT_ENUM` node so codegen can emit the correct C enum constant.