### PR TITLE
fix(typechecker): resolve implicit enum selectors in map key bracket access (#2246)

### DIFF
--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -6603,7 +6603,15 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
 
     case NODE_INDEX_EXPR: {
         GrayType *left = resolve_expression(checker, node->data.index_expr.left);
+        /* Propagate map key type as expected_type so .VARIANT resolves */
+        GrayType *saved_idx_expected = checker->expected_type;
+        if (left->kind == TK_MAP && left->key_type) {
+            GrayType *key_t = typechecker_type_from_name(checker, left->key_type);
+            if (key_t && key_t->kind == TK_ENUM && key_t->name)
+                checker->expected_type = key_t;
+        }
         GrayType *idx_t = resolve_expression(checker, node->data.index_expr.index);
+        checker->expected_type = saved_idx_expected;
         /* E3003: array index must be integer */
         if (left->kind == TK_ARRAY && idx_t->kind != TK_UNKNOWN &&
             !is_int_kind(idx_t->kind) && idx_t->kind != TK_BYTE) {

--- a/integration-tests/pass/core/implicit_enum_selector.gray
+++ b/integration-tests/pass/core/implicit_enum_selector.gray
@@ -170,6 +170,27 @@ do main() {
         failed += 1
     }
 
+    // Test 12: Map key bracket access (assignment)
+    mut palette [Color:string] = {:}
+    palette[.RED] = "#FF0000"
+    if palette[Color.RED] == "#FF0000" {
+        println("  [PASS] map key bracket assignment")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] map key bracket assignment")
+        failed += 1
+    }
+
+    // Test 13: Map key bracket access (read)
+    mut label string = palette[.RED]
+    if label == "#FF0000" {
+        println("  [PASS] map key bracket read")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] map key bracket read")
+        failed += 1
+    }
+
     // Summary
     println("")
     println("Results: ${passed} passed, ${failed} failed")


### PR DESCRIPTION
Fixes #2246

When a map has an enum key type (e.g., `[Color:string]`), implicit enum selectors like `.RED` in bracket access (`palette[.RED]`) now resolve correctly. The typechecker propagates the map's key type as `expected_type` before resolving the index expression, matching the pattern used for array element types and other contexts where implicit selectors already work.